### PR TITLE
Clean up the consistency checking in the integration state

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 
 # changes since last merge:
 
+ -- the maximum temperature for reactions, MAX_TEMP, is now
+    an adjustable input parameter rather than being hardcoded
+    at 1.d11.
+
 # previous changes:
 
 

--- a/integration/BS/_parameters
+++ b/integration/BS/_parameters
@@ -16,17 +16,9 @@ ode_scale_floor              real            1.d-6
 # extrapolation method (1) or a Rosenbrock method (2)
 ode_method                   integer         1
 
-
 # when constructing the intermediate steps in the stiff ODE
 # integration by how much do we allow the state variables to change
 # over a dt before giving up on the step and retrying with a smaller
 # step?
 safety_factor                real            1.d9
-
-
-# The absolute cutoff for species -- note that this might be larger
-# than {\tt small\_x}, but the issue is that we need to prevent underflow
-# issues and keep mass fractions positive in the integrator.  You may
-# have to increase the floor to, e.g. {\tt 1.d-20} if your rates are large.
-SMALL_X_SAFE                 real            1.0d-30
 

--- a/integration/BS/bs_type.F90
+++ b/integration/BS/bs_type.F90
@@ -42,7 +42,7 @@ contains
     !$acc routine seq
 
     use bl_constants_module, only: ONE
-    use extern_probin_module, only: SMALL_X_SAFE, renormalize_abundances
+    use extern_probin_module, only: SMALL_X_SAFE, renormalize_abundances, MAX_TEMP
     use actual_network, only: aion, nspec, nspec_evolve
     use burn_type_module, only: net_itemp
     use eos_type_module, only : eos_get_small_temp
@@ -50,9 +50,6 @@ contains
     implicit none
 
     type (bs_t), intent(inout) :: state
-
-    ! this should be larger than any reasonable temperature we will encounter
-    real (kind=dp_t), parameter :: MAX_TEMP = 1.0d11
 
     real (kind=dp_t) :: small_temp
 

--- a/integration/VODE/vode_rhs.f90
+++ b/integration/VODE/vode_rhs.f90
@@ -9,7 +9,7 @@
     use burn_type_module, only: burn_t, net_ienuc, net_itemp
     use bl_constants_module, only: ZERO, ONE
     use actual_rhs_module, only: actual_rhs
-    use extern_probin_module, only: call_eos_in_rhs, dT_crit, renormalize_abundances, &
+    use extern_probin_module, only: call_eos_in_rhs, dT_crit, &
                                     burning_mode, burning_mode_factor, &
                                     integrate_temperature, integrate_energy
     use vode_type_module, only: clean_state, renormalize_species, update_thermodynamics, &
@@ -38,12 +38,6 @@
     ! Fix the state as necessary.
 
     call clean_state(y, rpar)
-
-    ! Renormalize the abundances as necessary.
-
-    if (renormalize_abundances) then
-       call renormalize_species(y, rpar)
-    endif
 
     ! Update the thermodynamics as necessary.
 

--- a/integration/VODE/vode_type.f90
+++ b/integration/VODE/vode_type.f90
@@ -16,13 +16,11 @@ contains
     use burn_type_module, only: neqs, net_itemp
     use rpar_indices, only: n_rpar_comps
     use eos_type_module, only : eos_get_small_temp
-    use extern_probin_module, only: renormalize_abundances, SMALL_X_SAFE
+    use extern_probin_module, only: renormalize_abundances, SMALL_X_SAFE, MAX_TEMP
 
     implicit none
 
     real(dp_t) :: y(neqs), rpar(n_rpar_comps)
-
-    real(dp_t), parameter :: MAX_TEMP = 1.0d11
 
     real(dp_t) :: small_temp
 

--- a/integration/_parameters
+++ b/integration/_parameters
@@ -85,3 +85,6 @@ renormalize_abundances   logical   .false.
 # issues and keep mass fractions positive in the integrator.  You may
 # have to increase the floor to, e.g. {\tt 1.d-20} if your rates are large.
 SMALL_X_SAFE                 real            1.0d-30
+
+# The maximum temperature for reactions in the integration.
+MAX_TEMP                     real            1.0d11

--- a/integration/_parameters
+++ b/integration/_parameters
@@ -79,3 +79,9 @@ retry_burn_max_change    real      1.0d2
 # Whether to renormalize the mass fractions at each step in the evolution
 # so that they sum to unity.
 renormalize_abundances   logical   .false.
+
+# The absolute cutoff for species -- note that this might be larger
+# than {\tt small\_x}, but the issue is that we need to prevent underflow
+# issues and keep mass fractions positive in the integrator.  You may
+# have to increase the floor to, e.g. {\tt 1.d-20} if your rates are large.
+SMALL_X_SAFE                 real            1.0d-30


### PR DESCRIPTION
This brings VODE into alignment with BS regarding what checks we apply to the integration state.

It also makes the maximum temperature for reactions an adjustable input parameter, rather than being hardcoded at 10^11 K.

Fixes #45 
Fixes #46 