### PR TITLE
remove esum() for sums of 1 or 2 terms

### DIFF
--- a/networks/aprox13/actual_rhs.f90
+++ b/networks/aprox13/actual_rhs.f90
@@ -671,7 +671,7 @@ contains
        a(1) = -y(img24) * y(ihe4) * rate(irmgap)*(1.0d0-rate(irr1))
        a(2) =  y(isi28) * rate(irr1) * rate(irsigp)
 
-       dydt(img24) = dydt(img24) + esum(a,2)
+       dydt(img24) = dydt(img24) + sum(a(1:2))
 
     else
        a(1) = -y(img24)*y(ihe4) * rate(irmgap)*(1.0d0 - ratdum(irr1))
@@ -910,13 +910,13 @@ contains
     a(1) =  y(ife52) * y(ihe4) * rate(irfeag)
     a(2) = -y(ini56) * rate(irniga)
 
-    dydt(ini56) = dydt(ini56) + esum(a,2)
+    dydt(ini56) = dydt(ini56) + sum(a(1:2))
 
     if (.not.deriva) then
        a(1) =  y(ife52) * y(ihe4) * rate(irfeap)*(1.0d0-rate(iry1))
        a(2) = -y(ini56) * rate(iry1) * rate(irnigp)
 
-       dydt(ini56) = dydt(ini56) + esum(a,2)
+       dydt(ini56) = dydt(ini56) + sum(a(1:2))
 
     else
        a(1) =  y(ife52)*y(ihe4) * rate(irfeap)*(1.0d0-ratdum(iry1))
@@ -1992,7 +1992,7 @@ contains
     ! d(he4)/d(ne20)
     b(1) =  rate(irnega) 
     b(2) = -y(ihe4) * rate(irneag)
-    dfdy(ihe4,ine20) = esum(b,2)
+    dfdy(ihe4,ine20) = sum(b(1:2))
 
     ! d(he4)/d(mg24)
     b(1) =  rate(irmgga) 
@@ -2052,14 +2052,14 @@ contains
     ! d(he4)/d(ni56)
     b(1) = rate(irniga) 
     b(2) = rate(iry1) * rate(irnigp)
-    dfdy(ihe4,ini56) = esum(b,2)
+    dfdy(ihe4,ini56) = sum(b(1:2))
 
 
     ! c12 jacobian elements
     ! d(c12)/d(he4)
     b(1) =  0.5d0 * y(ihe4) * y(ihe4) * rate(ir3a) 
     b(2) = -y(ic12) * rate(ircag)
-    dfdy(ic12,ihe4) = esum(b,2)
+    dfdy(ic12,ihe4) = sum(b(1:2))
 
     ! d(c12)/d(c12)
     b(1) = -2.0d0 * y(ic12) * rate(ir1212) 
@@ -2071,7 +2071,7 @@ contains
     ! d(c12)/d(o16)
     b(1) = -y(ic12) * rate(ir1216) 
     b(2) =  rate(iroga)
-    dfdy(ic12,io16) = esum(b,2)
+    dfdy(ic12,io16) = sum(b(1:2))
 
 
 
@@ -2079,12 +2079,12 @@ contains
     ! d(o16)/d(he4)
     b(1) =  y(ic12)*rate(ircag) 
     b(2) = -y(io16)*rate(iroag)
-    dfdy(io16,ihe4) = esum(b,2)
+    dfdy(io16,ihe4) = sum(b(1:2))
 
     ! d(o16)/d(c12)
     b(1) = -y(io16)*rate(ir1216) 
     b(2) =  y(ihe4)*rate(ircag)
-    dfdy(io16,ic12) = esum(b,2)
+    dfdy(io16,ic12) = sum(b(1:2))
 
     ! d(o16)/d(o16)
     b(1) = -y(ic12) * rate(ir1216) 
@@ -2102,7 +2102,7 @@ contains
     ! d(ne20)/d(he4)
     b(1) =  y(io16) * rate(iroag) 
     b(2) = -y(ine20) * rate(irneag) 
-    dfdy(ine20,ihe4) = esum(b,2)
+    dfdy(ine20,ihe4) = sum(b(1:2))
 
     ! d(ne20)/d(c12)
     dfdy(ine20,ic12) = y(ic12) * rate(ir1212)
@@ -2113,7 +2113,7 @@ contains
     ! d(ne20)/d(ne20)
     b(1) = -y(ihe4) * rate(irneag) 
     b(2) = -rate(irnega)
-    dfdy(ine20,ine20) = esum(b,2)
+    dfdy(ine20,ine20) = sum(b(1:2))
 
     ! d(ne20)/d(mg24)
     dfdy(ine20,img24) = rate(irmgga)
@@ -2144,7 +2144,7 @@ contains
     ! d(mg24)/d(si28)
     b(1) = rate(irsiga) 
     b(2) = rate(irr1) * rate(irsigp)
-    dfdy(img24,isi28) = esum(b,2)
+    dfdy(img24,isi28) = sum(b(1:2))
 
 
     ! si28 jacobian elements
@@ -2167,7 +2167,7 @@ contains
     ! d(si28)/d(mg24)
     b(1) =  y(ihe4) * rate(irmgag) 
     b(2) =  y(ihe4) * rate(irmgap) * (1.0d0-rate(irr1))
-    dfdy(isi28,img24) = esum(b,2)
+    dfdy(isi28,img24) = sum(b(1:2))
 
     ! d(si28)/d(si28)
     b(1) =  -y(ihe4) * rate(irsiag) 
@@ -2179,7 +2179,7 @@ contains
     ! d(si28)/d(s32)
     b(1) = rate(irsga) 
     b(2) = rate(irs1) * rate(irsgp)
-    dfdy(isi28,is32) = esum(b,2)
+    dfdy(isi28,is32) = sum(b(1:2))
 
 
     ! s32 jacobian elements
@@ -2193,12 +2193,12 @@ contains
     ! d(s32)/d(o16)
     b(1) = 0.68d0*0.5d0*y(io16)*rate(ir1616)*(1.0d0-rate(irs1)) 
     b(2) = 0.2d0 * 0.5d0*y(io16) * rate(ir1616)
-    dfdy(is32,io16) = esum(b,2)
+    dfdy(is32,io16) = sum(b(1:2))
 
     ! d(s32)/d(si28)
     b(1)  =y(ihe4) * rate(irsiag) 
     b(2) = y(ihe4) * rate(irsiap) * (1.0d0-rate(irs1))
-    dfdy(is32,isi28) = esum(b,2)
+    dfdy(is32,isi28) = sum(b(1:2))
 
     ! d(s32)/d(s32)
     b(1) = -y(ihe4) * rate(irsag) 
@@ -2210,7 +2210,7 @@ contains
     ! d(s32)/d(ar36)
     b(1) = rate(irarga) 
     b(2) = rate(irt1) * rate(irargp)
-    dfdy(is32,iar36) = esum(b,2)
+    dfdy(is32,iar36) = sum(b(1:2))
 
 
     ! ar36 jacobian elements
@@ -2224,7 +2224,7 @@ contains
     ! d(ar36)/d(s32)
     b(1) = y(ihe4) * rate(irsag) 
     b(2) = y(ihe4) * rate(irsap) * (1.0d0-rate(irt1))
-    dfdy(iar36,is32) = esum(b,2)
+    dfdy(iar36,is32) = sum(b(1:2))
 
     ! d(ar36)/d(ar36)
     b(1) = -y(ihe4) * rate(irarag) 
