### PR TITLE
Modify burn retry strategy to stick with current integrator as long as possible

### DIFF
--- a/integration/integrator.F90
+++ b/integration/integrator.F90
@@ -118,7 +118,13 @@ contains
 #elif (INTEGRATOR == 1)
                 print *, "Retrying burn with VODE integrator"
 #endif
-             endif
+             else
+
+                ! We are out of integrators; give up.
+
+                exit
+
+             end if
 
           end if
 

--- a/integration/integrator.F90
+++ b/integration/integrator.F90
@@ -56,68 +56,75 @@ contains
 #if (INTEGRATOR == 0 || INTEGRATOR == 1)
     type (integration_status_t) :: status
     real(dp_t) :: retry_change_factor
+    integer :: current_integrator
 
-    retry_change_factor = ONE
+    do current_integrator = 0, 1
 
-    status % atol_spec = atol_spec
-    status % rtol_spec = rtol_spec
+       retry_change_factor = ONE
 
-    status % atol_temp = atol_temp
-    status % rtol_temp = rtol_temp
+       status % atol_spec = atol_spec
+       status % rtol_spec = rtol_spec
 
-    status % atol_enuc = atol_enuc
-    status % rtol_enuc = rtol_enuc
+       status % atol_temp = atol_temp
+       status % rtol_temp = rtol_temp
 
-    do while (retry_change_factor <= retry_burn_max_change)
+       status % atol_enuc = atol_enuc
+       status % rtol_enuc = rtol_enuc
 
-       status % integration_complete = .true.
+       do
 
-#if (INTEGRATOR == 0)
-       call vode_integrator(state_in, state_out, dt, time, status)
-#elif (INTEGRATOR == 1)
-       call bs_integrator(state_in, state_out, dt, time, status)
-#endif
-
-       if (status % integration_complete) exit
-
-       ! If we got here, the integration failed, try the next burner.
-
-       status % integration_complete = .true.
+          status % integration_complete = .true.
 
 #if (INTEGRATOR == 0)
-       print *, "Retrying burn with BS integrator"
-       call bs_integrator(state_in, state_out, dt, time, status)
+          if (current_integrator == 0) then
+             call vode_integrator(state_in, state_out, dt, time, status)
+          else if (current_integrator == 1) then
+             call bs_integrator(state_in, state_out, dt, time, status)
+          endif
 #elif (INTEGRATOR == 1)
-       print *, "Retrying burn with VODE integrator"
-       call vode_integrator(state_in, state_out, dt, time, status)
+          if (current_integrator == 0) then
+             call bs_integrator(state_in, state_out, dt, time, status)
+          else if (current_integrator == 1) then
+             call vode_integrator(state_in, state_out, dt, time, status)
+          endif
 #endif
 
+          if (status % integration_complete) exit
+
+          ! If we got here, the integration failed; loosen the tolerances.
+
+          if (retry_change_factor < retry_burn_max_change) then
+
+             print *, "Retrying burn with looser tolerances in zone ", state_in % i, state_in % j, state_in % k
+
+             retry_change_factor = retry_change_factor * retry_burn_factor
+
+             status % atol_spec = status % atol_spec * retry_burn_factor
+             status % rtol_spec = status % rtol_spec * retry_burn_factor
+
+             status % atol_temp = status % atol_temp * retry_burn_factor
+             status % rtol_temp = status % rtol_temp * retry_burn_factor
+
+             status % atol_enuc = status % atol_enuc * retry_burn_factor
+             status % rtol_enuc = status % rtol_enuc * retry_burn_factor
+
+             print *, "New tolerance loosening factor = ", retry_change_factor
+
+          else
+
+             if (current_integrator < 1) then
+#if (INTEGRATOR == 0)
+                print *, "Retrying burn with BS integrator"
+#elif (INTEGRATOR == 1)
+                print *, "Retrying burn with VODE integrator"
+#endif
+             endif
+
+          end if
+
+       end do
+
        if (status % integration_complete) exit
-
-       ! If we got here, all integrations failed, loosen the tolerances.
-
-       if (.not. retry_burn) then
-
-          call bl_error("ERROR in burner: integration failed")
-
-       else
-
-          print *, "Retrying burn with looser tolerances in zone ", state_in % i, state_in % j, state_in % k
-
-          retry_change_factor = retry_change_factor * retry_burn_factor
-
-          status % atol_spec = status % atol_spec * retry_burn_factor
-          status % rtol_spec = status % rtol_spec * retry_burn_factor
-
-          status % atol_temp = status % atol_temp * retry_burn_factor
-          status % rtol_temp = status % rtol_temp * retry_burn_factor
-
-          status % atol_enuc = status % atol_enuc * retry_burn_factor
-          status % rtol_enuc = status % rtol_enuc * retry_burn_factor
-
-          print *, "New tolerance loosening factor = ", retry_change_factor
-
-       end if
 
     end do
 

--- a/integration/integrator.F90
+++ b/integration/integrator.F90
@@ -58,6 +58,13 @@ contains
     real(dp_t) :: retry_change_factor
     integer :: current_integrator
 
+    ! Loop through all available integrators. Our strategy will be to
+    ! try the default integrator first. If the burn fails, we loosen
+    ! the tolerance and try again, and keep doing so until we succed.
+    ! If we keep failing and hit the threshold for how much tolerance
+    ! loosening we will accept, then we restart with the original tolerance
+    ! and switch to another integrator.
+
     do current_integrator = 0, 1
 
        retry_change_factor = ONE
@@ -70,6 +77,9 @@ contains
 
        status % atol_enuc = atol_enuc
        status % rtol_enuc = rtol_enuc
+
+       ! Loop until we either succeed at the integration, or run
+       ! out of tolerance loosening to try.
 
        do
 
@@ -130,9 +140,14 @@ contains
 
        end do
 
+       ! No need to do the next integrator if we have already succeeded.
+
        if (status % integration_complete) exit
 
     end do
+
+    ! If we get to this point, all available integrators have
+    ! failed at all available tolerances; we must abort.
 
     if (.not. status % integration_complete) then
 


### PR DESCRIPTION
Instead of swapping integrators at a fixed tolerance, we will instead hold the integrator constant and first attempt loosening the tolerance when a burn fails. This allows for a more consistent evolution when a burn fails, at the expense of a looser tolerance.

Closes #95