### PR TITLE
Do not define extra thermo components of eos_t ifndef EXTRA_THERMO

### DIFF
--- a/EOS/helmholtz/actual_eos.F90
+++ b/EOS/helmholtz/actual_eos.F90
@@ -219,7 +219,7 @@ contains
                             detadt,detadd,xnefer,dxnedt,dxnedd,s, &
                             temp,den,abar,zbar,ytot1,ye
 
-#if EXTRA_THERMO
+#ifdef EXTRA_THERMO
         !..for the abar derivatives
         double precision :: dpradda,deradda,dsradda, &
                             dpionda,deionda,dsionda, &

--- a/GMicrophysics.mak
+++ b/GMicrophysics.mak
@@ -29,7 +29,7 @@ endif
 EOS_TOP_DIR := $(MICROPHYSICS_HOME)/EOS
 
 ifdef EXTRA_THERMO
-  ifeq($(EXTRA_THERMO), t)
+  ifeq ($(EXTRA_THERMO), t)
     FPP_DEFINES += -DEXTRA_THERMO
   endif
 endif

--- a/GMicrophysics.mak
+++ b/GMicrophysics.mak
@@ -28,6 +28,12 @@ endif
 # EOS
 EOS_TOP_DIR := $(MICROPHYSICS_HOME)/EOS
 
+ifdef EXTRA_THERMO
+  ifeq($(EXTRA_THERMO), t)
+    FPP_DEFINES += -DEXTRA_THERMO
+  endif
+endif
+
 # the helmeos has a table
 ifeq ($(findstring helmholtz, $(EOS_DIR)), helmholtz)
   EOS_PATH := $(EOS_TOP_DIR)/helmholtz

--- a/interfaces/GPackage.mak
+++ b/interfaces/GPackage.mak
@@ -1,4 +1,4 @@
-f90sources += eos_type.f90
+F90sources += eos_type.F90
 F90sources += burn_type.F90
 ifdef SDC
   F90sources += sdc_type.F90

--- a/interfaces/eos_type.F90
+++ b/interfaces/eos_type.F90
@@ -131,20 +131,25 @@ module eos_type_module
     real(dp_t) :: mu
     real(dp_t) :: mu_e
     real(dp_t) :: y_e
+
+#ifdef EXTRA_THERMO
     real(dp_t) :: dedX(nspec)
     real(dp_t) :: dpdX(nspec)
     real(dp_t) :: dhdX(nspec)
+#endif
+
     real(dp_t) :: gam1
     real(dp_t) :: cs
 
     real(dp_t) :: abar
     real(dp_t) :: zbar
-    real(dp_t) :: dpdA
 
+#ifdef EXTRA_THERMO
+    real(dp_t) :: dpdA
     real(dp_t) :: dpdZ
     real(dp_t) :: dedA
     real(dp_t) :: dedZ
-
+#endif
   end type eos_t
 
 contains
@@ -190,6 +195,7 @@ contains
 
     type (eos_t), intent(inout) :: state
 
+#ifdef EXTRA_THERMO
     state % dpdX(:) = state % dpdA * (state % abar * aion_inv(:))   &
                                    * (aion(:) - state % abar) &
                     + state % dpdZ * (state % abar * aion_inv(:))   &
@@ -207,6 +213,7 @@ contains
                        *  state % dPdX(:) / state % dPdr
 
     endif
+#endif
 
   end subroutine composition_derivatives
 


### PR DESCRIPTION
This PR will not declare composition derivative components of `eos_t` unless `EXTRA_THERMO` is defined.

Previously, we would not yield a compiler error if we tried accessing the composition derivatives without `EXTRA_THERMO`, introducing undefined results and, when compiling with OpenMP, silent NaNs.

We should use the `eos_t.F90` here in Maestro to avoid problems like this.

This changes one instance of `if EXTRA_THERMO` to `ifdef EXTRA_THERMO` in `helmholtz/actual_eos.F90` to conform to all other ifdef statements in which `EXTRA_THERMO` appears.