@@ -2236,7 +2236,7 @@ contains
     ! d(ar36)/d(ca40)
     b(1) = rate(ircaga) 
     b(2) = rate(ircagp) * rate(iru1)
-    dfdy(iar36,ica40) = esum(b,2)
+    dfdy(iar36,ica40) = sum(b(1:2))
 
 
     ! ca40 jacobian elements
@@ -2250,7 +2250,7 @@ contains
     ! d(ca40)/d(ar36)
     b(1) =  y(ihe4) * rate(irarag) 
     b(2) =  y(ihe4) * rate(irarap)*(1.0d0-rate(iru1))
-    dfdy(ica40,iar36) = esum(b,2)
+    dfdy(ica40,iar36) = sum(b(1:2))
 
     ! d(ca40)/d(ca40)
     b(1) = -y(ihe4) * rate(ircaag) 
@@ -2262,7 +2262,7 @@ contains
     ! d(ca40)/d(ti44)
     b(1) = rate(irtiga) 
     b(2) = rate(irtigp) * rate(irv1)
-    dfdy(ica40,iti44) = esum(b,2)
+    dfdy(ica40,iti44) = sum(b(1:2))
 
 
 
@@ -2277,7 +2277,7 @@ contains
     ! d(ti44)/d(ca40)
     b(1) =  y(ihe4) * rate(ircaag) 
     b(2) =  y(ihe4) * rate(ircaap)*(1.0d0-rate(irv1))
-    dfdy(iti44,ica40) = esum(b,2)
+    dfdy(iti44,ica40) = sum(b(1:2))
 
     ! d(ti44)/d(ti44)
     b(1) = -y(ihe4) * rate(irtiag) 
@@ -2289,7 +2289,7 @@ contains
     ! d(ti44)/d(cr48)
     b(1) = rate(ircrga) 
     b(2) = rate(irw1) * rate(ircrgp)
-    dfdy(iti44,icr48) = esum(b,2)
+    dfdy(iti44,icr48) = sum(b(1:2))
 
 
 
@@ -2304,7 +2304,7 @@ contains
     ! d(cr48)/d(ti44)
     b(1) =  y(ihe4) * rate(irtiag) 
     b(2) =  y(ihe4) * rate(irtiap)*(1.0d0-rate(irw1))
-    dfdy(icr48,iti44) = esum(b,2)
+    dfdy(icr48,iti44) = sum(b(1:2))
 
     ! d(cr48)/d(cr48)
     b(1) = -y(ihe4) * rate(ircrag) 
@@ -2316,7 +2316,7 @@ contains
     ! d(cr48)/d(fe52)
     b(1) = rate(irfega) 
     b(2) = rate(irx1) * rate(irfegp)
-    dfdy(icr48,ife52) = esum(b,2)
+    dfdy(icr48,ife52) = sum(b(1:2))
 
 
 
@@ -2331,7 +2331,7 @@ contains
     ! d(fe52)/d(cr48)
     b(1) = y(ihe4) * rate(ircrag) 
     b(2) = y(ihe4) * rate(ircrap) * (1.0d0-rate(irx1))
-    dfdy(ife52,icr48) = esum(b,2)
+    dfdy(ife52,icr48) = sum(b(1:2))
 
     ! d(fe52)/d(fe52)
     b(1) = -y(ihe4) * rate(irfeag) 
@@ -2343,24 +2343,24 @@ contains
     ! d(fe52)/d(ni56)
     b(1) = rate(irniga) 
     b(2) = rate(iry1) * rate(irnigp)
-    dfdy(ife52,ini56) = esum(b,2)
+    dfdy(ife52,ini56) = sum(b(1:2))
 
 
     ! ni56 jacobian elements
     ! d(ni56)/d(he4)
     b(1) =  y(ife52) * rate(irfeag) 
     b(2) =  y(ife52) * rate(irfeap) * (1.0d0-rate(iry1))
-    dfdy(ini56,ihe4) = esum(b,2)
+    dfdy(ini56,ihe4) = sum(b(1:2))
 
     ! d(ni56)/d(fe52)
     b(1) = y(ihe4) * rate(irfeag) 
     b(2) = y(ihe4) * rate(irfeap) * (1.0d0-rate(iry1)) 
-    dfdy(ini56,ife52) = esum(b,2)
+    dfdy(ini56,ife52) = sum(b(1:2))
 
     ! d(ni56)/d(ni56)
     b(1) = -rate(irniga) 
     b(2) = -rate(iry1) * rate(irnigp)
-    dfdy(ini56,ini56) = esum(b,2)
+    dfdy(ini56,ini56) = sum(b(1:2))
 
   end subroutine dfdy_isotopes_aprox13
 

--- a/networks/aprox19/actual_rhs.f90
+++ b/networks/aprox19/actual_rhs.f90
@@ -369,22 +369,22 @@ contains
     a(1) = 0.5d0 * y(ihe3) * y(ihe3) * rate(ir33)
     a(2) = y(ihe3) * y(ihe4) * rate(irhe3ag)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,2)
+    dydt(ihe4) =  dydt(ihe4) + sum(a(1:2))
 
 
     ! cno cycles
     a(1) = y(io16) * y(ih1) * rate(iropg)
     a(2) = -y(ihe4) * y(in14) * rate(irnag) * 1.5d0
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,2)
+    dydt(ihe4) =  dydt(ihe4) + sum(a(1:2))
 
     if (.not. deriva) then
        a(1) = y(in14) * y(ih1) * rate(ifa) * rate(irnpg)
-       dydt(ihe4) =  dydt(ihe4) + esum(a,1)
+       dydt(ihe4) =  dydt(ihe4) + a(1)
     else
        a(1) = y(in14) * y(ih1) * rate(ifa) * ratdum(irnpg)
        a(2) = y(in14) * y(ih1) * ratdum(ifa) * rate(irnpg)
-       dydt(ihe4) =  dydt(ihe4) + esum(a,2)
+       dydt(ihe4) =  dydt(ihe4) + sum(a(1:2))
     end if
 
 
@@ -401,11 +401,11 @@ contains
 
     if (.not. deriva) then
        a(1) =  y(in14) * y(ih1) * rate(ifa) * rate(irnpg)
-       dydt(ic12) =  dydt(ic12) + esum(a,1)
+       dydt(ic12) =  dydt(ic12) + a(1)
     else
        a(1) =  y(in14) * y(ih1) * rate(ifa) * ratdum(irnpg)
        a(2) =  y(in14) * y(ih1) * ratdum(ifa) * rate(irnpg)
-       dydt(ic12) =  dydt(ic12) + esum(a,2)
+       dydt(ic12) =  dydt(ic12) + sum(a(1:2))
     end if
 
 
@@ -431,11 +431,11 @@ contains
 
     if (.not. deriva) then
        a(1) =  y(in14) * y(ih1) * rate(ifg) * rate(irnpg)
-       dydt(io16) =  dydt(io16) + esum(a,1)
+       dydt(io16) =  dydt(io16) + a(1)
     else
        a(1) =  y(in14) * y(ih1) * rate(ifg) * ratdum(irnpg)
        a(2) =  y(in14) * y(ih1) * ratdum(ifg) * rate(irnpg)
-       dydt(io16) =  dydt(io16) + esum(a,2)
+       dydt(io16) =  dydt(io16) + sum(a(1:2))
     end if
 
 
@@ -463,7 +463,7 @@ contains
        a(1) = -y(img24) * y(ihe4) * rate(irmgap)*(1.0d0-rate(irr1))
        a(2) =  y(isi28) * rate(irr1) * rate(irsigp)
 
