### PR TITLE
Update interfaces for CUDA.

### DIFF
--- a/interfaces/burn_type.F90
+++ b/interfaces/burn_type.F90
@@ -81,7 +81,7 @@ contains
 
   ! Given an eos type, copy the data relevant to the burn type.
 
-  subroutine eos_to_burn(eos_state, burn_state)
+  AMREX_DEVICE subroutine eos_to_burn(eos_state, burn_state)
 
     !$acc routine seq
 
@@ -113,7 +113,7 @@ contains
 
   ! Given a burn type, copy the data relevant to the eos type.
 
-  subroutine burn_to_eos(burn_state, eos_state)
+  AMREX_DEVICE subroutine burn_to_eos(burn_state, eos_state)
 
     !$acc routine seq
 
@@ -142,7 +142,7 @@ contains
   end subroutine burn_to_eos
 
 
-  subroutine normalize_abundances_burn(state)
+  AMREX_DEVICE subroutine normalize_abundances_burn(state)
 
     !$acc routine seq
 

--- a/unit_test/eos.F90
+++ b/unit_test/eos.F90
@@ -28,6 +28,41 @@ contains
     real(rt), optional :: small_temp
     real(rt), optional :: small_dens
 
+    ! Allocate module variables and initialize
+    allocate(mintemp)
+    allocate(maxtemp)
+    allocate(mindens)
+    allocate(maxdens)
+    allocate(minx)
+    allocate(maxx)
+    allocate(minye)
+    allocate(maxye)
+    allocate(mine)
+    allocate(maxe)
+    allocate(minp)
+    allocate(maxp)
+    allocate(mins)
+    allocate(maxs)
+    allocate(minh)
+    allocate(maxh)
+    
+    mintemp = 1.d-200
+    maxtemp = 1.d200
+    mindens = 1.d-200
+    maxdens = 1.d200
+    minx    = 1.d-200
+    maxx    = 1.d0 + 1.d-12
+    minye   = 1.d-200
+    maxye   = 1.d0 + 1.d-12
+    mine    = 1.d-200
+    maxe    = 1.d200
+    minp    = 1.d-200
+    maxp    = 1.d200
+    mins    = 1.d-200
+    maxs    = 1.d200
+    minh    = 1.d-200
+    maxh    = 1.d200
+
     ! Set up any specific parameters or initialization steps required by the EOS we are using.
 
     call actual_eos_init


### PR DESCRIPTION
This updates the burn type and eos type in /interfaces for CUDA managed memory and adds AMREX_DEVICE to the appropriate subroutines.

Allocating and initializing the eos module variables is now in unit_test/eos.F90.