### PR TITLE
Do not crash if non-convergence occurs in a BS step

### DIFF
--- a/integration/BS/stiff_ode.F90
+++ b/integration/BS/stiff_ode.F90
@@ -181,6 +181,10 @@ contains
 #endif
        endif
 
+       if (ierr /= IERR_NONE) then
+          exit
+       end if
+
        ! finished?
        if (bs % t - tmax >= ZERO) then
           finished = .true.
@@ -579,8 +583,9 @@ contains
     if (.not. converged .and. ierr == IERR_NONE) then
        ierr = IERR_NO_CONVERGENCE
 #ifndef ACC
+       print *, "Integration failed due to non-convergence in single_step_bs"
        call dump_bs_state(bs)
-       call bl_error("Error: non convergence in single_step_bs, something has gone wrong.")
+       return
 #endif       
     endif
 


### PR DESCRIPTION
With the scheme we now have for switching integrators on a failure,
we simply want to abort the integration when this occurs, not crash.