-       dydt(img24) =  dydt(img24) + esum(a,2)
+       dydt(img24) =  dydt(img24) + sum(a(1:2))
 
     else
        a(1) = -y(img24)*y(ihe4) * rate(irmgap)*(1.0d0 - ratdum(irr1))
@@ -676,7 +676,7 @@ contains
     if (.not.deriva) then
        a(1) =  y(icr48) * y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
        a(2) = -y(ife52) * rate(irx1) * rate(irfegp)
-       dydt(ife52) =  dydt(ife52) + esum(a,2)
+       dydt(ife52) =  dydt(ife52) + sum(a(1:2))
 
     else
        a(1) =  y(icr48)*y(ihe4) * rate(ircrap)*(1.0d0-ratdum(irx1))
@@ -2247,12 +2247,12 @@ contains
     ! d(h1)/d(he3)
     b(1) = 2.0d0 * y(ihe3) * ratdum(ir33)
     b(2) = -y(ihe4) * ratdum(irhe3ag)
-    dfdy(ih1,ihe3) = esum(b,2)
+    dfdy(ih1,ihe3) = sum(b(1:2))
 
     ! d(h1)/d(he4)
     b(1) = -y(ihe3) * ratdum(irhe3ag)
     b(2) = -y(ihe3) * y(ihe4) * dratdumdy1(irhe3ag)
-    dfdy(ih1,ihe4) = esum(b,2)
+    dfdy(ih1,ihe4) = sum(b(1:2))
 
     ! d(h1)/d(c12)
     dfdy(ih1,ic12) = -2.0d0 * y(ih1) * ratdum(ircpg)
@@ -2268,17 +2268,17 @@ contains
     ! d(he3)/d(h1)
     b(1) = y(ih1) * ratdum(irpp)
     b(2) = ratdum(irpen)
-    dfdy(ihe3,ih1) = esum(b,2)
+    dfdy(ihe3,ih1) = sum(b(1:2))
 
     ! d(he3)/d(he3)
     b(1) = -2.0d0 * y(ihe3) * ratdum(ir33)
     b(2) = -y(ihe4) * ratdum(irhe3ag)
-    dfdy(ihe3,ihe3) = esum(b,2)
+    dfdy(ihe3,ihe3) = sum(b(1:2))
 
     ! d(he3)/d(he4)
     b(1) = -y(ihe3) * ratdum(irhe3ag)
     b(2) = -y(ihe3) * y(ihe4) * dratdumdy1(irhe3ag)
-    dfdy(ihe3,ihe4) = esum(b,2)
+    dfdy(ihe3,ihe4) = sum(b(1:2))
 
 
     ! he4 jacobian elements
@@ -2292,7 +2292,7 @@ contains
     ! d(he4)/d(he3)
     b(1) = y(ihe3) * ratdum(ir33)
     b(2) = y(ihe4) * ratdum(irhe3ag)
-    dfdy(ihe4,ihe3) = esum(b,2)
+    dfdy(ihe4,ihe3) = sum(b(1:2))
 
 
     ! d(he4)/d(he4)
@@ -2333,7 +2333,7 @@ contains
     ! d(he4)/d(n14)
     b(1) =  y(ih1) * ratdum(ifa) * ratdum(irnpg)
     b(2) = -y(ihe4) * ratdum(irnag) * 1.5d0
-    dfdy(ihe4,in14) = esum(b,2)
+    dfdy(ihe4,in14) = sum(b(1:2))
 
     ! d(he4)/d(o16)
     b(1) =  0.5d0 * y(ic12) * ratdum(ir1216)
@@ -2347,7 +2347,7 @@ contains
     ! d(he4)/d(ne20)
     b(1) =  ratdum(irnega)
     b(2) = -y(ihe4) * ratdum(irneag)
-    dfdy(ihe4,ine20) = esum(b,2)
+    dfdy(ihe4,ine20) = sum(b(1:2))
 
     ! d(he4)/d(mg24)
     b(1) =  ratdum(irmgga)
@@ -2411,7 +2411,7 @@ contains
     ! d(he4)/d(ni56)
     b(1) = ratdum(irniga)
     b(2) = y(iprot) * ratdum(ir8f54)
-    dfdy(ihe4,ini56) = esum(b,2)
+    dfdy(ihe4,ini56) = sum(b(1:2))
 
     ! d(he4)/d(neut)
     b(1) = -y(ihe4) * dratdumdy1(iralf1)
@@ -2443,7 +2443,7 @@ contains
     ! d(c12)/d(he4)
     b(1) =  0.5d0 * y(ihe4) * y(ihe4) * ratdum(ir3a)
     b(2) = -y(ic12) * ratdum(ircag)
-    dfdy(ic12,ihe4) = esum(b,2)
+    dfdy(ic12,ihe4) = sum(b(1:2))
 
     ! d(c12)/d(c12)
     b(1) = -2.0d0 * y(ic12) * ratdum(ir1212)
@@ -2459,7 +2459,7 @@ contains
     ! d(c12)/d(o16)
     b(1) = -y(ic12) * ratdum(ir1216)
     b(2) =  ratdum(iroga)
-    dfdy(ic12,io16) = esum(b,2)
+    dfdy(ic12,io16) = sum(b(1:2))
 
 
     ! n14 jacobian elements
@@ -2480,7 +2480,7 @@ contains
     ! d(n14)/d(n14)
     b(1) = -y(ih1) * ratdum(irnpg)
     b(2) = -y(ihe4) * ratdum(irnag)
-    dfdy(in14,in14) = esum(b,2)
+    dfdy(in14,in14) = sum(b(1:2))
 
     ! d(n14)/d(o16)
     dfdy(in14,io16) = y(ih1) * ratdum(iropg)
@@ -2497,12 +2497,12 @@ contains
     ! d(o16)/d(he4)
     b(1) =  y(ic12)*ratdum(ircag)
     b(2) = -y(io16)*ratdum(iroag)
-    dfdy(io16,ihe4) = esum(b,2)
+    dfdy(io16,ihe4) = sum(b(1:2))
 
     ! d(o16)/d(c12)
     b(1) = -y(io16)*ratdum(ir1216)
     b(2) =  y(ihe4)*ratdum(ircag)
-    dfdy(io16,ic12) = esum(b,2)
+    dfdy(io16,ic12) = sum(b(1:2))
 
     ! d(o16)/d(n14)
     dfdy(io16,in14) = y(ih1) * ratdum(ifg) * ratdum(irnpg)
@@ -2538,7 +2538,7 @@ contains
     ! d(ne20)/d(ne20)
     b(1) = -y(ihe4) * ratdum(irneag)
     b(2) = -ratdum(irnega)
-    dfdy(ine20,ine20) = esum(b,2)
+    dfdy(ine20,ine20) = sum(b(1:2))
 
     ! d(ne20)/d(mg24)
     dfdy(ine20,img24) = ratdum(irmgga)
@@ -2569,7 +2569,7 @@ contains
     ! d(mg24)/d(si28)
     b(1) = ratdum(irsiga)
     b(2) = ratdum(irr1) * ratdum(irsigp)
-    dfdy(img24,isi28) = esum(b,2)
+    dfdy(img24,isi28) = sum(b(1:2))
 
 
     ! si28 jacobian elements
@@ -2592,7 +2592,7 @@ contains
     ! d(si28)/d(mg24)
     b(1) =  y(ihe4) * ratdum(irmgag)
     b(2) =  y(ihe4) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
