### PR TITLE
Set burn_cell.py to look into 'runprefix_output' 

### DIFF
--- a/unit_test/burn_cell/burn_cell.py
+++ b/unit_test/burn_cell/burn_cell.py
@@ -133,9 +133,6 @@ def rgba_to_hex(rgba):
     return '#{:02X}{:02X}{:02X}'.format(r,g,b)
 
 ## PLOTTING
-    
-# Obtain test prefix
-testprefix = input('Please input a testing prefix:   ')
 
 # Figure out time axis limits
 if args.tlo and args.thi:
@@ -193,16 +190,6 @@ plt.savefig(args.runprefix+'_logX.eps',
             bbox_extra_artists=(lgd,), bbox_inches='tight')
 plt.savefig(args.runprefix+'_logX.png', dpi=300,
             bbox_extra_artists=(lgd,), bbox_inches='tight')
-
-#Save Data to a file
-np.savetxt('{}_{}_xvec.txt'.format(args.runprefix, testprefix), xvec)
-for n in range(nspec):
-    np.savetxt('{}_{}_xn{}.txt'.format(args.runprefix, testprefix, n), xn[n])
-
-specfile = open('{}_short_spec_names.txt'.format(args.runprefix), 'w')
-for item in short_spec_names:
-    specfile.write('{}\n'.format(item))
-specfile.close()
 
 # Clear figure
 plt.clf()

--- a/unit_test/burn_cell/burn_cell.py
+++ b/unit_test/burn_cell/burn_cell.py
@@ -17,7 +17,7 @@ parser.add_argument('--nlo', type=float, help='File num lower limit')
 parser.add_argument('--nhi', type=float, help='File num upper limit')
 args = parser.parse_args()
 
-files = glob.glob(args.runprefix + r'_[0-9]*')
+files = glob.glob(args.runprefix + r'_output/' + args.runprefix + r'_[0-9]*')
 print('Found {} files matching pattern {}'.format(len(files), args.runprefix+'_[0-9]*'))
 if len(files) == 0:
     exit()
@@ -134,6 +134,9 @@ def rgba_to_hex(rgba):
 
 ## PLOTTING
     
+# Obtain test prefix
+testprefix = input('Please input a testing prefix:   ')
+
 # Figure out time axis limits
 if args.tlo and args.thi:
     ltlim = [args.tlo, args.thi]
@@ -190,6 +193,16 @@ plt.savefig(args.runprefix+'_logX.eps',
             bbox_extra_artists=(lgd,), bbox_inches='tight')
 plt.savefig(args.runprefix+'_logX.png', dpi=300,
             bbox_extra_artists=(lgd,), bbox_inches='tight')
+
+#Save Data to a file
+np.savetxt('{}_{}_xvec.txt'.format(args.runprefix, testprefix), xvec)
+for n in range(nspec):
+    np.savetxt('{}_{}_xn{}.txt'.format(args.runprefix, testprefix, n), xn[n])
+
+specfile = open('{}_short_spec_names.txt'.format(args.runprefix), 'w')
+for item in short_spec_names:
+    specfile.write('{}\n'.format(item))
+specfile.close()
 
 # Clear figure
 plt.clf()


### PR DESCRIPTION
Set burn_cell.py to look into 'runprefix_output' for the files required for plotting.