### PR TITLE
Do not rely on the numerical Jacobian for aprox19/aprox21

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 
 # changes since last merge:
 
+ -- the aprox19 and aprox21 networks no longer use a numerical
+    Jacobian by default, as this was found to result in some
+    bad numerical issues in VODE
+
  -- the maximum temperature for reactions, MAX_TEMP, is now
     an adjustable input parameter rather than being hardcoded
     at 1.d11.

--- a/networks/aprox19/_parameters
+++ b/networks/aprox19/_parameters
@@ -1,2 +1,0 @@
-# Default to numerical Jacobian.
-jacobian                 integer   2     100

--- a/networks/aprox21/_parameters
+++ b/networks/aprox21/_parameters
@@ -1,2 +1,0 @@
-# Default to numerical Jacobian.
-jacobian                 integer   2     100


### PR DESCRIPTION
The change was made at some point to use the numerical Jacobian for
these networks, because we learned that the hardwired Jacobian has
some missing terms. However, the numerical Jacobian in practice seems
to have big problems -- it can cause VODE to complete the integration
with crazy states that have X >> 1, but VODE thinks it is converged.
We also see NaN's in the Jacobian when we examine it. So we are going
to revert to the analytical Jacobian default -- this seems to work better.