-    dfdy(isi28,img24) = esum(b,2)
+    dfdy(isi28,img24) = sum(b(1:2))
 
     ! d(si28)/d(si28)
     b(1) =  -y(ihe4) * ratdum(irsiag)
@@ -2604,7 +2604,7 @@ contains
     ! d(si28)/d(s32)
     b(1) = ratdum(irsga)
     b(2) = ratdum(irs1) * ratdum(irsgp)
-    dfdy(isi28,is32) = esum(b,2)
+    dfdy(isi28,is32) = sum(b(1:2))
 
 
     ! s32 jacobian elements
@@ -2618,12 +2618,12 @@ contains
     ! d(s32)/d(o16)
     b(1) = 0.68d0*0.5d0*y(io16)*ratdum(ir1616)*(1.0d0-ratdum(irs1))
     b(2) = 0.2d0 * 0.5d0*y(io16) * ratdum(ir1616)
-    dfdy(is32,io16) = esum(b,2)
+    dfdy(is32,io16) = sum(b(1:2))
 
     ! d(s32)/d(si28)
     b(1)  =y(ihe4) * ratdum(irsiag)
     b(2) = y(ihe4) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
-    dfdy(is32,isi28) = esum(b,2)
+    dfdy(is32,isi28) = sum(b(1:2))
 
     ! d(s32)/d(s32)
     b(1) = -y(ihe4) * ratdum(irsag)
@@ -2635,7 +2635,7 @@ contains
     ! d(s32)/d(ar36)
     b(1) = ratdum(irarga)
     b(2) = ratdum(irt1) * ratdum(irargp)
-    dfdy(is32,iar36) = esum(b,2)
+    dfdy(is32,iar36) = sum(b(1:2))
 
 
     ! ar36 jacobian elements
@@ -2649,7 +2649,7 @@ contains
     ! d(ar36)/d(s32)
     b(1) = y(ihe4) * ratdum(irsag)
     b(2) = y(ihe4) * ratdum(irsap) * (1.0d0-ratdum(irt1))
-    dfdy(iar36,is32) = esum(b,2)
+    dfdy(iar36,is32) = sum(b(1:2))
 
     ! d(ar36)/d(ar36)
     b(1) = -y(ihe4) * ratdum(irarag)
@@ -2661,7 +2661,7 @@ contains
     ! d(ar36)/d(ca40)
     b(1) = ratdum(ircaga)
     b(2) = ratdum(ircagp) * ratdum(iru1)
-    dfdy(iar36,ica40) = esum(b,2)
+    dfdy(iar36,ica40) = sum(b(1:2))
 
 
     ! ca40 jacobian elements
@@ -2675,7 +2675,7 @@ contains
     ! d(ca40)/d(ar36)
     b(1) =  y(ihe4) * ratdum(irarag)
     b(2) =  y(ihe4) * ratdum(irarap)*(1.0d0-ratdum(iru1))
-    dfdy(ica40,iar36) = esum(b,2)
+    dfdy(ica40,iar36) = sum(b(1:2))
 
     ! d(ca40)/d(ca40)
     b(1) = -y(ihe4) * ratdum(ircaag)
@@ -2687,7 +2687,7 @@ contains
     ! d(ca40)/d(ti44)
     b(1) = ratdum(irtiga)
     b(2) = ratdum(irtigp) * ratdum(irv1)
-    dfdy(ica40,iti44) = esum(b,2)
+    dfdy(ica40,iti44) = sum(b(1:2))
 
 
     ! ti44 jacobian elements
@@ -2701,7 +2701,7 @@ contains
     ! d(ti44)/d(ca40)
     b(1) =  y(ihe4) * ratdum(ircaag)
     b(2) =  y(ihe4) * ratdum(ircaap)*(1.0d0-ratdum(irv1))
-    dfdy(iti44,ica40) = esum(b,2)
+    dfdy(iti44,ica40) = sum(b(1:2))
 
     ! d(ti44)/d(ti44)
     b(1) = -y(ihe4) * ratdum(irtiag)
@@ -2713,7 +2713,7 @@ contains
     ! d(ti44)/d(cr48)
     b(1) = ratdum(ircrga)
     b(2) = ratdum(irw1) * ratdum(ircrgp)
-    dfdy(iti44,icr48) = esum(b,2)
+    dfdy(iti44,icr48) = sum(b(1:2))
 
 
     ! cr48 jacobian elements
@@ -2727,7 +2727,7 @@ contains
     ! d(cr48)/d(ti44)
     b(1) =  y(ihe4) * ratdum(irtiag)
     b(2) =  y(ihe4) * ratdum(irtiap)*(1.0d0-ratdum(irw1))
-    dfdy(icr48,iti44) = esum(b,2)
+    dfdy(icr48,iti44) = sum(b(1:2))
 
     ! d(cr48)/d(cr48)
     b(1) = -y(ihe4) * ratdum(ircrag)
@@ -2739,7 +2739,7 @@ contains
     ! d(cr48)/d(fe52)
     b(1) = ratdum(irfega)
     b(2) = ratdum(irx1) * ratdum(irfegp)
-    dfdy(icr48,ife52) = esum(b,2)
+    dfdy(icr48,ife52) = sum(b(1:2))
 
 
     ! fe52 jacobian elements
@@ -2754,7 +2754,7 @@ contains
     ! d(fe52)/d(cr48)
     b(1) = y(ihe4) * ratdum(ircrag)
     b(2) = y(ihe4) * ratdum(ircrap) * (1.0d0-ratdum(irx1))
-    dfdy(ife52,icr48) = esum(b,2)
+    dfdy(ife52,icr48) = sum(b(1:2))
 
     ! d(fe52)/d(fe52)
     b(1) = -y(ihe4) * ratdum(irfeag)
@@ -2768,12 +2768,12 @@ contains
     ! d(fe52)/d(fe54)
     b(1) = ratdum(ir1f54)
     b(2) = y(iprot) * y(iprot) * ratdum(ir5f54)
-    dfdy(ife52,ife54) = esum(b,2)
+    dfdy(ife52,ife54) = sum(b(1:2))
 
     ! d(fe52)/d(ni56)
     b(1) = ratdum(irniga)
     b(2) = y(iprot) * ratdum(ir8f54)
-    dfdy(ife52,ini56) = esum(b,2)
+    dfdy(ife52,ini56) = sum(b(1:2))
 
     ! d(fe52)/d(neut)
     b(1) =  y(ife54) * dratdumdy1(ir1f54)
@@ -2799,7 +2799,7 @@ contains
     ! d(fe54)/d(fe52)
     b(1) =  y(ineut) * y(ineut) * ratdum(ir2f54)
     b(2) =  y(ihe4) * ratdum(ir6f54)
-    dfdy(ife54,ife52) = esum(b,2)
+    dfdy(ife54,ife52) = sum(b(1:2))
 
     ! d(fe54)/d(fe54)
     b(1) = -ratdum(ir1f54)
@@ -2810,7 +2810,7 @@ contains
     ! d(fe54)/d(ni56)
     b(1)  = ratdum(ir4f54)
     b(2)  = c54 * ratdum(irn56ec)
-    dfdy(ife54,ini56) = esum(b,2)
+    dfdy(ife54,ini56) = sum(b(1:2))
 
     ! d(fe54)/d(neut)
     b(1) = -y(ife54) * dratdumdy1(ir1f54)
@@ -2832,12 +2832,12 @@ contains
     ! d(ni56)/d(he4)
     b(1) =  y(ife52) * ratdum(irfeag)
     b(2) =  y(ife52) * y(iprot) * ratdum(ir7f54)
