### PR TITLE
Move ener_gener_rate into actual_rhs for subch network.

### DIFF
--- a/networks/subch/actual_network.f90
+++ b/networks/subch/actual_network.f90
@@ -182,19 +182,5 @@ contains
   subroutine actual_network_finalize()
     ! STUB FOR MAESTRO
   end subroutine actual_network_finalize
-  
-  subroutine ener_gener_rate(dydt, enuc)
-    ! Computes the instantaneous energy generation rate
-    !$acc routine seq
-  
-    implicit none
-
-    double precision :: dydt(nspec), enuc
-
-    ! This is basically e = m c**2
-
-    enuc = sum(dydt(:) * mion(:)) * enuc_conv2
-
-  end subroutine ener_gener_rate
 
 end module actual_network

--- a/networks/subch/actual_rhs.f90
+++ b/networks/subch/actual_rhs.f90
@@ -33,6 +33,20 @@ contains
     return
   end subroutine update_unevolved_species
 
+  subroutine ener_gener_rate(dydt, enuc)
+    ! Computes the instantaneous energy generation rate
+    !$acc routine seq
+
+    implicit none
+
+    double precision :: dydt(nspec), enuc
+
+    ! This is basically e = m c**2
+
+    enuc = sum(dydt(:) * mion(:)) * enuc_conv2
+
+  end subroutine ener_gener_rate
+
   subroutine evaluate_rates(state, rate_eval)
     !$acc routine seq
     type(burn_t)     :: state


### PR DESCRIPTION
This just moves the subroutine ener_gener_rate into the actual_rhs module for the subch network to match convention.