-    dfdy(ini56,ihe4) = esum(b,2)
+    dfdy(ini56,ihe4) = sum(b(1:2))
 
     ! d(ni56)/d(fe52)
     b(1) = y(ihe4) * ratdum(irfeag)
     b(2) = y(ihe4)* y(iprot) * ratdum(ir7f54)
-    dfdy(ini56,ife52) = esum(b,2)
+    dfdy(ini56,ife52) = sum(b(1:2))
 
     ! d(ni56)/d(fe54)
     dfdy(ini56,ife54) = y(iprot) * y(iprot) * ratdum(ir3f54)
@@ -2891,7 +2891,7 @@ contains
     ! photodisintegration proton jacobian elements
     b(1) =  2.0d0 * y(ife52) * ratdum(ir6f54)
     b(2) =  2.0d0 * ratdum(iralf1)
-    dfdy(iprot,ihe4) = esum(b,2)
+    dfdy(iprot,ihe4) = sum(b(1:2))
 
     ! d(prot)/d(fe52)
     dfdy(iprot,ife52) = 2.0d0 * y(ihe4) * ratdum(ir6f54)
@@ -2899,7 +2899,7 @@ contains
     ! d(prot)/d(fe54)
     b(1) = -2.0d0 * y(iprot) * y(iprot) * ratdum(ir3f54)
     b(2) = -2.0d0 * y(iprot) * y(iprot) * ratdum(ir5f54)
-    dfdy(iprot,ife54) = esum(b,2)
+    dfdy(iprot,ife54) = sum(b(1:2))
 
     ! d(prot)/d(ni56)
     dfdy(iprot,ini56) = 2.0d0 * ratdum(ir4f54)

--- a/networks/aprox21/actual_rhs.f90
+++ b/networks/aprox21/actual_rhs.f90
@@ -367,22 +367,22 @@ contains
     a(1) = 0.5d0 * y(ihe3) * y(ihe3) * rate(ir33)
     a(2) = y(ihe3) * y(ihe4) * rate(irhe3ag)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,2)
+    dydt(ihe4) =  dydt(ihe4) + sum(a(1:2))
 
 
     ! cno cycles
     a(1) = y(io16) * y(ih1) * rate(iropg)
     a(2) = -y(ihe4) * y(in14) * rate(irnag) * 1.5d0
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,2)
+    dydt(ihe4) =  dydt(ihe4) + sum(a(1:2))
 
     if (.not. deriva) then
        a(1) = y(in14) * y(ih1) * rate(ifa) * rate(irnpg)
-       dydt(ihe4) =  dydt(ihe4) + esum(a,1)
+       dydt(ihe4) =  dydt(ihe4) + a(1)
     else
        a(1) = y(in14) * y(ih1) * rate(ifa) * ratdum(irnpg)
        a(2) = y(in14) * y(ih1) * ratdum(ifa) * rate(irnpg)
-       dydt(ihe4) =  dydt(ihe4) + esum(a,2)
+       dydt(ihe4) =  dydt(ihe4) + sum(a(1:2))
     end if
 
 
@@ -399,11 +399,11 @@ contains
 
     if (.not. deriva) then
        a(1) =  y(in14) * y(ih1) * rate(ifa) * rate(irnpg)
-       dydt(ic12) =  dydt(ic12) + esum(a,1)
+       dydt(ic12) =  dydt(ic12) + a(1)
     else
        a(1) =  y(in14) * y(ih1) * rate(ifa) * ratdum(irnpg)
        a(2) =  y(in14) * y(ih1) * ratdum(ifa) * rate(irnpg)
-       dydt(ic12) =  dydt(ic12) + esum(a,2)
+       dydt(ic12) =  dydt(ic12) + sum(a(1:2))
     end if
 
 
@@ -429,11 +429,11 @@ contains
 
     if (.not. deriva) then
        a(1) =  y(in14) * y(ih1) * rate(ifg) * rate(irnpg)
-       dydt(io16) =  dydt(io16) + esum(a,1)
+       dydt(io16) =  dydt(io16) + a(1)
     else
        a(1) =  y(in14) * y(ih1) * rate(ifg) * ratdum(irnpg)
        a(2) =  y(in14) * y(ih1) * ratdum(ifg) * rate(irnpg)
-       dydt(io16) =  dydt(io16) + esum(a,2)
+       dydt(io16) =  dydt(io16) + sum(a(1:2))
     end if
 
 
@@ -461,7 +461,7 @@ contains
        a(1) = -y(img24) * y(ihe4) * rate(irmgap)*(1.0d0-rate(irr1))
        a(2) =  y(isi28) * rate(irr1) * rate(irsigp)
 
-       dydt(img24) =  dydt(img24) + esum(a,2)
+       dydt(img24) =  dydt(img24) + sum(a(1:2))
 
     else
        a(1) = -y(img24)*y(ihe4) * rate(irmgap)*(1.0d0 - ratdum(irr1))
@@ -663,7 +663,7 @@ contains
 
     ! cr56 reactions
     a(1)  = y(ife56) * 1.0d-04 * rate(irn56ec)
-    dydt(icr56) =  dydt(icr56) + esum(a,1)
+    dydt(icr56) =  dydt(icr56) + a(1)
 
 
     ! fe52 reactions
@@ -677,7 +677,7 @@ contains
     if (.not.deriva) then
        a(1) =  y(icr48) * y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
        a(2) = -y(ife52) * rate(irx1) * rate(irfegp)
-       dydt(ife52) =  dydt(ife52) + esum(a,2)
+       dydt(ife52) =  dydt(ife52) + sum(a(1:2))
 
     else
        a(1) =  y(icr48)*y(ihe4) * rate(ircrap)*(1.0d0-ratdum(irx1))
@@ -2401,12 +2401,12 @@ contains
     ! d(h1)/d(he3)
     b(1) = 2.0d0 * y(ihe3) * ratdum(ir33)
     b(2) = -y(ihe4) * ratdum(irhe3ag)
-    dfdy(ih1,ihe3) = esum(b,2)
+    dfdy(ih1,ihe3) = sum(b(1:2))
 
     ! d(h1)/d(he4)
     b(1) = -y(ihe3) * ratdum(irhe3ag)
     b(2) = -y(ihe3) * y(ihe4) * dratdumdy1(irhe3ag)
-    dfdy(ih1,ihe4) = esum(b,2)
+    dfdy(ih1,ihe4) = sum(b(1:2))
 
     ! d(h1)/d(c12)
     dfdy(ih1,ic12) = -2.0d0 * y(ih1) * ratdum(ircpg)
@@ -2422,17 +2422,17 @@ contains
     ! d(he3)/d(h1)
     b(1) = y(ih1) * ratdum(irpp)
     b(2) = ratdum(irpen)
-    dfdy(ihe3,ih1) = esum(b,2)
+    dfdy(ihe3,ih1) = sum(b(1:2))
 
     ! d(he3)/d(he3)
     b(1) = -2.0d0 * y(ihe3) * ratdum(ir33)
     b(2) = -y(ihe4) * ratdum(irhe3ag)
-    dfdy(ihe3,ihe3) = esum(b,2)
+    dfdy(ihe3,ihe3) = sum(b(1:2))
 
     ! d(he3)/d(he4)
     b(1) = -y(ihe3) * ratdum(irhe3ag)
     b(2) = -y(ihe3) * y(ihe4) * dratdumdy1(irhe3ag)
-    dfdy(ihe3,ihe4) = esum(b,2)
+    dfdy(ihe3,ihe4) = sum(b(1:2))
 
 
     ! he4 jacobian elements
@@ -2447,7 +2447,7 @@ contains
     ! d(he4)/d(he3)
     b(1) = y(ihe3) * ratdum(ir33)
     b(2) = y(ihe4) * ratdum(irhe3ag)
-    dfdy(ihe4,ihe3) = esum(b,2)
+    dfdy(ihe4,ihe3) = sum(b(1:2))
 
     ! d(he4)/d(he4)
     b(1)  = -1.5d0 * y(ihe4) * y(ihe4) * ratdum(ir3a)
@@ -2488,7 +2488,7 @@ contains
     ! d(he4)/d(n14)
     b(1) =  y(ih1) * ratdum(ifa) * ratdum(irnpg)
     b(2) = -y(ihe4) * ratdum(irnag) * 1.5d0
-    dfdy(ihe4,in14) = esum(b,2)
+    dfdy(ihe4,in14) = sum(b(1:2))
 
     ! d(he4)/d(o16)
     b(1) =  0.5d0 * y(ic12) * ratdum(ir1216)
@@ -2502,7 +2502,7 @@ contains
     ! d(he4)/d(ne20)
     b(1) =  ratdum(irnega)
     b(2) = -y(ihe4) * ratdum(irneag)
-    dfdy(ihe4,ine20) = esum(b,2)
+    dfdy(ihe4,ine20) = sum(b(1:2))
 
     ! d(he4)/d(mg24)
     b(1) =  ratdum(irmgga)
@@ -2563,7 +2563,7 @@ contains
     ! d(he4)/d(fe54)
     b(1) =  y(iprot) * y(iprot) * ratdum(ir5f54)
     b(2) = -y(ihe4) * ratdum(irfe56_aux4)
-    dfdy(ihe4,ife54) = esum(b,2)
+    dfdy(ihe4,ife54) = sum(b(1:2))
 
     ! d(he4)/d(fe56)
     dfdy(ihe4,ife56) = y(iprot) * y(iprot) * ratdum(irfe56_aux3)
@@ -2607,7 +2607,7 @@ contains
     ! d(c12)/d(he4)
     b(1) =  0.5d0 * y(ihe4) * y(ihe4) * ratdum(ir3a)
     b(2) = -y(ic12) * ratdum(ircag)
-    dfdy(ic12,ihe4) = esum(b,2)
+    dfdy(ic12,ihe4) = sum(b(1:2))
 
     ! d(c12)/d(c12)
     b(1) = -2.0d0 * y(ic12) * ratdum(ir1212)
@@ -2623,7 +2623,7 @@ contains
     ! d(c12)/d(o16)
     b(1) = -y(ic12) * ratdum(ir1216)
     b(2) =  ratdum(iroga)
-    dfdy(ic12,io16) = esum(b,2)
+    dfdy(ic12,io16) = sum(b(1:2))
 
 
     ! n14 jacobian elements
@@ -2644,7 +2644,7 @@ contains
     ! d(n14)/d(n14)
     b(1) = -y(ih1) * ratdum(irnpg)
     b(2) = -y(ihe4) * ratdum(irnag)
-    dfdy(in14,in14) = esum(b,2)
+    dfdy(in14,in14) = sum(b(1:2))
 
     ! d(n14)/d(o16)
     dfdy(in14,io16) = y(ih1) * ratdum(iropg)
@@ -2661,12 +2661,12 @@ contains
     ! d(o16)/d(he4)
     b(1) =  y(ic12)*ratdum(ircag)
     b(2) = -y(io16)*ratdum(iroag)
-    dfdy(io16,ihe4) = esum(b,2)
+    dfdy(io16,ihe4) = sum(b(1:2))
 
     ! d(o16)/d(c12)
     b(1) = -y(io16)*ratdum(ir1216)
     b(2) =  y(ihe4)*ratdum(ircag)
-    dfdy(io16,ic12) = esum(b,2)
+    dfdy(io16,ic12) = sum(b(1:2))
 
     ! d(o16)/d(n14)
     dfdy(io16,in14) = y(ih1) * ratdum(ifg) * ratdum(irnpg)
@@ -2703,7 +2703,7 @@ contains
     ! d(ne20)/d(ne20)
     b(1) = -y(ihe4) * ratdum(irneag)
     b(2) = -ratdum(irnega)
-    dfdy(ine20,ine20) = esum(b,2)
+    dfdy(ine20,ine20) = sum(b(1:2))
 
     ! d(ne20)/d(mg24)
     dfdy(ine20,img24) = ratdum(irmgga)
@@ -2735,7 +2735,7 @@ contains
     ! d(mg24)/d(si28)
     b(1) = ratdum(irsiga)
     b(2) = ratdum(irr1) * ratdum(irsigp)
-    dfdy(img24,isi28) = esum(b,2)
+    dfdy(img24,isi28) = sum(b(1:2))
 
 
 
@@ -2759,7 +2759,7 @@ contains
     ! d(si28)/d(mg24)
     b(1) =  y(ihe4) * ratdum(irmgag)
     b(2) =  y(ihe4) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
-    dfdy(isi28,img24) = esum(b,2)
+    dfdy(isi28,img24) = sum(b(1:2))
 
     ! d(si28)/d(si28)
     b(1) =  -y(ihe4) * ratdum(irsiag)
@@ -2771,7 +2771,7 @@ contains
     ! d(si28)/d(s32)
     b(1) = ratdum(irsga)
     b(2) = ratdum(irs1) * ratdum(irsgp)
-    dfdy(isi28,is32) = esum(b,2)
+    dfdy(isi28,is32) = sum(b(1:2))
 
 
     ! s32 jacobian elements
@@ -2785,12 +2785,12 @@ contains
     ! d(s32)/d(o16)
     b(1) = 0.68d0*0.5d0*y(io16)*ratdum(ir1616)*(1.0d0-ratdum(irs1))
     b(2) = 0.2d0 * 0.5d0*y(io16) * ratdum(ir1616)
-    dfdy(is32,io16) = esum(b,2)
+    dfdy(is32,io16) = sum(b(1:2))
 
     ! d(s32)/d(si28)
     b(1)  =y(ihe4) * ratdum(irsiag)
     b(2) = y(ihe4) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
-    dfdy(is32,isi28) = esum(b,2)
+    dfdy(is32,isi28) = sum(b(1:2))
 
     ! d(s32)/d(s32)
     b(1) = -y(ihe4) * ratdum(irsag)
@@ -2802,7 +2802,7 @@ contains
     ! d(s32)/d(ar36)
     b(1) = ratdum(irarga)
     b(2) = ratdum(irt1) * ratdum(irargp)
-    dfdy(is32,iar36) = esum(b,2)
+    dfdy(is32,iar36) = sum(b(1:2))
 
 
     ! ar36 jacobian elements
@@ -2816,7 +2816,7 @@ contains
     ! d(ar36)/d(s32)
     b(1) = y(ihe4) * ratdum(irsag)
     b(2) = y(ihe4) * ratdum(irsap) * (1.0d0-ratdum(irt1))
-    dfdy(iar36,is32) = esum(b,2)
+    dfdy(iar36,is32) = sum(b(1:2))
 
     ! d(ar36)/d(ar36)
     b(1) = -y(ihe4) * ratdum(irarag)
@@ -2828,7 +2828,7 @@ contains
     ! d(ar36)/d(ca40)
     b(1) = ratdum(ircaga)
     b(2) = ratdum(ircagp) * ratdum(iru1)
-    dfdy(iar36,ica40) = esum(b,2)
+    dfdy(iar36,ica40) = sum(b(1:2))
 
 
 
@@ -2843,7 +2843,7 @@ contains
     ! d(ca40)/d(ar36)
     b(1) =  y(ihe4) * ratdum(irarag)
     b(2) =  y(ihe4) * ratdum(irarap)*(1.0d0-ratdum(iru1))
-    dfdy(ica40,iar36) = esum(b,2)
+    dfdy(ica40,iar36) = sum(b(1:2))
 
     ! d(ca40)/d(ca40)
     b(1) =  -y(ihe4) * ratdum(ircaag)
@@ -2855,7 +2855,7 @@ contains
     ! d(ca40)/d(ti44)
     b(1) = ratdum(irtiga)
     b(2) = ratdum(irtigp) * ratdum(irv1)
-    dfdy(ica40,iti44) = esum(b,2)
+    dfdy(ica40,iti44) = sum(b(1:2))
 
 
     ! ti44 jacobian elements
@@ -2869,7 +2869,7 @@ contains
     ! d(ti44)/d(ca40)
     b(1) =  y(ihe4) * ratdum(ircaag)
     b(2) =  y(ihe4) * ratdum(ircaap)*(1.0d0-ratdum(irv1))
-    dfdy(iti44,ica40) = esum(b,2)
+    dfdy(iti44,ica40) = sum(b(1:2))
 
     ! d(ti44)/d(ti44)
     b(1) = -y(ihe4) * ratdum(irtiag)
@@ -2881,7 +2881,7 @@ contains
     ! d(ti44)/d(cr48)
     b(1) = ratdum(ircrga)
     b(2) = ratdum(irw1) * ratdum(ircrgp)
-    dfdy(iti44,icr48) = esum(b,2)
+    dfdy(iti44,icr48) = sum(b(1:2))
 
 
     ! cr48 jacobian elements
@@ -2895,7 +2895,7 @@ contains
     ! d(cr48)/d(ti44)
     b(1) =  y(ihe4) * ratdum(irtiag)
     b(2) =  y(ihe4) * ratdum(irtiap)*(1.0d0-ratdum(irw1))
-    dfdy(icr48,iti44) = esum(b,2)
+    dfdy(icr48,iti44) = sum(b(1:2))
 
     ! d(cr48)/d(cr48)
     b(1) = -y(ihe4) * ratdum(ircrag)
@@ -2907,7 +2907,7 @@ contains
     ! d(cr48)/d(fe52)
     b(1) = ratdum(irfega)
     b(2) = ratdum(irx1) * ratdum(irfegp)
-    dfdy(icr48,ife52) = esum(b,2)
+    dfdy(icr48,ife52) = sum(b(1:2))
 
 
     ! cr56 jacobian elements
@@ -2932,7 +2932,7 @@ contains
     ! d(fe52)/d(cr48)
     b(1) = y(ihe4) * ratdum(ircrag)
     b(2) = y(ihe4) * ratdum(ircrap) * (1.0d0-ratdum(irx1))
-    dfdy(ife52,icr48) = esum(b,2)
+    dfdy(ife52,icr48) = sum(b(1:2))
 
     ! d(fe52)/d(fe52)
     b(1) = -y(ihe4) * ratdum(irfeag)
@@ -2946,12 +2946,12 @@ contains
     ! d(fe52)/d(fe54)
     b(1) = ratdum(ir1f54)
     b(2) = y(iprot) * y(iprot) * ratdum(ir5f54)
-    dfdy(ife52,ife54) = esum(b,2)
+    dfdy(ife52,ife54) = sum(b(1:2))
 
     ! d(fe52)/d(ni56)
     b(1) = ratdum(irniga)
     b(2) = y(iprot) * ratdum(ir8f54)
-    dfdy(ife52,ini56) = esum(b,2)
+    dfdy(ife52,ini56) = sum(b(1:2))
 
     ! d(fe52)/d(neut)
     b(1) =  y(ife54) * dratdumdy1(ir1f54)
@@ -2976,12 +2976,12 @@ contains
     ! d(fe54)/d(he4)
     b(1) =  y(ife52) * ratdum(ir6f54)
     b(2) = -y(ife54) * ratdum(irfe56_aux4)
-    dfdy(ife54,ihe4) = esum(b,2)
+    dfdy(ife54,ihe4) = sum(b(1:2))
 
     ! d(fe54)/d(fe52)
     b(1) =  y(ineut) * y(ineut) * ratdum(ir2f54)
     b(2) =  y(ihe4) * ratdum(ir6f54)
-    dfdy(ife54,ife52) = esum(b,2)
+    dfdy(ife54,ife52) = sum(b(1:2))
 
     ! d(fe54)/d(fe54)
     b(1) = -ratdum(ir1f54)
@@ -2994,7 +2994,7 @@ contains
     ! d(fe54)/d(fe56)
     b(1) = ratdum(irfe56_aux1)
     b(2) = y(iprot) * y(iprot) * ratdum(irfe56_aux3)
-    dfdy(ife54,ife56) = esum(b,2)
+    dfdy(ife54,ife56) = sum(b(1:2))
 
     ! d(fe54)/d(ni56)
     dfdy(ife54,ini56) = ratdum(ir4f54)
@@ -3029,7 +3029,7 @@ contains
     ! d(fe56)/d(fe54)
     b(1)  = y(ineut) * y(ineut) * ratdum(irfe56_aux2)
     b(2)  = y(ihe4) * ratdum(irfe56_aux4)
-    dfdy(ife56,ife54) = esum(b,2)
+    dfdy(ife56,ife54) = sum(b(1:2))
 
     ! d(fe56)/d(fe56)
     b(1) = -1.0d-04 * ratdum(irn56ec)
@@ -3058,12 +3058,12 @@ contains
     ! d(ni56)/d(he4)
     b(1) =  y(ife52) * ratdum(irfeag)
     b(2) =  y(ife52) * y(iprot) * ratdum(ir7f54)
-    dfdy(ini56,ihe4) = esum(b,2)
+    dfdy(ini56,ihe4) = sum(b(1:2))
 
     ! d(ni56)/d(fe52)
     b(1) = y(ihe4) * ratdum(irfeag)
     b(2) = y(ihe4)* y(iprot) * ratdum(ir7f54)
-    dfdy(ini56,ife52) = esum(b,2)
+    dfdy(ini56,ife52) = sum(b(1:2))
 
     ! d(ni56)/d(fe54)
     dfdy(ini56,ife54) = y(iprot) * y(iprot) * ratdum(ir3f54)
@@ -3096,7 +3096,7 @@ contains
     ! d(neut)/d(fe54)
     b(1) = 2.0d0 * ratdum(ir1f54)
     b(2) = -2.0d0 * y(ineut) * y(ineut) * ratdum(irfe56_aux2)
-    dfdy(ineut,ife54) = esum(b,2)
+    dfdy(ineut,ife54) = sum(b(1:2))
 
     ! d(neut)/d(fe56)
     dfdy(ineut,ife56) = 2.0d0 * ratdum(irfe56_aux1)

--- a/networks/iso7/actual_rhs.f90
+++ b/networks/iso7/actual_rhs.f90
@@ -287,7 +287,7 @@ contains
     a(1) =  rate(irsi2ni) * y(ihe4)
     a(2) = -rate(irni2si) * y(ini56)
 
-    dydt(ini56) = esum(a,2)
+    dydt(ini56) = sum(a(1:2))
 
   end subroutine rhs
 
@@ -653,24 +653,24 @@ contains
     b(1) =  ratdum(irnega)
     b(2) = -y(ihe4) * ratdum(irneag)
 
-    dfdy(ihe4,ine20) = esum(b,2)
+    dfdy(ihe4,ine20) = sum(b(1:2))
 
     ! d(he4)/d(mg24)
     b(1) =  ratdum(irmgga)
     b(2) = -y(ihe4) * ratdum(irmgag)
 
-    dfdy(ihe4,img24) = esum(b,2)
+    dfdy(ihe4,img24) = sum(b(1:2))
 
     ! d(he4)/d(si28)
     b(1) =  ratdum(irsiga)
     b(2) = -7.0d0 * dratdumdy2(irsi2ni) * y(ihe4)
 
-    dfdy(ihe4,isi28) = esum(b,2)
+    dfdy(ihe4,isi28) = sum(b(1:2))
 
     ! d(he4)/d(ni56)
     b(1) =  7.0d0 * ratdum(irni2si)
 
-    dfdy(ihe4,ini56) = esum(b,1)
+    dfdy(ihe4,ini56) = b(1)
 
 
 
@@ -679,7 +679,7 @@ contains
     b(1) =  0.5d0 * y(ihe4) * y(ihe4) * ratdum(ir3a)
     b(2) = -y(ic12) * ratdum(ircag)
 
-    dfdy(ic12,ihe4) = esum(b,2)
+    dfdy(ic12,ihe4) = sum(b(1:2))
 
     ! d(c12)/d(c12)
     b(1) = -ratdum(irg3a)
@@ -693,7 +693,7 @@ contains
     b(1) =  ratdum(iroga)
     b(2) = -y(ic12) * ratdum(ir1216)
 
-    dfdy(ic12,io16) = esum(b,2)
+    dfdy(ic12,io16) = sum(b(1:2))
 
 
     ! 16o jacobian elements
@@ -701,13 +701,13 @@ contains
     b(1) =  y(ic12) * ratdum(ircag)
     b(2) = -y(io16) * ratdum(iroag)
 
-    dfdy(io16,ihe4) = esum(b,2)
+    dfdy(io16,ihe4) = sum(b(1:2))
 
     ! d(o16)/d(c12)
     b(1) =  y(ihe4) * ratdum(ircag)
     b(2) = -y(io16) * ratdum(ir1216)
 
-    dfdy(io16,ic12) = esum(b,2)
+    dfdy(io16,ic12) = sum(b(1:2))
 
     ! d(o16)/d(o16)
     b(1) = -ratdum(iroga)
@@ -720,7 +720,7 @@ contains
     ! d(o16)/d(ne20)
     b(1) =  ratdum(irnega)
 
-    dfdy(io16,ine20) = esum(b,1)
+    dfdy(io16,ine20) = b(1)
 
 
 
@@ -728,27 +728,27 @@ contains
     ! d(ne20)/d(he4)
     b(1) =  y(io16) * ratdum(iroag) - y(ine20) * ratdum(irneag)
 
-    dfdy(ine20,ihe4) = esum(b,1)
+    dfdy(ine20,ihe4) = b(1)
 
     ! d(ne20)/d(c12)
     b(1) =  y(ic12) * ratdum(ir1212)
 
-    dfdy(ine20,ic12) = esum(b,1)
+    dfdy(ine20,ic12) = b(1)
 
     ! d(ne20)/d(o16)
     b(1) =  y(ihe4) * ratdum(iroag)
 
-    dfdy(ine20,io16) = esum(b,1)
+    dfdy(ine20,io16) = b(1)
 
     ! d(ne20)/d(ne20)
     b(1) = -ratdum(irnega) - y(ihe4) * ratdum(irneag)
 
-    dfdy(ine20,ine20) = esum(b,1)
+    dfdy(ine20,ine20) = b(1)
 
     ! d(ne20)/d(mg24)
     b(1) =  ratdum(irmgga)
 
-    dfdy(ine20,img24) = esum(b,1)
+    dfdy(ine20,img24) = b(1)
 
 
 
@@ -757,33 +757,33 @@ contains
     b(1) =  y(ine20) * ratdum(irneag)
     b(2) = -y(img24) * ratdum(irmgag)
 
-    dfdy(img24,ihe4) = esum(b,2)
+    dfdy(img24,ihe4) = sum(b(1:2))
 
     ! d(mg24)/d(c12)
     b(1) =  0.5d0 * y(io16) * ratdum(ir1216)
 
-    dfdy(img24,ic12) = esum(b,1)
+    dfdy(img24,ic12) = b(1)
 
     ! d(mg24)/d(o16)
     b(1) =  0.5d0 * y(ic12) * ratdum(ir1216)
 
-    dfdy(img24,io16) = esum(b,1)
+    dfdy(img24,io16) = b(1)
 
     ! d(mg24)/d(ne20)
     b(1) =  y(ihe4) * ratdum(irneag)
 
-    dfdy(img24,ine20) = esum(b,1)
+    dfdy(img24,ine20) = b(1)
 
     ! d(mg24)/d(mg24)
     b(1) = -ratdum(irmgga)
     b(2) = -y(ihe4) * ratdum(irmgag)
 
-    dfdy(img24,img24) = esum(b,2)
+    dfdy(img24,img24) = sum(b(1:2))
 
     ! d(mg24)/d(si28)
     b(1) =  ratdum(irsiga)
 
-    dfdy(img24,isi28) = esum(b,1)
+    dfdy(img24,isi28) = b(1)
 
     ! 28si jacobian elements
     ! d(si28)/d(he4)
@@ -797,29 +797,29 @@ contains
     ! d(si28)/d(c12)
     b(1) =  0.5d0 * y(io16) * ratdum(ir1216)
 
-    dfdy(isi28,ic12) = esum(b,1)
+    dfdy(isi28,ic12) = b(1)
 
     ! d(si28)/d(o16)
     b(1) =  y(io16) * ratdum(ir1616)
     b(2) =  0.5d0 * y(ic12) * ratdum(ir1216)
 
-    dfdy(isi28,io16) = esum(b,2)
+    dfdy(isi28,io16) = sum(b(1:2))
 
     ! d(si28)/d(mg24)
     b(1) =  y(ihe4) * ratdum(irmgag)
 
-    dfdy(isi28,img24) = esum(b,1)
+    dfdy(isi28,img24) = b(1)
 
     ! d(si28)/d(si28)
     b(1) = -ratdum(irsiga)
     b(2) = -dratdumdy2(irsi2ni) * y(ihe4)
 
-    dfdy(isi28,isi28) = esum(b,2)
+    dfdy(isi28,isi28) = sum(b(1:2))
 
     ! d(si28)/d(ni56)
     b(1) =  ratdum(irni2si)
 
-    dfdy(isi28,ini56) = esum(b,1)
+    dfdy(isi28,ini56) = b(1)
 
     ! ni56 jacobian elements
     ! d(ni56)/d(he4)
@@ -832,12 +832,12 @@ contains
     ! d(ni56)/d(si28)
     b(1) = dratdumdy2(irsi2ni) * y(ihe4)
 
-    dfdy(ini56,isi28) = esum(b,1)
+    dfdy(ini56,isi28) = b(1)
 
     ! d(ni56)/d(ni56)
     b(1) = -ratdum(irni2si)
 
-    dfdy(ini56,ini56) = esum(b,1)
+    dfdy(ini56,ini56) = b(1)
 
   end subroutine dfdy_isotopes_iso7
 


### PR DESCRIPTION
`esum()` has no benefit for sums of 1 or 2 terms