### PR TITLE
Add utility modules and specialized esums

### DIFF
--- a/networks/aprox13/actual_rhs.f90
+++ b/networks/aprox13/actual_rhs.f90
@@ -428,7 +428,7 @@ contains
     !$acc routine seq
 
     use amrex_constants_module, only: ZERO, SIXTH
-    use microphysics_math_module, only: esum
+    use microphysics_math_module, only: esum3, esum4, esum5, esum6, esum8, esum10, esum12, esum17
 
     implicit none
 
@@ -448,7 +448,7 @@ contains
     a(2)  = 0.5d0 * y(ic12) * y(io16) * rate(ir1216)
     a(3)  = 0.56d0 * 0.5d0 * y(io16) * y(io16) * rate(ir1616)
 
-    dydt(ihe4) = dydt(ihe4) + esum(a,3)
+    dydt(ihe4) = dydt(ihe4) + esum3(a)
 
     ! (a,g) and (g,a) reactions
     a(1)  = -0.5d0 * y(ihe4) * y(ihe4) * y(ihe4) * rate(ir3a)
@@ -464,7 +464,7 @@ contains
     a(11) = -y(ihe4)  * y(isi28)*rate(irsiag)
     a(12) =  y(is32)  * rate(irsga)
 
-    dydt(ihe4) = dydt(ihe4) + esum(a,12)
+    dydt(ihe4) = dydt(ihe4) + esum12(a)
 
     a(1)  = -y(ihe4)  * y(is32) * rate(irsag)
     a(2)  =  y(iar36) * rate(irarga)
@@ -479,7 +479,7 @@ contains
     a(11) = -y(ihe4)  * y(ife52) * rate(irfeag)
     a(12) =  y(ini56) * rate(irniga)
 
-    dydt(ihe4) = dydt(ihe4) + esum(a,12)
+    dydt(ihe4) = dydt(ihe4) + esum12(a)
 
     ! (a,p)(p,g) and (g,p)(p,a) reactions
 
@@ -503,7 +503,7 @@ contains
        a(16) = -y(ihe4)  * y(ife52) * rate(irfeap)*(1.0d0-rate(iry1))
        a(17) =  y(ini56) * rate(irnigp) * rate(iry1)
 
-       dydt(ihe4) = dydt(ihe4) + esum(a,17)
+       dydt(ihe4) = dydt(ihe4) + esum17(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * ratdum(irs1) * rate(ir1616)
@@ -517,7 +517,7 @@ contains
        a(9)  =  y(is32)  * ratdum(irsgp) * rate(irs1)
        a(10) =  y(is32)  * rate(irsgp) * ratdum(irs1)
 
-       dydt(ihe4) = dydt(ihe4) + esum(a,10)
+       dydt(ihe4) = dydt(ihe4) + esum10(a)
 
        a(1)  = -y(ihe4)*y(is32) * rate(irsap)*(1.0d0 - ratdum(irt1))
        a(2)  =  y(ihe4)*y(is32) * ratdum(irsap)*rate(irt1)
@@ -532,7 +532,7 @@ contains
        a(11) =  y(iti44) * ratdum(irtigp) * rate(irv1)
        a(12) =  y(iti44) * rate(irtigp) * ratdum(irv1)
 
-       dydt(ihe4) = dydt(ihe4) + esum(a,12)
+       dydt(ihe4) = dydt(ihe4) + esum12(a)
 
        a(1)  = -y(ihe4)*y(iti44) * rate(irtiap)*(1.0d0 - ratdum(irw1))
        a(2)  =  y(ihe4)*y(iti44) * ratdum(irtiap)*rate(irw1)
@@ -547,7 +547,7 @@ contains
        a(11) =  y(ini56) * ratdum(irnigp) * rate(iry1)
        a(12) =  y(ini56) * rate(irnigp) * ratdum(iry1)
 
-       dydt(ihe4) = dydt(ihe4) + esum(a,12)
+       dydt(ihe4) = dydt(ihe4) + esum12(a)
     end if
 
 
@@ -559,7 +559,7 @@ contains
     a(5) = -y(ic12) * y(ihe4) * rate(ircag)
     a(6) =  y(io16) * rate(iroga)
 
-    dydt(ic12) = dydt(ic12) + esum(a,6)
+    dydt(ic12) = dydt(ic12) + esum6(a)
 
 
     ! o16 reactions
@@ -570,7 +570,7 @@ contains
     a(5) = -y(io16) * rate(iroga)
     a(6) =  y(ine20) * rate(irnega)
 
-    dydt(io16) = dydt(io16) + esum(a,6)
+    dydt(io16) = dydt(io16) + esum6(a)
 
 
     ! ne20 reactions
@@ -580,7 +580,7 @@ contains
     a(4) = -y(ine20) * rate(irnega)
     a(5) =  y(img24) * rate(irmgga)
 
-    dydt(ine20) = dydt(ine20) + esum(a,5)
+    dydt(ine20) = dydt(ine20) + esum5(a)
 
 
     ! mg24 reactions
@@ -590,7 +590,7 @@ contains
     a(4) = -y(img24) * rate(irmgga)
     a(5) =  y(isi28) * rate(irsiga)
 
-    dydt(img24) = dydt(img24) + esum(a,5)
+    dydt(img24) = dydt(img24) + esum5(a)
 
     if (.not.deriva) then
        a(1) = -y(img24) * y(ihe4) * rate(irmgap)*(1.0d0-rate(irr1))
@@ -604,7 +604,7 @@ contains
        a(3) =  y(isi28) * ratdum(irr1) * rate(irsigp)
        a(4) =  y(isi28) * rate(irr1) * ratdum(irsigp)
 
-       dydt(img24) = dydt(img24) + esum(a,4)
+       dydt(img24) = dydt(img24) + esum4(a)
     end if
 
 
@@ -617,7 +617,7 @@ contains
     a(5) = -y(isi28) * rate(irsiga)
     a(6) =  y(is32)  * rate(irsga)
 
-    dydt(isi28) = dydt(isi28) + esum(a,6)
+    dydt(isi28) = dydt(isi28) + esum6(a)
 
     if (.not.deriva) then
 
@@ -627,7 +627,7 @@ contains
        a(4) = -y(isi28) * y(ihe4) * rate(irsiap)*(1.0d0-rate(irs1))
        a(5) =  y(is32)  * rate(irs1) * rate(irsgp)
 
-       dydt(isi28) = dydt(isi28) + esum(a,5)
+       dydt(isi28) = dydt(isi28) + esum5(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * ratdum(irs1)*rate(ir1616)
@@ -641,7 +641,7 @@ contains
        a(9)  = y(is32) * ratdum(irs1) * rate(irsgp)
        a(10) = y(is32) * rate(irs1) * ratdum(irsgp)
 
-       dydt(isi28) = dydt(isi28) + esum(a,10)
+       dydt(isi28) = dydt(isi28) + esum10(a)
     end if
 
 
@@ -653,7 +653,7 @@ contains
     a(4) = -y(is32) * rate(irsga)
     a(5) =  y(iar36) * rate(irarga)
 
-    dydt(is32) = dydt(is32) + esum(a,5)
+    dydt(is32) = dydt(is32) + esum5(a)
 
 
     if (.not.deriva) then
@@ -663,7 +663,7 @@ contains
        a(4) = -y(is32) * y(ihe4) * rate(irsap)*(1.0d0-rate(irt1))
        a(5) =  y(iar36) * rate(irt1) * rate(irargp)
 
-       dydt(is32) = dydt(is32) + esum(a,5)
+       dydt(is32) = dydt(is32) + esum5(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * rate(ir1616)*(1.0d0-ratdum(irs1))
@@ -677,7 +677,7 @@ contains
        a(9)  =  y(iar36) * ratdum(irt1) * rate(irargp)
        a(10) =  y(iar36) * rate(irt1) * ratdum(irargp)
 
-       dydt(is32) = dydt(is32) + esum(a,10)
+       dydt(is32) = dydt(is32) + esum10(a)
     end if
 
 
@@ -687,7 +687,7 @@ contains
     a(3) = -y(iar36) * rate(irarga)
     a(4) =  y(ica40) * rate(ircaga)
 
-    dydt(iar36) = dydt(iar36) + esum(a,4)
+    dydt(iar36) = dydt(iar36) + esum4(a)
 
     if (.not.deriva) then
        a(1) = y(is32)  * y(ihe4) * rate(irsap)*(1.0d0-rate(irt1))
@@ -695,7 +695,7 @@ contains
        a(3) = -y(iar36) * y(ihe4) * rate(irarap)*(1.0d0-rate(iru1))
        a(4) =  y(ica40) * rate(ircagp) * rate(iru1)
 
-       dydt(iar36) = dydt(iar36) + esum(a,4)
+       dydt(iar36) = dydt(iar36) + esum4(a)
 
     else
        a(1) =  y(is32)*y(ihe4) * rate(irsap)*(1.0d0 - ratdum(irt1))
@@ -707,7 +707,7 @@ contains
        a(7) =  y(ica40) * ratdum(ircagp) * rate(iru1)
        a(8) =  y(ica40) * rate(ircagp) * ratdum(iru1)
 
-       dydt(iar36) = dydt(iar36) + esum(a,8)
+       dydt(iar36) = dydt(iar36) + esum8(a)
     end if
 
 
@@ -717,7 +717,7 @@ contains
     a(3) = -y(ica40) * rate(ircaga)
     a(4) =  y(iti44) * rate(irtiga)
 
-    dydt(ica40) = dydt(ica40) + esum(a,4)
+    dydt(ica40) = dydt(ica40) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(iar36) * y(ihe4) * rate(irarap)*(1.0d0-rate(iru1))
@@ -725,7 +725,7 @@ contains
        a(3) = -y(ica40) * y(ihe4) * rate(ircaap)*(1.0d0-rate(irv1))
        a(4) =  y(iti44) * rate(irtigp) * rate(irv1)
 
-       dydt(ica40) = dydt(ica40) + esum(a,4)
+       dydt(ica40) = dydt(ica40) + esum4(a)
 
     else
        a(1) =  y(iar36)*y(ihe4) * rate(irarap)*(1.0d0-ratdum(iru1))
@@ -737,7 +737,7 @@ contains
        a(7) =  y(iti44) * ratdum(irtigp) * rate(irv1)
        a(8) =  y(iti44) * rate(irtigp) * ratdum(irv1)
 
-       dydt(ica40) = dydt(ica40) + esum(a,8)
+       dydt(ica40) = dydt(ica40) + esum8(a)
     end if
 
 
@@ -747,7 +747,7 @@ contains
     a(3) = -y(iti44) * rate(irtiga)
     a(4) =  y(icr48) * rate(ircrga)
 
-    dydt(iti44) = dydt(iti44) + esum(a,4)
+    dydt(iti44) = dydt(iti44) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(ica40) * y(ihe4) * rate(ircaap)*(1.0d0-rate(irv1))
@@ -755,7 +755,7 @@ contains
        a(3) = -y(iti44) * y(ihe4) * rate(irtiap)*(1.0d0-rate(irw1))
        a(4) =  y(icr48) * rate(irw1) * rate(ircrgp)
 
-       dydt(iti44) = dydt(iti44) + esum(a,4)
+       dydt(iti44) = dydt(iti44) + esum4(a)
 
     else
        a(1) =  y(ica40)*y(ihe4) * rate(ircaap)*(1.0d0-ratdum(irv1))
@@ -767,7 +767,7 @@ contains
        a(7) =  y(icr48) * ratdum(irw1) * rate(ircrgp)
        a(8) =  y(icr48) * rate(irw1) * ratdum(ircrgp)
 
-       dydt(iti44) = dydt(iti44) + esum(a,8)
+       dydt(iti44) = dydt(iti44) + esum8(a)
     end if
 
 
@@ -777,7 +777,7 @@ contains
     a(3) = -y(icr48) * rate(ircrga)
     a(4) =  y(ife52) * rate(irfega)
 
-    dydt(icr48) = dydt(icr48) + esum(a,4)
+    dydt(icr48) = dydt(icr48) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(iti44) * y(ihe4) * rate(irtiap)*(1.0d0-rate(irw1))
@@ -785,7 +785,7 @@ contains
        a(3) = -y(icr48) * y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
        a(4) =  y(ife52) * rate(irx1) * rate(irfegp)
 
-       dydt(icr48) = dydt(icr48) + esum(a,4)
+       dydt(icr48) = dydt(icr48) + esum4(a)
 
     else
        a(1) =  y(iti44)*y(ihe4) * rate(irtiap)*(1.0d0-ratdum(irw1))
@@ -797,7 +797,7 @@ contains
        a(7) =  y(ife52) * ratdum(irx1) * rate(irfegp)
        a(8) =  y(ife52) * rate(irx1) * ratdum(irfegp)
 
-       dydt(icr48) = dydt(icr48) + esum(a,8)
+       dydt(icr48) = dydt(icr48) + esum8(a)
     end if
 
 
@@ -807,7 +807,7 @@ contains
     a(3) = -y(ife52) * rate(irfega)
     a(4) =  y(ini56) * rate(irniga)
 
-    dydt(ife52) = dydt(ife52) + esum(a,4)
+    dydt(ife52) = dydt(ife52) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(icr48) * y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
@@ -815,7 +815,7 @@ contains
        a(3) = -y(ife52) * y(ihe4) * rate(irfeap)*(1.0d0-rate(iry1))
        a(4) =  y(ini56) * rate(iry1) * rate(irnigp)
 
-       dydt(ife52) = dydt(ife52) + esum(a,4)
+       dydt(ife52) = dydt(ife52) + esum4(a)
 
     else
        a(1) =  y(icr48)*y(ihe4) * rate(ircrap)*(1.0d0-ratdum(irx1))
@@ -827,7 +827,7 @@ contains
        a(7) =  y(ini56) * ratdum(iry1) * rate(irnigp)
        a(8) =  y(ini56) * rate(iry1) * ratdum(irnigp)
 
-       dydt(ife52) = dydt(ife52) + esum(a,8)
+       dydt(ife52) = dydt(ife52) + esum8(a)
     end if
 
 
@@ -849,7 +849,7 @@ contains
        a(3) = -y(ini56) * ratdum(iry1) * rate(irnigp)
        a(4) = -y(ini56) * rate(iry1) * ratdum(irnigp)
 
-       dydt(ini56) = dydt(ini56) + esum(a,4)
+       dydt(ini56) = dydt(ini56) + esum4(a)
     end if
 
   end subroutine rhs
@@ -1871,7 +1871,7 @@ contains
     !$acc routine seq
 
     use network
-    use microphysics_math_module, only: esum
+    use microphysics_math_module, only: esum3, esum4, esum5, esum20
 
     implicit none
 
@@ -1904,7 +1904,7 @@ contains
     b(18) = -y(iti44) * rate(irtiap) * (1.0d0-rate(irw1)) 
     b(19) = -y(icr48) * rate(ircrap) * (1.0d0-rate(irx1)) 
     b(20) = -y(ife52) * rate(irfeap) * (1.0d0-rate(iry1))
-    dfdy(ihe4,ihe4) = esum(b,20)
+    dfdy(ihe4,ihe4) = esum20(b)
 
 
     ! d(he4)/d(c12)
@@ -1912,7 +1912,7 @@ contains
     b(2) =  0.5d0 * y(io16) * rate(ir1216) 
     b(3) =  3.0d0 * rate(irg3a) 
     b(4) = -y(ihe4) * rate(ircag)
-    dfdy(ihe4,ic12) = esum(b,4)
+    dfdy(ihe4,ic12) = esum4(b)
 
     ! d(he4)/d(o16)
     b(1) =  0.5d0 * y(ic12) * rate(ir1216) 
@@ -1920,7 +1920,7 @@ contains
     b(3) =  0.68d0 * rate(irs1) * 0.5d0*y(io16) * rate(ir1616) 
     b(4) =  rate(iroga) 
     b(5) = -y(ihe4) * rate(iroag) 
-    dfdy(ihe4,io16) = esum(b,5)
+    dfdy(ihe4,io16) = esum5(b)
 
     ! d(he4)/d(ne20)
     b(1) =  rate(irnega) 
@@ -1931,56 +1931,56 @@ contains
     b(1) =  rate(irmgga) 
     b(2) = -y(ihe4) * rate(irmgag) 
     b(3) = -y(ihe4) * rate(irmgap) * (1.0d0-rate(irr1))
-    dfdy(ihe4,img24) = esum(b,3)
+    dfdy(ihe4,img24) = esum3(b)
 
     ! d(he4)/d(si28)
     b(1) =  rate(irsiga) 
     b(2) = -y(ihe4) * rate(irsiag) 
     b(3) = -y(ihe4) * rate(irsiap) * (1.0d0-rate(irs1)) 
     b(4) =  rate(irr1) * rate(irsigp)
-    dfdy(ihe4,isi28) = esum(b,4)
+    dfdy(ihe4,isi28) = esum4(b)
 
     ! d(he4)/d(s32)
     b(1) =  rate(irsga) 
     b(2) = -y(ihe4) * rate(irsag) 
     b(3) = -y(ihe4) * rate(irsap) * (1.0d0-rate(irt1)) 
     b(4) =  rate(irs1) * rate(irsgp)
-    dfdy(ihe4,is32) = esum(b,4)
+    dfdy(ihe4,is32) = esum4(b)
 
     ! d(he4)/d(ar36)
     b(1)  =  rate(irarga) 
     b(2)  = -y(ihe4) * rate(irarag) 
     b(3)  = -y(ihe4) * rate(irarap) * (1.0d0-rate(iru1)) 
     b(4)  =  rate(irt1) * rate(irargp)
-    dfdy(ihe4,iar36) = esum(b,4)
+    dfdy(ihe4,iar36) = esum4(b)
 
     ! d(he4)/d(ca40)
     b(1) =  rate(ircaga) 
     b(2) = -y(ihe4) * rate(ircaag) 
     b(3) = -y(ihe4) * rate(ircaap) * (1.0d0-rate(irv1)) 
     b(4) =  rate(iru1) * rate(ircagp)
-    dfdy(ihe4,ica40) = esum(b,4)
+    dfdy(ihe4,ica40) = esum4(b)
 
     ! d(he4)/d(ti44)
     b(1) =  rate(irtiga) 
     b(2) = -y(ihe4) * rate(irtiag) 
     b(3) = -y(ihe4) * rate(irtiap) * (1.0d0-rate(irw1)) 
     b(4) =  rate(irv1) * rate(irtigp)
-    dfdy(ihe4,iti44) = esum(b,4)
+    dfdy(ihe4,iti44) = esum4(b)
 
     ! d(he4)/d(cr48)
     b(1) =  rate(ircrga) 
     b(2) = -y(ihe4) * rate(ircrag) 
     b(3) = -y(ihe4) * rate(ircrap) * (1.0d0-rate(irx1)) 
     b(4) =  rate(irw1) * rate(ircrgp)
-    dfdy(ihe4,icr48) = esum(b,4)
+    dfdy(ihe4,icr48) = esum4(b)
 
     ! d(he4)/d(fe52)
     b(1) =  rate(irfega) 
     b(2) = -y(ihe4) * rate(irfeag) 
     b(3) = -y(ihe4) * rate(irfeap) * (1.0d0-rate(iry1)) 
     b(4) =  rate(irx1) * rate(irfegp)
-    dfdy(ihe4,ife52) = esum(b,4)
+    dfdy(ihe4,ife52) = esum4(b)
 
     ! d(he4)/d(ni56)
     b(1) = rate(irniga) 
@@ -1999,7 +1999,7 @@ contains
     b(2) = -y(io16) * rate(ir1216) 
     b(3) = -rate(irg3a) 
     b(4) = -y(ihe4) * rate(ircag) 
-    dfdy(ic12,ic12) = esum(b,4)
+    dfdy(ic12,ic12) = esum4(b)
 
     ! d(c12)/d(o16)
     b(1) = -y(ic12) * rate(ir1216) 
@@ -2024,7 +2024,7 @@ contains
     b(2) = -2.0d0 * y(io16) * rate(ir1616) 
     b(3) = -y(ihe4) * rate(iroag) 
     b(4) = -rate(iroga) 
-    dfdy(io16,io16) = esum(b,4)
+    dfdy(io16,io16) = esum4(b)
 
     ! d(o16)/d(ne20)
     dfdy(io16,ine20) = rate(irnega)
@@ -2057,7 +2057,7 @@ contains
     b(1) =  y(ine20) * rate(irneag) 
     b(2) = -y(img24) * rate(irmgag) 
     b(3) = -y(img24) * rate(irmgap) * (1.0d0-rate(irr1))
-    dfdy(img24,ihe4) = esum(b,3)
+    dfdy(img24,ihe4) = esum3(b)
 
     ! d(mg24)/d(c12)
     dfdy(img24,ic12) = 0.5d0 * y(io16) * rate(ir1216)
@@ -2072,7 +2072,7 @@ contains
     b(1) = -y(ihe4) * rate(irmgag) 
     b(2) = -rate(irmgga) 
     b(3) = -y(ihe4) * rate(irmgap) * (1.0d0-rate(irr1))
-    dfdy(img24,img24) = esum(b,3)
+    dfdy(img24,img24) = esum3(b)
 
     ! d(mg24)/d(si28)
     b(1) = rate(irsiga) 
@@ -2086,7 +2086,7 @@ contains
     b(2) = -y(isi28) * rate(irsiag) 
     b(3) =  y(img24) * rate(irmgap) * (1.0d0-rate(irr1)) 
     b(4) = -y(isi28) * rate(irsiap) * (1.0d0-rate(irs1))
-    dfdy(isi28,ihe4) = esum(b,4)
+    dfdy(isi28,ihe4) = esum4(b)
 
     ! d(si28)/d(c12)
     dfdy(isi28,ic12) =  0.5d0 * y(io16) * rate(ir1216)
@@ -2095,7 +2095,7 @@ contains
     b(1) = 0.5d0 * y(ic12) * rate(ir1216) 
     b(2) = 1.12d0 * 0.5d0*y(io16) * rate(ir1616) 
     b(3) = 0.68d0 * 0.5d0*y(io16) * rate(irs1) * rate(ir1616)
-    dfdy(isi28,io16) = esum(b,3)
+    dfdy(isi28,io16) = esum3(b)
 
     ! d(si28)/d(mg24)
     b(1) =  y(ihe4) * rate(irmgag) 
@@ -2107,7 +2107,7 @@ contains
     b(2) = -rate(irsiga) 
     b(3) = -rate(irr1) * rate(irsigp) 
     b(4) = -y(ihe4) * rate(irsiap) * (1.0d0-rate(irs1))
-    dfdy(isi28,isi28) = esum(b,4)
+    dfdy(isi28,isi28) = esum4(b)
 
     ! d(si28)/d(s32)
     b(1) = rate(irsga) 
@@ -2121,7 +2121,7 @@ contains
     b(2) = -y(is32) * rate(irsag) 
     b(3) =  y(isi28) * rate(irsiap) * (1.0d0-rate(irs1)) 
     b(4) = -y(is32) * rate(irsap) * (1.0d0-rate(irt1))
-    dfdy(is32,ihe4) = esum(b,4)
+    dfdy(is32,ihe4) = esum4(b)
 
     ! d(s32)/d(o16)
     b(1) = 0.68d0*0.5d0*y(io16)*rate(ir1616)*(1.0d0-rate(irs1)) 
@@ -2138,7 +2138,7 @@ contains
     b(2) = -rate(irsga) 
     b(3) = -rate(irs1) * rate(irsgp) 
     b(4) = -y(ihe4) * rate(irsap) * (1.0d0-rate(irt1))
-    dfdy(is32,is32) = esum(b,4)
+    dfdy(is32,is32) = esum4(b)
 
     ! d(s32)/d(ar36)
     b(1) = rate(irarga) 
@@ -2152,7 +2152,7 @@ contains
     b(2) = -y(iar36) * rate(irarag) 
     b(3) =  y(is32)  * rate(irsap) * (1.0d0-rate(irt1)) 
     b(4) = -y(iar36) * rate(irarap) * (1.0d0-rate(iru1))
-    dfdy(iar36,ihe4) = esum(b,4)
+    dfdy(iar36,ihe4) = esum4(b)
 
     ! d(ar36)/d(s32)
     b(1) = y(ihe4) * rate(irsag) 
@@ -2164,7 +2164,7 @@ contains
     b(2) = -rate(irarga) 
     b(3) = -rate(irt1) * rate(irargp) 
     b(4) = -y(ihe4) * rate(irarap) * (1.0d0-rate(iru1))
-    dfdy(iar36,iar36) = esum(b,4)
+    dfdy(iar36,iar36) = esum4(b)
 
     ! d(ar36)/d(ca40)
     b(1) = rate(ircaga) 
@@ -2178,7 +2178,7 @@ contains
     b(2)  = -y(ica40) * rate(ircaag) 
     b(3)  =  y(iar36) * rate(irarap)*(1.0d0-rate(iru1)) 
     b(4)  = -y(ica40) * rate(ircaap)*(1.0d0-rate(irv1))
-    dfdy(ica40,ihe4) = esum(b,4)
+    dfdy(ica40,ihe4) = esum4(b)
 
     ! d(ca40)/d(ar36)
     b(1) =  y(ihe4) * rate(irarag) 
@@ -2190,7 +2190,7 @@ contains
     b(2) = -rate(ircaga) 
     b(3) = -rate(ircagp) * rate(iru1) 
     b(4) = -y(ihe4) * rate(ircaap)*(1.0d0-rate(irv1))
-    dfdy(ica40,ica40) = esum(b,4)
+    dfdy(ica40,ica40) = esum4(b)
 
     ! d(ca40)/d(ti44)
     b(1) = rate(irtiga) 
@@ -2205,7 +2205,7 @@ contains
     b(2) = -y(iti44) * rate(irtiag) 
     b(3) =  y(ica40) * rate(ircaap)*(1.0d0-rate(irv1)) 
     b(4) = -y(iti44) * rate(irtiap)*(1.0d0-rate(irw1))
-    dfdy(iti44,ihe4) = esum(b,4)
+    dfdy(iti44,ihe4) = esum4(b)
 
     ! d(ti44)/d(ca40)
     b(1) =  y(ihe4) * rate(ircaag) 
@@ -2217,7 +2217,7 @@ contains
     b(2) = -rate(irtiga) 
     b(3) = -rate(irv1) * rate(irtigp) 
     b(4) = -y(ihe4) * rate(irtiap)*(1.0d0-rate(irw1))
-    dfdy(iti44,iti44) = esum(b,4)
+    dfdy(iti44,iti44) = esum4(b)
 
     ! d(ti44)/d(cr48)
     b(1) = rate(ircrga) 
@@ -2232,7 +2232,7 @@ contains
     b(2) = -y(icr48) * rate(ircrag) 
     b(3) =  y(iti44) * rate(irtiap)*(1.0d0-rate(irw1)) 
     b(4) = -y(icr48) * rate(ircrap)*(1.0d0-rate(irx1))
-    dfdy(icr48,ihe4) = esum(b,4)
+    dfdy(icr48,ihe4) = esum4(b)
 
     ! d(cr48)/d(ti44)
     b(1) =  y(ihe4) * rate(irtiag) 
@@ -2244,7 +2244,7 @@ contains
     b(2) = -rate(ircrga) 
     b(3) = -rate(irw1) * rate(ircrgp) 
     b(4) = -y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
-    dfdy(icr48,icr48) = esum(b,4)
+    dfdy(icr48,icr48) = esum4(b)
 
     ! d(cr48)/d(fe52)
     b(1) = rate(irfega) 
@@ -2259,7 +2259,7 @@ contains
     b(2) = -y(ife52) * rate(irfeag) 
     b(3) =  y(icr48) * rate(ircrap) * (1.0d0-rate(irx1)) 
     b(4) = -y(ife52) * rate(irfeap) * (1.0d0-rate(iry1)) 
-    dfdy(ife52,ihe4) = esum(b,4)
+    dfdy(ife52,ihe4) = esum4(b)
 
     ! d(fe52)/d(cr48)
     b(1) = y(ihe4) * rate(ircrag) 
@@ -2271,7 +2271,7 @@ contains
     b(2) = -rate(irfega) 
     b(3) = -rate(irx1) * rate(irfegp) 
     b(4) = -y(ihe4) * rate(irfeap) * (1.0d0-rate(iry1))
-    dfdy(ife52,ife52) = esum(b,4)
+    dfdy(ife52,ife52) = esum4(b)
 
     ! d(fe52)/d(ni56)
     b(1) = rate(irniga) 

--- a/networks/aprox19/actual_rhs.f90
+++ b/networks/aprox19/actual_rhs.f90
@@ -211,7 +211,7 @@ contains
   subroutine rhs(y, rate, ratdum, dydt, deriva)
 
     use amrex_constants_module, only: ZERO, SIXTH
-    use microphysics_math_module, only: esum
+    use microphysics_math_module, only: esum3, esum4, esum5, esum6, esum7, esum8, esum10, esum12, esum15
 
     implicit none
 
@@ -236,7 +236,7 @@ contains
     a(6) = -2.0d0 * y(io16) * y(ih1) * rate(iropg)
     a(7) = -3.0d0 * y(ih1) * rate(irpen)
 
-    dydt(ih1) = dydt(ih1) + esum(a,7)
+    dydt(ih1) = dydt(ih1) + esum7(a)
 
 
 
@@ -246,7 +246,7 @@ contains
     a(3)  = -y(ihe3) * y(ihe4) * rate(irhe3ag)
     a(4)  =  y(ih1) * rate(irpen)
 
-    dydt(ihe3) = dydt(ihe3) + esum(a,4)
+    dydt(ihe3) = dydt(ihe3) + esum4(a)
 
 
     ! he4 reactions
@@ -255,7 +255,7 @@ contains
     a(2)  = 0.5d0 * y(ic12) * y(io16) * rate(ir1216)
     a(3)  = 0.56d0 * 0.5d0 * y(io16) * y(io16) * rate(ir1616)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,3)
+    dydt(ihe4) =  dydt(ihe4) + esum3(a)
 
 
     ! (a,g) and (g,a) reactions
@@ -272,7 +272,7 @@ contains
     a(11) = -y(ihe4)  * y(isi28)*rate(irsiag)
     a(12) =  y(is32)  * rate(irsga)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,12)
+    dydt(ihe4) =  dydt(ihe4) + esum12(a)
 
     a(1)  = -y(ihe4)  * y(is32) * rate(irsag)
     a(2)  =  y(iar36) * rate(irarga)
@@ -287,7 +287,7 @@ contains
     a(11) = -y(ihe4)  * y(ife52) * rate(irfeag)
     a(12) =  y(ini56) * rate(irniga)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,12)
+    dydt(ihe4) =  dydt(ihe4) + esum12(a)
 
 
     ! (a,p)(p,g) and (g,p)(p,a) reactions
@@ -309,7 +309,7 @@ contains
        a(14) = -y(ihe4)  * y(icr48) * rate(ircrap)*(1.0d0-rate(irx1))
        a(15) =  y(ife52) * rate(irfegp) * rate(irx1)
 
-       dydt(ihe4) =  dydt(ihe4) + esum(a,15)
+       dydt(ihe4) =  dydt(ihe4) + esum15(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * ratdum(irs1) * rate(ir1616)
@@ -323,7 +323,7 @@ contains
        a(9)  =  y(is32)  * ratdum(irsgp) * rate(irs1)
        a(10) =  y(is32)  * rate(irsgp) * ratdum(irs1)
 
-       dydt(ihe4) =  dydt(ihe4) + esum(a,10)
+       dydt(ihe4) =  dydt(ihe4) + esum10(a)
 
        a(1)  = -y(ihe4)*y(is32) * rate(irsap)*(1.0d0 - ratdum(irt1))
        a(2)  =  y(ihe4)*y(is32) * ratdum(irsap)*rate(irt1)
@@ -338,7 +338,7 @@ contains
        a(11) =  y(iti44) * ratdum(irtigp) * rate(irv1)
        a(12) =  y(iti44) * rate(irtigp) * ratdum(irv1)
 
-       dydt(ihe4) =  dydt(ihe4) + esum(a,12)
+       dydt(ihe4) =  dydt(ihe4) + esum12(a)
 
        a(1)  = -y(ihe4)*y(iti44) * rate(irtiap)*(1.0d0 - ratdum(irw1))
        a(2)  =  y(ihe4)*y(iti44) * ratdum(irtiap)*rate(irw1)
@@ -349,7 +349,7 @@ contains
        a(7)  =  y(ife52) * ratdum(irfegp) * rate(irx1)
        a(8)  =  y(ife52) * rate(irfegp) * ratdum(irx1)
 
-       dydt(ihe4) =  dydt(ihe4) + esum(a,8)
+       dydt(ihe4) =  dydt(ihe4) + esum8(a)
     end if
 
 
@@ -361,7 +361,7 @@ contains
     a(5) = -y(ihe4) * rate(iralf1)
     a(6) =  y(ineut)*y(ineut) * y(iprot)*y(iprot) * rate(iralf2)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,6)
+    dydt(ihe4) =  dydt(ihe4) + esum6(a)
 
 
     ! ppchain
@@ -396,7 +396,7 @@ contains
     a(6) =  y(io16) * rate(iroga)
     a(7) = -y(ic12) * y(ih1) * rate(ircpg)
 
-    dydt(ic12) =  dydt(ic12) + esum(a,7)
+    dydt(ic12) =  dydt(ic12) + esum7(a)
 
     if (.not. deriva) then
        a(1) =  y(in14) * y(ih1) * rate(ifa) * rate(irnpg)
@@ -414,7 +414,7 @@ contains
     a(3) =  y(io16) * y(ih1) * rate(iropg)
     a(4) = -y(ihe4) * y(in14) * rate(irnag)
 
-    dydt(in14) =  dydt(in14) + esum(a,4)
+    dydt(in14) =  dydt(in14) + esum4(a)
 
 
     ! o16 reactions
@@ -426,7 +426,7 @@ contains
     a(6) =  y(ine20) * rate(irnega)
     a(7) = -y(io16) * y(ih1) * rate(iropg)
 
-    dydt(io16) =  dydt(io16) + esum(a,7)
+    dydt(io16) =  dydt(io16) + esum7(a)
 
     if (.not. deriva) then
        a(1) =  y(in14) * y(ih1) * rate(ifg) * rate(irnpg)
@@ -446,7 +446,7 @@ contains
     a(5) =  y(img24) * rate(irmgga)
     a(6) =  y(in14) * y(ihe4) * rate(irnag)
 
-    dydt(ine20) =  dydt(ine20) + esum(a,6)
+    dydt(ine20) =  dydt(ine20) + esum6(a)
 
 
     ! mg24 reactions
@@ -456,7 +456,7 @@ contains
     a(4) = -y(img24) * rate(irmgga)
     a(5) =  y(isi28) * rate(irsiga)
 
-    dydt(img24) =  dydt(img24) + esum(a,5)
+    dydt(img24) =  dydt(img24) + esum5(a)
 
     if (.not.deriva) then
        a(1) = -y(img24) * y(ihe4) * rate(irmgap)*(1.0d0-rate(irr1))
@@ -470,7 +470,7 @@ contains
        a(3) =  y(isi28) * ratdum(irr1) * rate(irsigp)
        a(4) =  y(isi28) * rate(irr1) * ratdum(irsigp)
 
-       dydt(img24) =  dydt(img24) + esum(a,4)
+       dydt(img24) =  dydt(img24) + esum4(a)
     end if
 
 
@@ -482,7 +482,7 @@ contains
     a(5) = -y(isi28) * rate(irsiga)
     a(6) =  y(is32)  * rate(irsga)
 
-    dydt(isi28) =  dydt(isi28) + esum(a,6)
+    dydt(isi28) =  dydt(isi28) + esum6(a)
 
     if (.not.deriva) then
        a(1) =  0.34d0*0.5d0*y(io16)*y(io16)*rate(irs1)*rate(ir1616)
@@ -491,7 +491,7 @@ contains
        a(4) = -y(isi28) * y(ihe4) * rate(irsiap)*(1.0d0-rate(irs1))
        a(5) =  y(is32)  * rate(irs1) * rate(irsgp)
 
-       dydt(isi28) =  dydt(isi28) + esum(a,5)
+       dydt(isi28) =  dydt(isi28) + esum5(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * ratdum(irs1)*rate(ir1616)
@@ -505,7 +505,7 @@ contains
        a(9)  = y(is32) * ratdum(irs1) * rate(irsgp)
        a(10) = y(is32) * rate(irs1) * ratdum(irsgp)
 
-       dydt(isi28) =  dydt(isi28) + esum(a,10)
+       dydt(isi28) =  dydt(isi28) + esum10(a)
     end if
 
 
@@ -516,7 +516,7 @@ contains
     a(4) = -y(is32) * rate(irsga)
     a(5) =  y(iar36) * rate(irarga)
 
-    dydt(is32) =  dydt(is32) + esum(a,5)
+    dydt(is32) =  dydt(is32) + esum5(a)
 
     if (.not.deriva) then
        a(1) =  0.34d0*0.5d0*y(io16)*y(io16)* rate(ir1616)*(1.0d0-rate(irs1))
@@ -525,7 +525,7 @@ contains
        a(4) = -y(is32) * y(ihe4) * rate(irsap)*(1.0d0-rate(irt1))
        a(5) =  y(iar36) * rate(irt1) * rate(irargp)
 
-       dydt(is32) =  dydt(is32) + esum(a,5)
+       dydt(is32) =  dydt(is32) + esum5(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * rate(ir1616)*(1.0d0-ratdum(irs1))
@@ -539,7 +539,7 @@ contains
        a(9)  =  y(iar36) * ratdum(irt1) * rate(irargp)
        a(10) =  y(iar36) * rate(irt1) * ratdum(irargp)
 
-       dydt(is32) =  dydt(is32) + esum(a,10)
+       dydt(is32) =  dydt(is32) + esum10(a)
     end if
 
 
@@ -549,7 +549,7 @@ contains
     a(3) = -y(iar36) * rate(irarga)
     a(4) =  y(ica40) * rate(ircaga)
 
-    dydt(iar36) =  dydt(iar36) + esum(a,4)
+    dydt(iar36) =  dydt(iar36) + esum4(a)
 
     if (.not.deriva) then
        a(1) = y(is32)  * y(ihe4) * rate(irsap)*(1.0d0-rate(irt1))
@@ -557,7 +557,7 @@ contains
        a(3) = -y(iar36) * y(ihe4) * rate(irarap)*(1.0d0-rate(iru1))
        a(4) =  y(ica40) * rate(ircagp) * rate(iru1)
 
-       dydt(iar36) =  dydt(iar36) + esum(a,4)
+       dydt(iar36) =  dydt(iar36) + esum4(a)
 
     else
        a(1) =  y(is32)*y(ihe4) * rate(irsap)*(1.0d0 - ratdum(irt1))
@@ -569,7 +569,7 @@ contains
        a(7) =  y(ica40) * ratdum(ircagp) * rate(iru1)
        a(8) =  y(ica40) * rate(ircagp) * ratdum(iru1)
 
-       dydt(iar36) =  dydt(iar36) + esum(a,8)
+       dydt(iar36) =  dydt(iar36) + esum8(a)
     end if
 
 
@@ -579,7 +579,7 @@ contains
     a(3) = -y(ica40) * rate(ircaga)
     a(4) =  y(iti44) * rate(irtiga)
 
-    dydt(ica40) =  dydt(ica40) + esum(a,4)
+    dydt(ica40) =  dydt(ica40) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(iar36) * y(ihe4) * rate(irarap)*(1.0d0-rate(iru1))
@@ -587,7 +587,7 @@ contains
        a(3) = -y(ica40) * y(ihe4) * rate(ircaap)*(1.0d0-rate(irv1))
        a(4) =  y(iti44) * rate(irtigp) * rate(irv1)
 
-       dydt(ica40) =  dydt(ica40) + esum(a,4)
+       dydt(ica40) =  dydt(ica40) + esum4(a)
 
     else
        a(1) =  y(iar36)*y(ihe4) * rate(irarap)*(1.0d0-ratdum(iru1))
@@ -599,7 +599,7 @@ contains
        a(7) =  y(iti44) * ratdum(irtigp) * rate(irv1)
        a(8) =  y(iti44) * rate(irtigp) * ratdum(irv1)
 
-       dydt(ica40) =  dydt(ica40) + esum(a,8)
+       dydt(ica40) =  dydt(ica40) + esum8(a)
     end if
 
 
@@ -609,7 +609,7 @@ contains
     a(3) = -y(iti44) * rate(irtiga)
     a(4) =  y(icr48) * rate(ircrga)
 
-    dydt(iti44) =  dydt(iti44) + esum(a,4)
+    dydt(iti44) =  dydt(iti44) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(ica40) * y(ihe4) * rate(ircaap)*(1.0d0-rate(irv1))
@@ -617,7 +617,7 @@ contains
        a(3) = -y(iti44) * y(ihe4) * rate(irtiap)*(1.0d0-rate(irw1))
        a(4) =  y(icr48) * rate(irw1) * rate(ircrgp)
 
-       dydt(iti44) =  dydt(iti44) + esum(a,4)
+       dydt(iti44) =  dydt(iti44) + esum4(a)
 
     else
        a(1) =  y(ica40)*y(ihe4) * rate(ircaap)*(1.0d0-ratdum(irv1))
@@ -629,7 +629,7 @@ contains
        a(7) =  y(icr48) * ratdum(irw1) * rate(ircrgp)
        a(8) =  y(icr48) * rate(irw1) * ratdum(ircrgp)
 
-       dydt(iti44) =  dydt(iti44) + esum(a,8)
+       dydt(iti44) =  dydt(iti44) + esum8(a)
     end if
 
 
@@ -639,7 +639,7 @@ contains
     a(3) = -y(icr48) * rate(ircrga)
     a(4) =  y(ife52) * rate(irfega)
 
-    dydt(icr48) =  dydt(icr48) + esum(a,4)
+    dydt(icr48) =  dydt(icr48) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(iti44) * y(ihe4) * rate(irtiap)*(1.0d0-rate(irw1))
@@ -647,7 +647,7 @@ contains
        a(3) = -y(icr48) * y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
        a(4) =  y(ife52) * rate(irx1) * rate(irfegp)
 
-       dydt(icr48) =  dydt(icr48) + esum(a,4)
+       dydt(icr48) =  dydt(icr48) + esum4(a)
 
     else
        a(1) =  y(iti44)*y(ihe4) * rate(irtiap)*(1.0d0-ratdum(irw1))
@@ -659,7 +659,7 @@ contains
        a(7) =  y(ife52) * ratdum(irx1) * rate(irfegp)
        a(8) =  y(ife52) * rate(irx1) * ratdum(irfegp)
 
-       dydt(icr48) =  dydt(icr48) + esum(a,8)
+       dydt(icr48) =  dydt(icr48) + esum8(a)
     end if
 
 
@@ -670,7 +670,7 @@ contains
     a(3) = -y(ife52) * rate(irfega)
     a(4) =  y(ini56) * rate(irniga)
 
-    dydt(ife52) =  dydt(ife52) + esum(a,4)
+    dydt(ife52) =  dydt(ife52) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(icr48) * y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
@@ -682,7 +682,7 @@ contains
        a(2) = -y(icr48)*y(ihe4) * ratdum(ircrap)*rate(irx1)
        a(3) = -y(ife52) * ratdum(irx1) * rate(irfegp)
        a(4) = -y(ife52) * rate(irx1) * ratdum(irfegp)
-       dydt(ife52) =  dydt(ife52) + esum(a,4)
+       dydt(ife52) =  dydt(ife52) + esum4(a)
     end if
 
 
@@ -694,7 +694,7 @@ contains
     a(5) = -y(ife52) * y(ihe4) * y(iprot) * rate(ir7f54)
     a(6) =  y(ini56) * y(iprot) * rate(ir8f54)
 
-    dydt(ife52) =  dydt(ife52) + esum(a,6)
+    dydt(ife52) =  dydt(ife52) + esum6(a)
 
 
     ! fe54 reactions
@@ -706,7 +706,7 @@ contains
     a(6)  =  y(ife52) * y(ihe4) * rate(ir6f54)
     a(7)  =  c54 * y(ini56) * rate(irn56ec)
 
-    dydt(ife54) =  dydt(ife54) + esum(a,7)
+    dydt(ife54) =  dydt(ife54) + esum7(a)
 
 
     ! ni56 reactions
@@ -714,7 +714,7 @@ contains
     a(2) = -y(ini56) * rate(irniga)
     a(3) = -y(ini56) * rate(irn56ec)
 
-    dydt(ini56) =  dydt(ini56) + esum(a,3)
+    dydt(ini56) =  dydt(ini56) + esum3(a)
 
 
     ! photodisintegration reactions
@@ -723,7 +723,7 @@ contains
     a(3) =  y(ife52) * y(ihe4)* y(iprot) * rate(ir7f54)
     a(4) = -y(ini56) * y(iprot) * rate(ir8f54)
 
-    dydt(ini56) =  dydt(ini56) + esum(a,4)
+    dydt(ini56) =  dydt(ini56) + esum4(a)
 
 
     ! photodisintegration neutrons
@@ -734,7 +734,7 @@ contains
     a(5) =  y(iprot) * rate(irpen)
     a(6) = -y(ineut) * rate(irnep)
 
-    dydt(ineut) =  dydt(ineut) + esum(a,6)
+    dydt(ineut) =  dydt(ineut) + esum6(a)
 
 
     ! photodisintegration protons
@@ -747,7 +747,7 @@ contains
     a(7)  = -y(iprot) * rate(irpen)
     a(8)  =  y(ineut) * rate(irnep)
 
-    dydt(iprot) =  dydt(iprot) + esum(a,8)
+    dydt(iprot) =  dydt(iprot) + esum8(a)
 
   end subroutine rhs
 
@@ -2230,7 +2230,7 @@ contains
   subroutine dfdy_isotopes_aprox19(y,dfdy,ratdum,dratdumdy1,dratdumdy2)
 
     use network
-    use microphysics_math_module, only: esum
+    use microphysics_math_module, only: esum3, esum4, esum5, esum6, esum7, esum10, esum25
 
     implicit none
 
@@ -2250,7 +2250,7 @@ contains
     b(5) = -2.0d0 * y(io16) * ratdum(iropg)
     b(6) = -2.0d0 * y(io16) * y(ih1) * dratdumdy1(iropg)
     b(7) = -3.0d0 * ratdum(irpen)
-    dfdy(ih1,ih1) = esum(b,7)
+    dfdy(ih1,ih1) = esum7(b)
 
     ! d(h1)/d(he3)
     b(1) = 2.0d0 * y(ihe3) * ratdum(ir33)
@@ -2295,7 +2295,7 @@ contains
     b(2) =  y(in14) * y(ih1) * ratdum(ifa) * dratdumdy1(irnpg)
     b(3) =  y(io16) * ratdum(iropg)
     b(4) =  y(io16) * y(ih1) * dratdumdy1(iropg)
-    dfdy(ihe4,ih1) = esum(b,4)
+    dfdy(ihe4,ih1) = esum4(b)
 
     ! d(he4)/d(he3)
     b(1) = y(ihe3) * ratdum(ir33)
@@ -2329,14 +2329,14 @@ contains
     b(23) =  y(ihe3) * ratdum(irhe3ag)
     b(24) =  y(ihe3) * y(ihe4) * dratdumdy1(irhe3ag)
     b(25) = -y(in14) * ratdum(irnag) * 1.5d0
-    dfdy(ihe4,ihe4) = esum(b,25)
+    dfdy(ihe4,ihe4) = esum25(b)
 
     ! d(he4)/d(c12)
     b(1) =  y(ic12) * ratdum(ir1212)
     b(2) =  0.5d0 * y(io16) * ratdum(ir1216)
     b(3) =  3.0d0 * ratdum(irg3a)
     b(4) = -y(ihe4) * ratdum(ircag)
-    dfdy(ihe4,ic12) = esum(b,4)
+    dfdy(ihe4,ic12) = esum4(b)
 
     ! d(he4)/d(n14)
     b(1) =  y(ih1) * ratdum(ifa) * ratdum(irnpg)
@@ -2350,7 +2350,7 @@ contains
     b(4) =  ratdum(iroga)
     b(5) = -y(ihe4) * ratdum(iroag)
     b(6) =  y(ih1) * ratdum(iropg)
-    dfdy(ihe4,io16) = esum(b,6)
+    dfdy(ihe4,io16) = esum6(b)
 
     ! d(he4)/d(ne20)
     b(1) =  ratdum(irnega)
@@ -2361,49 +2361,49 @@ contains
     b(1) =  ratdum(irmgga)
     b(2) = -y(ihe4) * ratdum(irmgag)
     b(3) = -y(ihe4) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
-    dfdy(ihe4,img24) = esum(b,3)
+    dfdy(ihe4,img24) = esum3(b)
 
     ! d(he4)/d(si28)
     b(1) =  ratdum(irsiga)
     b(2) = -y(ihe4) * ratdum(irsiag)
     b(3) = -y(ihe4) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
     b(4) =  ratdum(irr1) * ratdum(irsigp)
-    dfdy(ihe4,isi28) = esum(b,4)
+    dfdy(ihe4,isi28) = esum4(b)
 
     ! d(he4)/d(s32)
     b(1) =  ratdum(irsga)
     b(2) = -y(ihe4) * ratdum(irsag)
     b(3) = -y(ihe4) * ratdum(irsap) * (1.0d0-ratdum(irt1))
     b(4) =  ratdum(irs1) * ratdum(irsgp)
-    dfdy(ihe4,is32) = esum(b,4)
+    dfdy(ihe4,is32) = esum4(b)
 
     ! d(he4)/d(ar36)
     b(1)  =  ratdum(irarga)
     b(2)  = -y(ihe4) * ratdum(irarag)
     b(3)  = -y(ihe4) * ratdum(irarap) * (1.0d0-ratdum(iru1))
     b(4)  =  ratdum(irt1) * ratdum(irargp)
-    dfdy(ihe4,iar36) = esum(b,4)
+    dfdy(ihe4,iar36) = esum4(b)
 
     ! d(he4)/d(ca40)
     b(1) =  ratdum(ircaga)
     b(2) = -y(ihe4) * ratdum(ircaag)
     b(3) = -y(ihe4) * ratdum(ircaap) * (1.0d0-ratdum(irv1))
     b(4) =  ratdum(iru1) * ratdum(ircagp)
-    dfdy(ihe4,ica40) = esum(b,4)
+    dfdy(ihe4,ica40) = esum4(b)
 
     ! d(he4)/d(ti44)
     b(1) =  ratdum(irtiga)
     b(2) = -y(ihe4) * ratdum(irtiag)
     b(3) = -y(ihe4) * ratdum(irtiap) * (1.0d0-ratdum(irw1))
     b(4) =  ratdum(irv1) * ratdum(irtigp)
-    dfdy(ihe4,iti44) = esum(b,4)
+    dfdy(ihe4,iti44) = esum4(b)
 
     ! d(he4)/d(cr48)
     b(1) =  ratdum(ircrga)
     b(2) = -y(ihe4) * ratdum(ircrag)
     b(3) = -y(ihe4) * ratdum(ircrap) * (1.0d0-ratdum(irx1))
     b(4) =  ratdum(irw1) * ratdum(ircrgp)
-    dfdy(ihe4,icr48) = esum(b,4)
+    dfdy(ihe4,icr48) = esum4(b)
 
     ! d(he4)/d(fe52)
     b(1) =  ratdum(irfega)
@@ -2411,7 +2411,7 @@ contains
     b(3) =  ratdum(irx1) * ratdum(irfegp)
     b(4) = -y(ihe4) * ratdum(ir6f54)
     b(5) = -y(ihe4) * y(iprot) * ratdum(ir7f54)
-    dfdy(ihe4,ife52) = esum(b,5)
+    dfdy(ihe4,ife52) = esum5(b)
 
     ! d(he4)/d(fe54)
     dfdy(ihe4,ife54) = y(iprot) * y(iprot) * ratdum(ir5f54)
@@ -2425,7 +2425,7 @@ contains
     b(1) = -y(ihe4) * dratdumdy1(iralf1)
     b(2) =  2.0d0 * y(ineut) * y(iprot)*y(iprot) * ratdum(iralf2)
     b(3) =  y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy1(iralf2)
-    dfdy(ihe4,ineut) = esum(b,3)
+    dfdy(ihe4,ineut) = esum3(b)
 
     ! d(he4)/d(prot)
     b(1)  =  2.0d0 * y(ife54) * y(iprot) * ratdum(ir5f54)
@@ -2438,7 +2438,7 @@ contains
     b(8)  = -y(ihe4) * dratdumdy2(iralf1)
     b(9)  =  2.0d0 * y(ineut)*y(ineut) * y(iprot) * ratdum(iralf2)
     b(10) =  y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy2(iralf2)
-    dfdy(ihe4,iprot) = esum(b,10)
+    dfdy(ihe4,iprot) = esum10(b)
 
 
     ! c12 jacobian elements
@@ -2446,7 +2446,7 @@ contains
     b(1) = -y(ic12) * ratdum(ircpg)
     b(2) =  y(in14) * ratdum(ifa) * ratdum(irnpg)
     b(3) =  y(in14) * y(ih1) * ratdum(ifa) * dratdumdy1(irnpg)
-    dfdy(ic12,ih1) = esum(b,3)
+    dfdy(ic12,ih1) = esum3(b)
 
     ! d(c12)/d(he4)
     b(1) =  0.5d0 * y(ihe4) * y(ihe4) * ratdum(ir3a)
@@ -2459,7 +2459,7 @@ contains
     b(3) = -ratdum(irg3a)
     b(4) = -y(ihe4) * ratdum(ircag)
     b(5) = -y(ih1) * ratdum(ircpg)
-    dfdy(ic12,ic12) = esum(b,5)
+    dfdy(ic12,ic12) = esum5(b)
 
     ! d(c12)/d(n14)
     dfdy(ic12,in14) = y(ih1) * ratdum(ifa) * ratdum(irnpg)
@@ -2477,7 +2477,7 @@ contains
     b(3) =  -y(in14) * y(ih1) * dratdumdy1(irnpg)
     b(4) =   y(io16) * ratdum(iropg)
     b(5) =   y(io16) * y(ih1) * dratdumdy1(iropg)
-    dfdy(in14,ih1) = esum(b,5)
+    dfdy(in14,ih1) = esum5(b)
 
     ! d(n14)/d(he4)
     dfdy(in14,ihe4) = -y(in14) * ratdum(irnag)
@@ -2500,7 +2500,7 @@ contains
     b(2) =  y(in14) * y(ih1) * ratdum(ifg) * dratdumdy1(irnpg)
     b(3) = -y(io16) * ratdum(iropg)
     b(4) = -y(io16) * y(ih1) * dratdumdy1(iropg)
-    dfdy(io16,ih1) = esum(b,4)
+    dfdy(io16,ih1) = esum4(b)
 
     ! d(o16)/d(he4)
     b(1) =  y(ic12)*ratdum(ircag)
@@ -2521,7 +2521,7 @@ contains
     b(3) = -y(ihe4) * ratdum(iroag)
     b(4) = -ratdum(iroga)
     b(5) = -y(ih1) * ratdum(iropg)
-    dfdy(io16,io16) = esum(b,5)
+    dfdy(io16,io16) = esum5(b)
 
     ! d(o16)/d(ne20)
     dfdy(io16,ine20) = ratdum(irnega)
@@ -2532,7 +2532,7 @@ contains
     b(1) =  y(io16) * ratdum(iroag)
     b(2) = -y(ine20) * ratdum(irneag)
     b(3) =  y(in14) * ratdum(irnag)
-    dfdy(ine20,ihe4) = esum(b,3)
+    dfdy(ine20,ihe4) = esum3(b)
 
     ! d(ne20)/d(c12)
     dfdy(ine20,ic12) = y(ic12) * ratdum(ir1212)
@@ -2557,7 +2557,7 @@ contains
     b(1) =  y(ine20) * ratdum(irneag)
     b(2) = -y(img24) * ratdum(irmgag)
     b(3) = -y(img24) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
-    dfdy(img24,ihe4) = esum(b,3)
+    dfdy(img24,ihe4) = esum3(b)
 
     ! d(mg24)/d(c12)
     dfdy(img24,ic12) = 0.5d0 * y(io16) * ratdum(ir1216)
@@ -2572,7 +2572,7 @@ contains
     b(1) = -y(ihe4) * ratdum(irmgag)
     b(2) = -ratdum(irmgga)
     b(3) = -y(ihe4) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
-    dfdy(img24,img24) = esum(b,3)
+    dfdy(img24,img24) = esum3(b)
 
     ! d(mg24)/d(si28)
     b(1) = ratdum(irsiga)
@@ -2586,7 +2586,7 @@ contains
     b(2) = -y(isi28) * ratdum(irsiag)
     b(3) =  y(img24) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
     b(4) = -y(isi28) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
-    dfdy(isi28,ihe4) = esum(b,4)
+    dfdy(isi28,ihe4) = esum4(b)
 
     ! d(si28)/d(c12)
     dfdy(isi28,ic12) =  0.5d0 * y(io16) * ratdum(ir1216)
@@ -2595,7 +2595,7 @@ contains
     b(1) = 0.5d0 * y(ic12) * ratdum(ir1216)
     b(2) = 1.12d0 * 0.5d0*y(io16) * ratdum(ir1616)
     b(3) = 0.68d0 * 0.5d0*y(io16) * ratdum(irs1) * ratdum(ir1616)
-    dfdy(isi28,io16) = esum(b,3)
+    dfdy(isi28,io16) = esum3(b)
 
     ! d(si28)/d(mg24)
     b(1) =  y(ihe4) * ratdum(irmgag)
@@ -2607,7 +2607,7 @@ contains
     b(2) = -ratdum(irsiga)
     b(3) = -ratdum(irr1) * ratdum(irsigp)
     b(4) = -y(ihe4) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
-    dfdy(isi28,isi28) = esum(b,4)
+    dfdy(isi28,isi28) = esum4(b)
 
     ! d(si28)/d(s32)
     b(1) = ratdum(irsga)
@@ -2621,7 +2621,7 @@ contains
     b(2) = -y(is32) * ratdum(irsag)
     b(3) =  y(isi28) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
     b(4) = -y(is32) * ratdum(irsap) * (1.0d0-ratdum(irt1))
-    dfdy(is32,ihe4) = esum(b,4)
+    dfdy(is32,ihe4) = esum4(b)
 
     ! d(s32)/d(o16)
     b(1) = 0.68d0*0.5d0*y(io16)*ratdum(ir1616)*(1.0d0-ratdum(irs1))
@@ -2638,7 +2638,7 @@ contains
     b(2) = -ratdum(irsga)
     b(3) = -ratdum(irs1) * ratdum(irsgp)
     b(4) = -y(ihe4) * ratdum(irsap) * (1.0d0-ratdum(irt1))
-    dfdy(is32,is32) = esum(b,4)
+    dfdy(is32,is32) = esum4(b)
 
     ! d(s32)/d(ar36)
     b(1) = ratdum(irarga)
@@ -2652,7 +2652,7 @@ contains
     b(2) = -y(iar36) * ratdum(irarag)
     b(3) =  y(is32)  * ratdum(irsap) * (1.0d0-ratdum(irt1))
     b(4) = -y(iar36) * ratdum(irarap) * (1.0d0-ratdum(iru1))
-    dfdy(iar36,ihe4) = esum(b,4)
+    dfdy(iar36,ihe4) = esum4(b)
 
     ! d(ar36)/d(s32)
     b(1) = y(ihe4) * ratdum(irsag)
@@ -2664,7 +2664,7 @@ contains
     b(2) = -ratdum(irarga)
     b(3) = -ratdum(irt1) * ratdum(irargp)
     b(4) = -y(ihe4) * ratdum(irarap) * (1.0d0-ratdum(iru1))
-    dfdy(iar36,iar36) = esum(b,4)
+    dfdy(iar36,iar36) = esum4(b)
 
     ! d(ar36)/d(ca40)
     b(1) = ratdum(ircaga)
@@ -2678,7 +2678,7 @@ contains
     b(2)  = -y(ica40) * ratdum(ircaag)
     b(3)  =  y(iar36) * ratdum(irarap)*(1.0d0-ratdum(iru1))
     b(4)  = -y(ica40) * ratdum(ircaap)*(1.0d0-ratdum(irv1))
-    dfdy(ica40,ihe4) = esum(b,4)
+    dfdy(ica40,ihe4) = esum4(b)
 
     ! d(ca40)/d(ar36)
     b(1) =  y(ihe4) * ratdum(irarag)
@@ -2690,7 +2690,7 @@ contains
     b(2) = -ratdum(ircaga)
     b(3) = -ratdum(ircagp) * ratdum(iru1)
     b(4) = -y(ihe4) * ratdum(ircaap)*(1.0d0-ratdum(irv1))
-    dfdy(ica40,ica40) = esum(b,4)
+    dfdy(ica40,ica40) = esum4(b)
 
     ! d(ca40)/d(ti44)
     b(1) = ratdum(irtiga)
@@ -2704,7 +2704,7 @@ contains
     b(2) = -y(iti44) * ratdum(irtiag)
     b(3) =  y(ica40) * ratdum(ircaap)*(1.0d0-ratdum(irv1))
     b(4) = -y(iti44) * ratdum(irtiap)*(1.0d0-ratdum(irw1))
-    dfdy(iti44,ihe4) = esum(b,4)
+    dfdy(iti44,ihe4) = esum4(b)
 
     ! d(ti44)/d(ca40)
     b(1) =  y(ihe4) * ratdum(ircaag)
@@ -2716,7 +2716,7 @@ contains
     b(2) = -ratdum(irtiga)
     b(3) = -ratdum(irv1) * ratdum(irtigp)
     b(4) = -y(ihe4) * ratdum(irtiap)*(1.0d0-ratdum(irw1))
-    dfdy(iti44,iti44) = esum(b,4)
+    dfdy(iti44,iti44) = esum4(b)
 
     ! d(ti44)/d(cr48)
     b(1) = ratdum(ircrga)
@@ -2730,7 +2730,7 @@ contains
     b(2) = -y(icr48) * ratdum(ircrag)
     b(3) =  y(iti44) * ratdum(irtiap)*(1.0d0-ratdum(irw1))
     b(4) = -y(icr48) * ratdum(ircrap)*(1.0d0-ratdum(irx1))
-    dfdy(icr48,ihe4) = esum(b,4)
+    dfdy(icr48,ihe4) = esum4(b)
 
     ! d(cr48)/d(ti44)
     b(1) =  y(ihe4) * ratdum(irtiag)
@@ -2742,7 +2742,7 @@ contains
     b(2) = -ratdum(ircrga)
     b(3) = -ratdum(irw1) * ratdum(ircrgp)
     b(4) = -y(ihe4) * ratdum(ircrap)*(1.0d0-ratdum(irx1))
-    dfdy(icr48,icr48) = esum(b,4)
+    dfdy(icr48,icr48) = esum4(b)
 
     ! d(cr48)/d(fe52)
     b(1) = ratdum(irfega)
@@ -2757,7 +2757,7 @@ contains
     b(3) =  y(icr48) * ratdum(ircrap) * (1.0d0-ratdum(irx1))
     b(4) = -y(ife52) * ratdum(ir6f54)
     b(5) = -y(ife52) * y(iprot) * ratdum(ir7f54)
-    dfdy(ife52,ihe4) = esum(b,5)
+    dfdy(ife52,ihe4) = esum5(b)
 
     ! d(fe52)/d(cr48)
     b(1) = y(ihe4) * ratdum(ircrag)
@@ -2771,7 +2771,7 @@ contains
     b(4) = -y(ineut) * y(ineut) * ratdum(ir2f54)
     b(5) = -y(ihe4) * ratdum(ir6f54)
     b(6) = -y(ihe4) * y(iprot) * ratdum(ir7f54)
-    dfdy(ife52,ife52) = esum(b,6)
+    dfdy(ife52,ife52) = esum6(b)
 
     ! d(fe52)/d(fe54)
     b(1) = ratdum(ir1f54)
@@ -2787,7 +2787,7 @@ contains
     b(1) =  y(ife54) * dratdumdy1(ir1f54)
     b(2) = -2.0d0 * y(ife52) * y(ineut) * ratdum(ir2f54)
     b(3) = -y(ife52) * y(ineut) * y(ineut) * dratdumdy1(ir2f54)
-    dfdy(ife52,ineut) = esum(b,3)
+    dfdy(ife52,ineut) = esum3(b)
 
     ! d(fe52)/d(prot)
     b(1) =  2.0d0 * y(ife54) * y(iprot) * ratdum(ir5f54)
@@ -2797,7 +2797,7 @@ contains
     b(5) = -y(ife52) * y(ihe4) * y(iprot) * dratdumdy1(ir7f54)
     b(6) =  y(ini56) * ratdum(ir8f54)
     b(7) =  y(ini56) * y(iprot) * dratdumdy1(ir8f54)
-    dfdy(ife52,iprot) = esum(b,7)
+    dfdy(ife52,iprot) = esum7(b)
 
 
     ! fe54 jacobian elements
@@ -2813,7 +2813,7 @@ contains
     b(1) = -ratdum(ir1f54)
     b(2) = -y(iprot) * y(iprot) * ratdum(ir3f54)
     b(3) = -y(iprot) * y(iprot) * ratdum(ir5f54)
-    dfdy(ife54,ife54) = esum(b,3)
+    dfdy(ife54,ife54) = esum3(b)
 
     ! d(fe54)/d(ni56)
     b(1)  = ratdum(ir4f54)
@@ -2824,7 +2824,7 @@ contains
     b(1) = -y(ife54) * dratdumdy1(ir1f54)
     b(2) =  2.0d0 * y(ife52) * y(ineut) * ratdum(ir2f54)
     b(3) =  y(ife52) * y(ineut) * y(ineut) * dratdumdy1(ir2f54)
-    dfdy(ife52,ineut) = esum(b,3)
+    dfdy(ife52,ineut) = esum3(b)
 
     ! d(fe54)/d(prot)
     b(1) = -2.0d0 * y(ife54) * y(iprot) * ratdum(ir3f54)
@@ -2833,7 +2833,7 @@ contains
     b(4) = -2.0d0 * y(ife54) * y(iprot) * ratdum(ir5f54)
     b(5) = -y(ife54) * y(iprot) * y(iprot) * dratdumdy1(ir5f54)
     b(6) =  y(ihe4) * y(ife52) * dratdumdy1(ir6f54)
-    dfdy(ife52,iprot) = esum(b,6)
+    dfdy(ife52,iprot) = esum6(b)
 
 
     ! ni56 jacobian elements
@@ -2855,7 +2855,7 @@ contains
     b(2) = -ratdum(ir4f54)
     b(3) = -y(iprot) * ratdum(ir8f54)
     b(4) = -ratdum(irn56ec)
-    dfdy(ini56,ini56) = esum(b,4)
+    dfdy(ini56,ini56) = esum4(b)
 
     ! d(ni56)/d(prot)
     b(1) =  2.0d0 * y(ife54) * y(iprot) * ratdum(ir3f54)
@@ -2865,7 +2865,7 @@ contains
     b(5) =  y(ife52) * y(ihe4)* y(iprot) * dratdumdy1(ir7f54)
     b(6) = -y(ini56) * ratdum(ir8f54)
     b(7) = -y(ini56) * y(iprot) * dratdumdy1(ir8f54)
-    dfdy(ini56,iprot) = esum(b,7)
+    dfdy(ini56,iprot) = esum7(b)
 
 
     ! photodisintegration neutron jacobian elements
@@ -2886,14 +2886,14 @@ contains
     b(5)  = -4.0d0 * y(ineut) * y(iprot)*y(iprot) * ratdum(iralf2)
     b(6)  = -2.0d0 * y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy1(iralf2)
     b(7)  = -ratdum(irnep)
-    dfdy(ineut,ineut) = esum(b,7)
+    dfdy(ineut,ineut) = esum7(b)
 
     ! d(neut)/d(prot)
     b(1) =  2.0d0 * y(ihe4) * dratdumdy2(iralf1)
     b(2) = -4.0d0 * y(ineut)*y(ineut) * y(iprot) * ratdum(iralf2)
     b(3) = -2.0d0 * y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy2(iralf2)
     b(4) =  ratdum(irpen)
-    dfdy(ineut,iprot) = esum(b,4)
+    dfdy(ineut,iprot) = esum4(b)
 
 
     ! photodisintegration proton jacobian elements
@@ -2917,7 +2917,7 @@ contains
     b(2) = -4.0d0 * y(ineut) * y(iprot)*y(iprot) * ratdum(iralf2)
     b(3) = -2.0d0 * y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy1(iralf2)
     b(4) =  ratdum(irnep)
-    dfdy(iprot,ineut) = esum(b,4)
+    dfdy(iprot,ineut) = esum4(b)
 
     ! d(prot)/d(prot)
     b(1)  =  -4.0d0 * y(ife54) * y(iprot) * ratdum(ir3f54)
@@ -2930,7 +2930,7 @@ contains
     b(8)  =  -4.0d0 * y(ineut)*y(ineut) * y(iprot) * ratdum(iralf2)
     b(9)  =  -2.0d0 * y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy2(iralf2)
     b(10) =  -ratdum(irpen)
-    dfdy(iprot,iprot) = esum(b,10)
+    dfdy(iprot,iprot) = esum10(b)
 
   end subroutine dfdy_isotopes_aprox19
 

--- a/networks/aprox21/actual_rhs.f90
+++ b/networks/aprox21/actual_rhs.f90
@@ -209,7 +209,7 @@ contains
   subroutine rhs(y, rate, ratdum, dydt, deriva)
 
     use amrex_constants_module, only: ZERO, SIXTH
-    use microphysics_math_module, only: esum
+    use microphysics_math_module, only: esum3, esum4, esum5, esum6, esum7, esum8, esum10, esum12, esum15
 
     implicit none
 
@@ -234,7 +234,7 @@ contains
     a(6) = -2.0d0 * y(io16) * y(ih1) * rate(iropg)
     a(7) = -3.0d0 * y(ih1) * rate(irpen)
 
-    dydt(ih1) = dydt(ih1) + esum(a,7)
+    dydt(ih1) = dydt(ih1) + esum7(a)
 
 
 
@@ -244,7 +244,7 @@ contains
     a(3)  = -y(ihe3) * y(ihe4) * rate(irhe3ag)
     a(4)  =  y(ih1) * rate(irpen)
 
-    dydt(ihe3) = dydt(ihe3) + esum(a,4)
+    dydt(ihe3) = dydt(ihe3) + esum4(a)
 
 
     ! he4 reactions
@@ -252,7 +252,7 @@ contains
     a(1)  = 0.5d0 * y(ic12) * y(ic12) * rate(ir1212)
     a(2)  = 0.5d0 * y(ic12) * y(io16) * rate(ir1216)
     a(3)  = 0.56d0 * 0.5d0 * y(io16) * y(io16) * rate(ir1616)
-    dydt(ihe4) =  dydt(ihe4) + esum(a,3)
+    dydt(ihe4) =  dydt(ihe4) + esum3(a)
 
 
     ! (a,g) and (g,a) reactions
@@ -269,7 +269,7 @@ contains
     a(11) = -y(ihe4)  * y(isi28)*rate(irsiag)
     a(12) =  y(is32)  * rate(irsga)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,12)
+    dydt(ihe4) =  dydt(ihe4) + esum12(a)
 
     a(1)  = -y(ihe4)  * y(is32) * rate(irsag)
     a(2)  =  y(iar36) * rate(irarga)
@@ -284,7 +284,7 @@ contains
     a(11) = -y(ihe4)  * y(ife52) * rate(irfeag)
     a(12) =  y(ini56) * rate(irniga)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,12)
+    dydt(ihe4) =  dydt(ihe4) + esum12(a)
 
 
     ! (a,p)(p,g) and (g,p)(p,a) reactions
@@ -306,7 +306,7 @@ contains
        a(14) = -y(ihe4)  * y(icr48) * rate(ircrap)*(1.0d0-rate(irx1))
        a(15) =  y(ife52) * rate(irfegp) * rate(irx1)
 
-       dydt(ihe4) =  dydt(ihe4) + esum(a,15)
+       dydt(ihe4) =  dydt(ihe4) + esum15(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * ratdum(irs1) * rate(ir1616)
@@ -320,7 +320,7 @@ contains
        a(9)  =  y(is32)  * ratdum(irsgp) * rate(irs1)
        a(10) =  y(is32)  * rate(irsgp) * ratdum(irs1)
 
-       dydt(ihe4) =  dydt(ihe4) + esum(a,10)
+       dydt(ihe4) =  dydt(ihe4) + esum10(a)
 
        a(1)  = -y(ihe4)*y(is32) * rate(irsap)*(1.0d0 - ratdum(irt1))
        a(2)  =  y(ihe4)*y(is32) * ratdum(irsap)*rate(irt1)
@@ -335,7 +335,7 @@ contains
        a(11) =  y(iti44) * ratdum(irtigp) * rate(irv1)
        a(12) =  y(iti44) * rate(irtigp) * ratdum(irv1)
 
-       dydt(ihe4) =  dydt(ihe4) + esum(a,12)
+       dydt(ihe4) =  dydt(ihe4) + esum12(a)
 
        a(1)  = -y(ihe4)*y(iti44) * rate(irtiap)*(1.0d0 - ratdum(irw1))
        a(2)  =  y(ihe4)*y(iti44) * ratdum(irtiap)*rate(irw1)
@@ -346,7 +346,7 @@ contains
        a(7)  =  y(ife52) * ratdum(irfegp) * rate(irx1)
        a(8)  =  y(ife52) * rate(irfegp) * ratdum(irx1)
 
-       dydt(ihe4) =  dydt(ihe4) + esum(a,8)
+       dydt(ihe4) =  dydt(ihe4) + esum8(a)
     end if
 
 
@@ -360,7 +360,7 @@ contains
     a(7) =  y(ife56) * y(iprot) * y(iprot) * rate(irfe56_aux3) 
     a(8) = -y(ife54) * y(ihe4) * rate(irfe56_aux4)
 
-    dydt(ihe4) =  dydt(ihe4) + esum(a,8)
+    dydt(ihe4) =  dydt(ihe4) + esum8(a)
 
 
     ! ppchain
@@ -395,7 +395,7 @@ contains
     a(6) =  y(io16) * rate(iroga)
     a(7) = -y(ic12) * y(ih1) * rate(ircpg)
 
-    dydt(ic12) =  dydt(ic12) + esum(a,7)
+    dydt(ic12) =  dydt(ic12) + esum7(a)
 
     if (.not. deriva) then
        a(1) =  y(in14) * y(ih1) * rate(ifa) * rate(irnpg)
@@ -413,7 +413,7 @@ contains
     a(3) =  y(io16) * y(ih1) * rate(iropg)
     a(4) = -y(ihe4) * y(in14) * rate(irnag)
 
-    dydt(in14) =  dydt(in14) + esum(a,4)
+    dydt(in14) =  dydt(in14) + esum4(a)
 
 
     ! o16 reactions
@@ -425,7 +425,7 @@ contains
     a(6) =  y(ine20) * rate(irnega)
     a(7) = -y(io16) * y(ih1) * rate(iropg)
 
-    dydt(io16) =  dydt(io16) + esum(a,7)
+    dydt(io16) =  dydt(io16) + esum7(a)
 
     if (.not. deriva) then
        a(1) =  y(in14) * y(ih1) * rate(ifg) * rate(irnpg)
@@ -445,7 +445,7 @@ contains
     a(5) =  y(img24) * rate(irmgga)
     a(6) =  y(in14) * y(ihe4) * rate(irnag)
 
-    dydt(ine20) =  dydt(ine20) + esum(a,6)
+    dydt(ine20) =  dydt(ine20) + esum6(a)
 
 
     ! mg24 reactions
@@ -455,7 +455,7 @@ contains
     a(4) = -y(img24) * rate(irmgga)
     a(5) =  y(isi28) * rate(irsiga)
 
-    dydt(img24) =  dydt(img24) + esum(a,5)
+    dydt(img24) =  dydt(img24) + esum5(a)
 
     if (.not.deriva) then
        a(1) = -y(img24) * y(ihe4) * rate(irmgap)*(1.0d0-rate(irr1))
@@ -469,7 +469,7 @@ contains
        a(3) =  y(isi28) * ratdum(irr1) * rate(irsigp)
        a(4) =  y(isi28) * rate(irr1) * ratdum(irsigp)
 
-       dydt(img24) =  dydt(img24) + esum(a,4)
+       dydt(img24) =  dydt(img24) + esum4(a)
     end if
 
 
@@ -481,7 +481,7 @@ contains
     a(5) = -y(isi28) * rate(irsiga)
     a(6) =  y(is32)  * rate(irsga)
 
-    dydt(isi28) =  dydt(isi28) + esum(a,6)
+    dydt(isi28) =  dydt(isi28) + esum6(a)
 
     if (.not.deriva) then
        a(1) =  0.34d0*0.5d0*y(io16)*y(io16)*rate(irs1)*rate(ir1616)
@@ -490,7 +490,7 @@ contains
        a(4) = -y(isi28) * y(ihe4) * rate(irsiap)*(1.0d0-rate(irs1))
        a(5) =  y(is32)  * rate(irs1) * rate(irsgp)
 
-       dydt(isi28) =  dydt(isi28) + esum(a,5)
+       dydt(isi28) =  dydt(isi28) + esum5(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * ratdum(irs1)*rate(ir1616)
@@ -504,7 +504,7 @@ contains
        a(9)  = y(is32) * ratdum(irs1) * rate(irsgp)
        a(10) = y(is32) * rate(irs1) * ratdum(irsgp)
 
-       dydt(isi28) =  dydt(isi28) + esum(a,10)
+       dydt(isi28) =  dydt(isi28) + esum10(a)
     end if
 
 
@@ -515,7 +515,7 @@ contains
     a(4) = -y(is32) * rate(irsga)
     a(5) =  y(iar36) * rate(irarga)
 
-    dydt(is32) =  dydt(is32) + esum(a,5)
+    dydt(is32) =  dydt(is32) + esum5(a)
 
     if (.not.deriva) then
        a(1) =  0.34d0*0.5d0*y(io16)*y(io16)* rate(ir1616)*(1.0d0-rate(irs1))
@@ -524,7 +524,7 @@ contains
        a(4) = -y(is32) * y(ihe4) * rate(irsap)*(1.0d0-rate(irt1))
        a(5) =  y(iar36) * rate(irt1) * rate(irargp)
 
-       dydt(is32) =  dydt(is32) + esum(a,5)
+       dydt(is32) =  dydt(is32) + esum5(a)
 
     else
        a(1)  =  0.34d0*0.5d0*y(io16)*y(io16) * rate(ir1616)*(1.0d0-ratdum(irs1))
@@ -538,7 +538,7 @@ contains
        a(9)  =  y(iar36) * ratdum(irt1) * rate(irargp)
        a(10) =  y(iar36) * rate(irt1) * ratdum(irargp)
 
-       dydt(is32) =  dydt(is32) + esum(a,10)
+       dydt(is32) =  dydt(is32) + esum10(a)
     end if
 
 
@@ -548,7 +548,7 @@ contains
     a(3) = -y(iar36) * rate(irarga)
     a(4) =  y(ica40) * rate(ircaga)
 
-    dydt(iar36) =  dydt(iar36) + esum(a,4)
+    dydt(iar36) =  dydt(iar36) + esum4(a)
 
     if (.not.deriva) then
        a(1) = y(is32)  * y(ihe4) * rate(irsap)*(1.0d0-rate(irt1))
@@ -556,7 +556,7 @@ contains
        a(3) = -y(iar36) * y(ihe4) * rate(irarap)*(1.0d0-rate(iru1))
        a(4) =  y(ica40) * rate(ircagp) * rate(iru1)
 
-       dydt(iar36) =  dydt(iar36) + esum(a,4)
+       dydt(iar36) =  dydt(iar36) + esum4(a)
 
     else
        a(1) =  y(is32)*y(ihe4) * rate(irsap)*(1.0d0 - ratdum(irt1))
@@ -568,7 +568,7 @@ contains
        a(7) =  y(ica40) * ratdum(ircagp) * rate(iru1)
        a(8) =  y(ica40) * rate(ircagp) * ratdum(iru1)
 
-       dydt(iar36) =  dydt(iar36) + esum(a,8)
+       dydt(iar36) =  dydt(iar36) + esum8(a)
     end if
 
 
@@ -578,7 +578,7 @@ contains
     a(3) = -y(ica40) * rate(ircaga)
     a(4) =  y(iti44) * rate(irtiga)
 
-    dydt(ica40) =  dydt(ica40) + esum(a,4)
+    dydt(ica40) =  dydt(ica40) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(iar36) * y(ihe4) * rate(irarap)*(1.0d0-rate(iru1))
@@ -586,7 +586,7 @@ contains
        a(3) = -y(ica40) * y(ihe4) * rate(ircaap)*(1.0d0-rate(irv1))
        a(4) =  y(iti44) * rate(irtigp) * rate(irv1)
 
-       dydt(ica40) =  dydt(ica40) + esum(a,4)
+       dydt(ica40) =  dydt(ica40) + esum4(a)
 
     else
        a(1) =  y(iar36)*y(ihe4) * rate(irarap)*(1.0d0-ratdum(iru1))
@@ -598,7 +598,7 @@ contains
        a(7) =  y(iti44) * ratdum(irtigp) * rate(irv1)
        a(8) =  y(iti44) * rate(irtigp) * ratdum(irv1)
 
-       dydt(ica40) =  dydt(ica40) + esum(a,8)
+       dydt(ica40) =  dydt(ica40) + esum8(a)
     end if
 
 
@@ -608,7 +608,7 @@ contains
     a(3) = -y(iti44) * rate(irtiga)
     a(4) =  y(icr48) * rate(ircrga)
 
-    dydt(iti44) =  dydt(iti44) + esum(a,4)
+    dydt(iti44) =  dydt(iti44) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(ica40) * y(ihe4) * rate(ircaap)*(1.0d0-rate(irv1))
@@ -616,7 +616,7 @@ contains
        a(3) = -y(iti44) * y(ihe4) * rate(irtiap)*(1.0d0-rate(irw1))
        a(4) =  y(icr48) * rate(irw1) * rate(ircrgp)
 
-       dydt(iti44) =  dydt(iti44) + esum(a,4)
+       dydt(iti44) =  dydt(iti44) + esum4(a)
 
     else
        a(1) =  y(ica40)*y(ihe4) * rate(ircaap)*(1.0d0-ratdum(irv1))
@@ -628,7 +628,7 @@ contains
        a(7) =  y(icr48) * ratdum(irw1) * rate(ircrgp)
        a(8) =  y(icr48) * rate(irw1) * ratdum(ircrgp)
 
-       dydt(iti44) =  dydt(iti44) + esum(a,8)
+       dydt(iti44) =  dydt(iti44) + esum8(a)
     end if
 
 
@@ -638,7 +638,7 @@ contains
     a(3) = -y(icr48) * rate(ircrga)
     a(4) =  y(ife52) * rate(irfega)
 
-    dydt(icr48) =  dydt(icr48) + esum(a,4)
+    dydt(icr48) =  dydt(icr48) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(iti44) * y(ihe4) * rate(irtiap)*(1.0d0-rate(irw1))
@@ -646,7 +646,7 @@ contains
        a(3) = -y(icr48) * y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
        a(4) =  y(ife52) * rate(irx1) * rate(irfegp)
 
-       dydt(icr48) =  dydt(icr48) + esum(a,4)
+       dydt(icr48) =  dydt(icr48) + esum4(a)
 
     else
        a(1) =  y(iti44)*y(ihe4) * rate(irtiap)*(1.0d0-ratdum(irw1))
@@ -658,7 +658,7 @@ contains
        a(7) =  y(ife52) * ratdum(irx1) * rate(irfegp)
        a(8) =  y(ife52) * rate(irx1) * ratdum(irfegp)
 
-       dydt(icr48) =  dydt(icr48) + esum(a,8)
+       dydt(icr48) =  dydt(icr48) + esum8(a)
     end if
 
     ! cr56 reactions
@@ -672,7 +672,7 @@ contains
     a(3) = -y(ife52) * rate(irfega)
     a(4) =  y(ini56) * rate(irniga)
 
-    dydt(ife52) =  dydt(ife52) + esum(a,4)
+    dydt(ife52) =  dydt(ife52) + esum4(a)
 
     if (.not.deriva) then
        a(1) =  y(icr48) * y(ihe4) * rate(ircrap)*(1.0d0-rate(irx1))
@@ -684,7 +684,7 @@ contains
        a(2) = -y(icr48)*y(ihe4) * ratdum(ircrap)*rate(irx1)
        a(3) = -y(ife52) * ratdum(irx1) * rate(irfegp)
        a(4) = -y(ife52) * rate(irx1) * ratdum(irfegp)
-       dydt(ife52) =  dydt(ife52) + esum(a,4)
+       dydt(ife52) =  dydt(ife52) + esum4(a)
     end if
 
 
@@ -696,7 +696,7 @@ contains
     a(5) = -y(ife52) * y(ihe4) * y(iprot) * rate(ir7f54)
     a(6) =  y(ini56) * y(iprot) * rate(ir8f54)
 
-    dydt(ife52) =  dydt(ife52) + esum(a,6)
+    dydt(ife52) =  dydt(ife52) + esum6(a)
 
 
     ! fe54 reactions
@@ -711,7 +711,7 @@ contains
     a(9)  =  y(ife56) * y(iprot) * y(iprot) * rate(irfe56_aux3) 
     a(10) = -y(ife54) * y(ihe4) * rate(irfe56_aux4) 
 
-    dydt(ife54) =  dydt(ife54) + esum(a,10)
+    dydt(ife54) =  dydt(ife54) + esum10(a)
 
     ! fe56 reactions
     a(1) =  y(ini56) * rate(irn56ec) 
@@ -721,14 +721,14 @@ contains
     a(5) = -y(ife56) * y(iprot) * y(iprot) * rate(irfe56_aux3) 
     a(6) =  y(ife54) * y(ihe4) * rate(irfe56_aux4) 
 
-    dydt(ife56) =  dydt(ife56) + esum(a,6) 
+    dydt(ife56) =  dydt(ife56) + esum6(a) 
 
     ! ni56 reactions
     a(1) =  y(ife52) * y(ihe4) * rate(irfeag)
     a(2) = -y(ini56) * rate(irniga)
     a(3) = -y(ini56) * rate(irn56ec)
 
-    dydt(ini56) =  dydt(ini56) + esum(a,3)
+    dydt(ini56) =  dydt(ini56) + esum3(a)
 
 
     ! photodisintegration reactions
@@ -737,7 +737,7 @@ contains
     a(3) =  y(ife52) * y(ihe4)* y(iprot) * rate(ir7f54)
     a(4) = -y(ini56) * y(iprot) * rate(ir8f54)
 
-    dydt(ini56) =  dydt(ini56) + esum(a,4)
+    dydt(ini56) =  dydt(ini56) + esum4(a)
 
 
     ! photodisintegration neutrons
@@ -750,7 +750,7 @@ contains
     a(7) =  2.0d0 * y(ife56) * rate(irfe56_aux1) 
     a(8) = -2.0d0 * y(ife54) * y(ineut) * y(ineut) * rate(irfe56_aux2)
 
-    dydt(ineut) =  dydt(ineut) + esum(a,8)
+    dydt(ineut) =  dydt(ineut) + esum8(a)
 
 
     ! photodisintegration protons
@@ -765,7 +765,7 @@ contains
     a(9)  = -2.0d0 * y(ife56) * y(iprot) * y(iprot) * rate(irfe56_aux3) 
     a(10) =  2.0d0 * y(ife54) * y(ihe4) * rate(irfe56_aux4)
 
-    dydt(iprot) =  dydt(iprot) + esum(a,10)
+    dydt(iprot) =  dydt(iprot) + esum10(a)
 
   end subroutine rhs
 
@@ -2383,7 +2383,7 @@ contains
   subroutine dfdy_isotopes_aprox21(y,dfdy,ratdum,dratdumdy1,dratdumdy2)
 
     use network
-    use microphysics_math_module, only: esum
+    use microphysics_math_module, only: esum3, esum4, esum5, esum6, esum7, esum9, esum10, esum13, esum26
     use amrex_constants_module, only: ZERO
 
     implicit none
@@ -2404,7 +2404,7 @@ contains
     b(5) = -2.0d0 * y(io16) * ratdum(iropg)
     b(6) = -2.0d0 * y(io16) * y(ih1) * dratdumdy1(iropg)
     b(7) = -3.0d0 * ratdum(irpen)
-    dfdy(ih1,ih1) = esum(b,7)
+    dfdy(ih1,ih1) = esum7(b)
 
 
     ! d(h1)/d(he3)
@@ -2450,7 +2450,7 @@ contains
     b(2) =  y(in14) * y(ih1) * ratdum(ifa) * dratdumdy1(irnpg)
     b(3) =  y(io16) * ratdum(iropg)
     b(4) =  y(io16) * y(ih1) * dratdumdy1(iropg)
-    dfdy(ihe4,ih1) = esum(b,4)
+    dfdy(ihe4,ih1) = esum4(b)
 
 
     ! d(he4)/d(he3)
@@ -2485,14 +2485,14 @@ contains
     b(24) =  y(ihe3) * ratdum(irhe3ag)
     b(25) =  y(ihe3) * y(ihe4) * dratdumdy1(irhe3ag)
     b(26) = -y(in14) * ratdum(irnag) * 1.5d0
-    dfdy(ihe4,ihe4) = esum(b,26)
+    dfdy(ihe4,ihe4) = esum26(b)
 
     ! d(he4)/d(c12)
     b(1) =  y(ic12) * ratdum(ir1212)
     b(2) =  0.5d0 * y(io16) * ratdum(ir1216)
     b(3) =  3.0d0 * ratdum(irg3a)
     b(4) = -y(ihe4) * ratdum(ircag)
-    dfdy(ihe4,ic12) = esum(b,4)
+    dfdy(ihe4,ic12) = esum4(b)
 
     ! d(he4)/d(n14)
     b(1) =  y(ih1) * ratdum(ifa) * ratdum(irnpg)
@@ -2506,7 +2506,7 @@ contains
     b(4) =  ratdum(iroga)
     b(5) = -y(ihe4) * ratdum(iroag)
     b(6) =  y(ih1) * ratdum(iropg)
-    dfdy(ihe4,io16) = esum(b,6)
+    dfdy(ihe4,io16) = esum6(b)
 
     ! d(he4)/d(ne20)
     b(1) =  ratdum(irnega)
@@ -2517,49 +2517,49 @@ contains
     b(1) =  ratdum(irmgga)
     b(2) = -y(ihe4) * ratdum(irmgag)
     b(3) = -y(ihe4) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
-    dfdy(ihe4,img24) = esum(b,3)
+    dfdy(ihe4,img24) = esum3(b)
 
     ! d(he4)/d(si28)
     b(1) =  ratdum(irsiga)
     b(2) = -y(ihe4) * ratdum(irsiag)
     b(3) = -y(ihe4) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
     b(4) =  ratdum(irr1) * ratdum(irsigp)
-    dfdy(ihe4,isi28) = esum(b,4)
+    dfdy(ihe4,isi28) = esum4(b)
 
     ! d(he4)/d(s32)
     b(1) =  ratdum(irsga)
     b(2) = -y(ihe4) * ratdum(irsag)
     b(3) = -y(ihe4) * ratdum(irsap) * (1.0d0-ratdum(irt1))
     b(4) =  ratdum(irs1) * ratdum(irsgp)
-    dfdy(ihe4,is32) = esum(b,4)
+    dfdy(ihe4,is32) = esum4(b)
 
     ! d(he4)/d(ar36)
     b(1)  =  ratdum(irarga)
     b(2)  = -y(ihe4) * ratdum(irarag)
     b(3)  = -y(ihe4) * ratdum(irarap) * (1.0d0-ratdum(iru1))
     b(4)  =  ratdum(irt1) * ratdum(irargp)
-    dfdy(ihe4,iar36) = esum(b,4)
+    dfdy(ihe4,iar36) = esum4(b)
 
     ! d(he4)/d(ca40)
     b(1) =  ratdum(ircaga)
     b(2) = -y(ihe4) * ratdum(ircaag)
     b(3) = -y(ihe4) * ratdum(ircaap) * (1.0d0-ratdum(irv1))
     b(4) =  ratdum(iru1) * ratdum(ircagp)
-    dfdy(ihe4,ica40) = esum(b,4)
+    dfdy(ihe4,ica40) = esum4(b)
 
     ! d(he4)/d(ti44)
     b(1) =  ratdum(irtiga)
     b(2) = -y(ihe4) * ratdum(irtiag)
     b(3) = -y(ihe4) * ratdum(irtiap) * (1.0d0-ratdum(irw1))
     b(4) =  ratdum(irv1) * ratdum(irtigp)
-    dfdy(ihe4,iti44) = esum(b,4)
+    dfdy(ihe4,iti44) = esum4(b)
 
     ! d(he4)/d(cr48)
     b(1) =  ratdum(ircrga)
     b(2) = -y(ihe4) * ratdum(ircrag)
     b(3) = -y(ihe4) * ratdum(ircrap) * (1.0d0-ratdum(irx1))
     b(4) =  ratdum(irw1) * ratdum(ircrgp)
-    dfdy(ihe4,icr48) = esum(b,4)
+    dfdy(ihe4,icr48) = esum4(b)
 
     ! d(he4)/d(fe52)
     b(1) =  ratdum(irfega)
@@ -2567,7 +2567,7 @@ contains
     b(3) =  ratdum(irx1) * ratdum(irfegp)
     b(4) = -y(ihe4) * ratdum(ir6f54)
     b(5) = -y(ihe4) * y(iprot) * ratdum(ir7f54)
-    dfdy(ihe4,ife52) = esum(b,5)
+    dfdy(ihe4,ife52) = esum5(b)
 
     ! d(he4)/d(fe54)
     b(1) =  y(iprot) * y(iprot) * ratdum(ir5f54)
@@ -2586,7 +2586,7 @@ contains
     b(1) = -y(ihe4) * dratdumdy1(iralf1)
     b(2) =  2.0d0 * y(ineut) * y(iprot)*y(iprot) * ratdum(iralf2)
     b(3) =  y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy1(iralf2)
-    dfdy(ihe4,ineut) = esum(b,3)
+    dfdy(ihe4,ineut) = esum3(b)
 
     ! d(he4)/d(prot)
     b(1)  =  2.0d0 * y(ife54) * y(iprot) * ratdum(ir5f54)
@@ -2602,7 +2602,7 @@ contains
     b(11) =  2.0d0 * y(ife56) * y(iprot) * ratdum(irfe56_aux3)
     b(12) =  y(ife56) * y(iprot) * y(iprot) * dratdumdy1(irfe56_aux3)
     b(13) = -y(ihe4) * y(ife54) * dratdumdy1(irfe56_aux4)
-    dfdy(ihe4,iprot) = esum(b,13)
+    dfdy(ihe4,iprot) = esum13(b)
 
 
 
@@ -2611,7 +2611,7 @@ contains
     b(1) = -y(ic12) * ratdum(ircpg)
     b(2) =  y(in14) * ratdum(ifa) * ratdum(irnpg)
     b(3) =  y(in14) * y(ih1) * ratdum(ifa) * dratdumdy1(irnpg)
-    dfdy(ic12,ih1) = esum(b,3)
+    dfdy(ic12,ih1) = esum3(b)
 
     ! d(c12)/d(he4)
     b(1) =  0.5d0 * y(ihe4) * y(ihe4) * ratdum(ir3a)
@@ -2624,7 +2624,7 @@ contains
     b(3) = -ratdum(irg3a)
     b(4) = -y(ihe4) * ratdum(ircag)
     b(5) = -y(ih1) * ratdum(ircpg)
-    dfdy(ic12,ic12) = esum(b,5)
+    dfdy(ic12,ic12) = esum5(b)
 
     ! d(c12)/d(n14)
     dfdy(ic12,in14) = y(ih1) * ratdum(ifa) * ratdum(irnpg)
@@ -2642,7 +2642,7 @@ contains
     b(3) =  -y(in14) * y(ih1) * dratdumdy1(irnpg)
     b(4) =   y(io16) * ratdum(iropg)
     b(5) =   y(io16) * y(ih1) * dratdumdy1(iropg)
-    dfdy(in14,ih1) = esum(b,5)
+    dfdy(in14,ih1) = esum5(b)
 
     ! d(n14)/d(he4)
     dfdy(in14,ihe4) = -y(in14) * ratdum(irnag)
@@ -2665,7 +2665,7 @@ contains
     b(2) =  y(in14) * y(ih1) * ratdum(ifg) * dratdumdy1(irnpg)
     b(3) = -y(io16) * ratdum(iropg)
     b(4) = -y(io16) * y(ih1) * dratdumdy1(iropg)
-    dfdy(io16,ih1) = esum(b,4)
+    dfdy(io16,ih1) = esum4(b)
 
     ! d(o16)/d(he4)
     b(1) =  y(ic12)*ratdum(ircag)
@@ -2686,7 +2686,7 @@ contains
     b(3) = -y(ihe4) * ratdum(iroag)
     b(4) = -ratdum(iroga)
     b(5) = -y(ih1) * ratdum(iropg)
-    dfdy(io16,io16) = esum(b,5)
+    dfdy(io16,io16) = esum5(b)
 
     ! d(o16)/d(ne20)
     dfdy(io16,ine20) = ratdum(irnega)
@@ -2698,7 +2698,7 @@ contains
     b(1) =  y(io16) * ratdum(iroag)
     b(2) = -y(ine20) * ratdum(irneag)
     b(3) =  y(in14) * ratdum(irnag)
-    dfdy(ine20,ihe4) = esum(b,3)
+    dfdy(ine20,ihe4) = esum3(b)
 
     ! d(ne20)/d(c12)
     dfdy(ine20,ic12) = y(ic12) * ratdum(ir1212)
@@ -2724,7 +2724,7 @@ contains
     b(1) =  y(ine20) * ratdum(irneag)
     b(2) = -y(img24) * ratdum(irmgag)
     b(3) = -y(img24) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
-    dfdy(img24,ihe4) = esum(b,3)
+    dfdy(img24,ihe4) = esum3(b)
 
     ! d(mg24)/d(c12)
     dfdy(img24,ic12) = 0.5d0 * y(io16) * ratdum(ir1216)
@@ -2739,7 +2739,7 @@ contains
     b(1) =  -y(ihe4) * ratdum(irmgag)
     b(2) = -ratdum(irmgga)
     b(3) = -y(ihe4) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
-    dfdy(img24,img24) = esum(b,3)
+    dfdy(img24,img24) = esum3(b)
 
     ! d(mg24)/d(si28)
     b(1) = ratdum(irsiga)
@@ -2754,7 +2754,7 @@ contains
     b(2) = -y(isi28) * ratdum(irsiag)
     b(3) =  y(img24) * ratdum(irmgap) * (1.0d0-ratdum(irr1))
     b(4) = -y(isi28) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
-    dfdy(isi28,ihe4) = esum(b,4)
+    dfdy(isi28,ihe4) = esum4(b)
 
     ! d(si28)/d(c12)
     dfdy(isi28,ic12) =  0.5d0 * y(io16) * ratdum(ir1216)
@@ -2763,7 +2763,7 @@ contains
     b(1) = 0.5d0 * y(ic12) * ratdum(ir1216)
     b(2) = 1.12d0 * 0.5d0*y(io16) * ratdum(ir1616)
     b(3) = 0.68d0 * 0.5d0*y(io16) * ratdum(irs1) * ratdum(ir1616)
-    dfdy(isi28,io16) = esum(b,3)
+    dfdy(isi28,io16) = esum3(b)
 
     ! d(si28)/d(mg24)
     b(1) =  y(ihe4) * ratdum(irmgag)
@@ -2775,7 +2775,7 @@ contains
     b(2) = -ratdum(irsiga)
     b(3) = -ratdum(irr1) * ratdum(irsigp)
     b(4) = -y(ihe4) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
-    dfdy(isi28,isi28) = esum(b,4)
+    dfdy(isi28,isi28) = esum4(b)
 
     ! d(si28)/d(s32)
     b(1) = ratdum(irsga)
@@ -2789,7 +2789,7 @@ contains
     b(2) = -y(is32) * ratdum(irsag)
     b(3) =  y(isi28) * ratdum(irsiap) * (1.0d0-ratdum(irs1))
     b(4) = -y(is32) * ratdum(irsap) * (1.0d0-ratdum(irt1))
-    dfdy(is32,ihe4) = esum(b,4)
+    dfdy(is32,ihe4) = esum4(b)
 
     ! d(s32)/d(o16)
     b(1) = 0.68d0*0.5d0*y(io16)*ratdum(ir1616)*(1.0d0-ratdum(irs1))
@@ -2806,7 +2806,7 @@ contains
     b(2) = -ratdum(irsga)
     b(3) = -ratdum(irs1) * ratdum(irsgp)
     b(4) = -y(ihe4) * ratdum(irsap) * (1.0d0-ratdum(irt1))
-    dfdy(is32,is32) = esum(b,4)
+    dfdy(is32,is32) = esum4(b)
 
     ! d(s32)/d(ar36)
     b(1) = ratdum(irarga)
@@ -2820,7 +2820,7 @@ contains
     b(2) = -y(iar36) * ratdum(irarag)
     b(3) =  y(is32)  * ratdum(irsap) * (1.0d0-ratdum(irt1))
     b(4) = -y(iar36) * ratdum(irarap) * (1.0d0-ratdum(iru1))
-    dfdy(iar36,ihe4) = esum(b,4)
+    dfdy(iar36,ihe4) = esum4(b)
 
     ! d(ar36)/d(s32)
     b(1) = y(ihe4) * ratdum(irsag)
@@ -2832,7 +2832,7 @@ contains
     b(2) = -ratdum(irarga)
     b(3) = -ratdum(irt1) * ratdum(irargp)
     b(4) = -y(ihe4) * ratdum(irarap) * (1.0d0-ratdum(iru1))
-    dfdy(iar36,iar36) = esum(b,4)
+    dfdy(iar36,iar36) = esum4(b)
 
     ! d(ar36)/d(ca40)
     b(1) = ratdum(ircaga)
@@ -2847,7 +2847,7 @@ contains
     b(2)  = -y(ica40) * ratdum(ircaag)
     b(3)  =  y(iar36) * ratdum(irarap)*(1.0d0-ratdum(iru1))
     b(4)  = -y(ica40) * ratdum(ircaap)*(1.0d0-ratdum(irv1))
-    dfdy(ica40,ihe4) = esum(b,4)
+    dfdy(ica40,ihe4) = esum4(b)
 
     ! d(ca40)/d(ar36)
     b(1) =  y(ihe4) * ratdum(irarag)
@@ -2859,7 +2859,7 @@ contains
     b(2) = -ratdum(ircaga)
     b(3) = -ratdum(ircagp) * ratdum(iru1)
     b(4) = -y(ihe4) * ratdum(ircaap)*(1.0d0-ratdum(irv1))
-    dfdy(ica40,ica40) = esum(b,4)
+    dfdy(ica40,ica40) = esum4(b)
 
     ! d(ca40)/d(ti44)
     b(1) = ratdum(irtiga)
@@ -2873,7 +2873,7 @@ contains
     b(2) = -y(iti44) * ratdum(irtiag)
     b(3) =  y(ica40) * ratdum(ircaap)*(1.0d0-ratdum(irv1))
     b(4) = -y(iti44) * ratdum(irtiap)*(1.0d0-ratdum(irw1))
-    dfdy(iti44,ihe4) = esum(b,4)
+    dfdy(iti44,ihe4) = esum4(b)
 
     ! d(ti44)/d(ca40)
     b(1) =  y(ihe4) * ratdum(ircaag)
@@ -2885,7 +2885,7 @@ contains
     b(2) = -ratdum(irtiga)
     b(3) = -ratdum(irv1) * ratdum(irtigp)
     b(4) = -y(ihe4) * ratdum(irtiap)*(1.0d0-ratdum(irw1))
-    dfdy(iti44,iti44) = esum(b,4)
+    dfdy(iti44,iti44) = esum4(b)
 
     ! d(ti44)/d(cr48)
     b(1) = ratdum(ircrga)
@@ -2899,7 +2899,7 @@ contains
     b(2) = -y(icr48) * ratdum(ircrag)
     b(3) =  y(iti44) * ratdum(irtiap)*(1.0d0-ratdum(irw1))
     b(4) = -y(icr48) * ratdum(ircrap)*(1.0d0-ratdum(irx1))
-    dfdy(icr48,ihe4) = esum(b,4)
+    dfdy(icr48,ihe4) = esum4(b)
 
     ! d(cr48)/d(ti44)
     b(1) =  y(ihe4) * ratdum(irtiag)
@@ -2911,7 +2911,7 @@ contains
     b(2) = -ratdum(ircrga)
     b(3) = -ratdum(irw1) * ratdum(ircrgp)
     b(4) = -y(ihe4) * ratdum(ircrap)*(1.0d0-ratdum(irx1))
-    dfdy(icr48,icr48) = esum(b,4)
+    dfdy(icr48,icr48) = esum4(b)
 
     ! d(cr48)/d(fe52)
     b(1) = ratdum(irfega)
@@ -2936,7 +2936,7 @@ contains
     b(3) =  y(icr48) * ratdum(ircrap) * (1.0d0-ratdum(irx1))
     b(4) = -y(ife52) * ratdum(ir6f54)
     b(5) = -y(ife52) * y(iprot) * ratdum(ir7f54)
-    dfdy(ife52,ihe4) = esum(b,5)
+    dfdy(ife52,ihe4) = esum5(b)
 
     ! d(fe52)/d(cr48)
     b(1) = y(ihe4) * ratdum(ircrag)
@@ -2950,7 +2950,7 @@ contains
     b(4) = -y(ineut) * y(ineut) * ratdum(ir2f54)
     b(5) = -y(ihe4) * ratdum(ir6f54)
     b(6) = -y(ihe4) * y(iprot) * ratdum(ir7f54)
-    dfdy(ife52,ife52) = esum(b,6)
+    dfdy(ife52,ife52) = esum6(b)
 
     ! d(fe52)/d(fe54)
     b(1) = ratdum(ir1f54)
@@ -2966,7 +2966,7 @@ contains
     b(1) =  y(ife54) * dratdumdy1(ir1f54)
     b(2) = -2.0d0 * y(ife52) * y(ineut) * ratdum(ir2f54)
     b(3) = -y(ife52) * y(ineut) * y(ineut) * dratdumdy1(ir2f54)
-    dfdy(ife52,ineut) = esum(b,3)
+    dfdy(ife52,ineut) = esum3(b)
 
     ! d(fe52)/d(prot)
     b(1) =  2.0d0 * y(ife54) * y(iprot) * ratdum(ir5f54)
@@ -2976,7 +2976,7 @@ contains
     b(5) = -y(ife52) * y(ihe4) * y(iprot) * dratdumdy1(ir7f54)
     b(6) =  y(ini56) * ratdum(ir8f54)
     b(7) =  y(ini56) * y(iprot) * dratdumdy1(ir8f54)
-    dfdy(ife52,iprot) = esum(b,7)
+    dfdy(ife52,iprot) = esum7(b)
 
 
 
@@ -2998,7 +2998,7 @@ contains
     b(3) = -y(iprot) * y(iprot) * ratdum(ir5f54)
     b(4) = -y(ineut) * y(ineut) * ratdum(irfe56_aux2)
     b(5) = -y(ihe4) * ratdum(irfe56_aux4)
-    dfdy(ife54,ife54) = esum(b,5)
+    dfdy(ife54,ife54) = esum5(b)
 
     ! d(fe54)/d(fe56)
     b(1) = ratdum(irfe56_aux1)
@@ -3015,7 +3015,7 @@ contains
     b(4) =  y(ife56) * dratdumdy1(irfe56_aux1)
     b(5) = -2.0d0 * y(ife54) * y(ineut) * ratdum(irfe56_aux2)
     b(6) = -y(ife54) * y(ineut) * y(ineut) * dratdumdy1(irfe56_aux2)
-    dfdy(ife54,ineut) = esum(b,6)
+    dfdy(ife54,ineut) = esum6(b)
 
     ! d(fe54)/d(prot)
     b(1) = -2.0d0 * y(ife54) * y(iprot) * ratdum(ir3f54)
@@ -3027,7 +3027,7 @@ contains
     b(7) =  2.0d0 * y(ife56) * y(iprot) * ratdum(irfe56_aux3)
     b(8) =  y(ife56) * y(iprot) * y(iprot) * dratdumdy1(irfe56_aux3)
     b(9) = -y(ihe4) * y(ife54) * dratdumdy1(irfe56_aux4)
-    dfdy(ife54,iprot) = esum(b,9)
+    dfdy(ife54,iprot) = esum9(b)
 
 
     ! fe56 jacobian elements
@@ -3044,7 +3044,7 @@ contains
     b(1) = -1.0d-04 * ratdum(irn56ec)
     b(2) = -ratdum(irfe56_aux1)
     b(3) = -y(iprot) * y(iprot) * ratdum(irfe56_aux3)
-    dfdy(ife56,ife56) = esum(b,3)
+    dfdy(ife56,ife56) = esum3(b)
 
     ! d(fe56)/d(ni56)
     dfdy(ife56,ini56) = ratdum(irn56ec)
@@ -3053,13 +3053,13 @@ contains
     b(1) = -y(ife56) * dratdumdy1(irfe56_aux1)
     b(2) =  2.0d0 * y(ife54) * y(ineut) * ratdum(irfe56_aux2)
     b(3) =  y(ife54) * y(ineut) * y(ineut) * dratdumdy1(irfe56_aux2)
-    dfdy(ife56,ineut) = esum(b,3)
+    dfdy(ife56,ineut) = esum3(b)
 
     ! d(fe56)/d(prot)
     b(1) = -2.0d0 * y(ife56) * y(iprot) * ratdum(irfe56_aux3)
     b(2) = -y(ife56) * y(iprot) * y(iprot) * dratdumdy1(irfe56_aux3)
     b(3) =  y(ihe4) * y(ife54) * dratdumdy1(irfe56_aux4)
-    dfdy(ife56,iprot) = esum(b,3)
+    dfdy(ife56,iprot) = esum3(b)
 
 
 
@@ -3082,7 +3082,7 @@ contains
     b(2) = -ratdum(ir4f54)
     b(3) = -y(iprot) * ratdum(ir8f54)
     b(4) = -ratdum(irn56ec)
-    dfdy(ini56,ini56) = esum(b,4)
+    dfdy(ini56,ini56) = esum4(b)
 
     ! d(ni56)/d(prot)
     b(1) =  2.0d0 * y(ife54) * y(iprot) * ratdum(ir3f54)
@@ -3092,7 +3092,7 @@ contains
     b(5) =  y(ife52) * y(ihe4)* y(iprot) * dratdumdy1(ir7f54)
     b(6) = -y(ini56) * ratdum(ir8f54)
     b(7) = -y(ini56) * y(iprot) * dratdumdy1(ir8f54)
-    dfdy(ini56,iprot) = esum(b,7)
+    dfdy(ini56,iprot) = esum7(b)
 
 
     ! photodisintegration neutron jacobian elements
@@ -3121,14 +3121,14 @@ contains
     b(8)  =  2.0d0 * y(ife56) * dratdumdy1(irfe56_aux1)
     b(9)  = -4.0d0 * y(ife54) * y(ineut) * ratdum(irfe56_aux2)
     b(10) = -2.0d0 * y(ife54) * y(ineut) * y(ineut) * dratdumdy1(irfe56_aux2)
-    dfdy(ineut,ineut) = esum(b,10)
+    dfdy(ineut,ineut) = esum10(b)
 
     ! d(neut)/d(prot)
     b(1) =  2.0d0 * y(ihe4) * dratdumdy2(iralf1)
     b(2) = -4.0d0 * y(ineut)*y(ineut) * y(iprot) * ratdum(iralf2)
     b(3) = -2.0d0 * y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy2(iralf2)
     b(4) =  ratdum(irpen)
-    dfdy(ineut,iprot) = esum(b,4)
+    dfdy(ineut,iprot) = esum4(b)
 
 
     ! photodisintegration proton jacobian elements
@@ -3136,7 +3136,7 @@ contains
     b(1) =  2.0d0 * y(ife52) * ratdum(ir6f54)
     b(2) =  2.0d0 * ratdum(iralf1)
     b(3) =  2.0d0 * y(ife54) * ratdum(irfe56_aux4)
-    dfdy(iprot,ihe4) = esum(b,3)
+    dfdy(iprot,ihe4) = esum3(b)
 
     ! d(prot)/d(fe52)
     dfdy(iprot,ife52) = 2.0d0 * y(ihe4) * ratdum(ir6f54)
@@ -3145,7 +3145,7 @@ contains
     b(1) = -2.0d0 * y(iprot) * y(iprot) * ratdum(ir3f54)
     b(2) = -2.0d0 * y(iprot) * y(iprot) * ratdum(ir5f54)
     b(3) =  2.0d0 * y(ihe4) * ratdum(irfe56_aux4)
-    dfdy(iprot,ife54) = esum(b,3)
+    dfdy(iprot,ife54) = esum3(b)
 
     ! d(prot)/d(fe56)
     dfdy(iprot,ife56) = -2.0d0 * y(iprot) * y(iprot) * ratdum(irfe56_aux3)
@@ -3158,7 +3158,7 @@ contains
     b(2) = -4.0d0 * y(ineut) * y(iprot)*y(iprot) * ratdum(iralf2)
     b(3) = -2.0d0 * y(ineut)*y(ineut) * y(iprot)*y(iprot) * dratdumdy1(iralf2)
     b(4) =  ratdum(irnep)
-    dfdy(iprot,ineut)  = esum(b,4)
+    dfdy(iprot,ineut)  = esum4(b)
 
     ! d(prot)/d(prot)
     b(1)  =  -4.0d0 * y(ife54) * y(iprot) * ratdum(ir3f54)
@@ -3174,7 +3174,7 @@ contains
     b(11) =  -4.0d0 * y(ife56) * y(iprot) * ratdum(irfe56_aux3)
     b(12) =  -2.0d0 * y(ife56) * y(iprot)*y(iprot) * dratdumdy1(irfe56_aux3)
     b(13) =   2.0d0 * y(ihe4) * y(ife54) * dratdumdy1(irfe56_aux4)
-    dfdy(iprot,iprot) = esum(b,13)
+    dfdy(iprot,iprot) = esum13(b)
 
   end subroutine dfdy_isotopes_aprox21
 

--- a/networks/iso7/actual_rhs.f90
+++ b/networks/iso7/actual_rhs.f90
@@ -199,7 +199,7 @@ contains
   subroutine rhs(y, rate, ratdum, dydt, deriva)
 
     use amrex_constants_module, only: ZERO, SIXTH
-    use microphysics_math_module, only: esum
+    use microphysics_math_module, only: esum5, esum6, esum15
 
     implicit none
 
@@ -233,7 +233,7 @@ contains
     a(14) = -7.0d0 * rate(irsi2ni) * y(ihe4)
     a(15) =  7.0d0 * rate(irni2si) * y(ini56)
 
-    dydt(ihe4) = esum(a,15)
+    dydt(ihe4) = esum15(a)
 
     ! 12c reactions
     a(1) =  SIXTH * y(ihe4) * y(ihe4) * y(ihe4) * rate(ir3a)
@@ -243,7 +243,7 @@ contains
     a(5) = -y(ic12) * y(ic12) * rate(ir1212)
     a(6) = -y(ic12) * y(io16) * rate(ir1216)
 
-    dydt(ic12) = esum(a,6)
+    dydt(ic12) = esum6(a)
 
     ! 16o reactions
     a(1) = -y(io16) * rate(iroga)
@@ -253,7 +253,7 @@ contains
     a(5) = -y(io16) * y(ihe4) * rate(iroag)
     a(6) =  y(ine20) * rate(irnega)
 
-    dydt(io16) = esum(a,6)
+    dydt(io16) = esum6(a)
 
     ! 20ne reactions
     a(1) =  0.5d0 * y(ic12) * y(ic12) * rate(ir1212)
@@ -262,7 +262,7 @@ contains
     a(4) =  y(img24) * rate(irmgga)
     a(5) = -y(ine20) * y(ihe4) * rate(irneag)
 
-    dydt(ine20) = esum(a,5)
+    dydt(ine20) = esum5(a)
 
     ! 24mg reactions
     a(1) =  0.5d0 * y(ic12) * y(io16) * rate(ir1216)
@@ -271,7 +271,7 @@ contains
     a(4) =  y(isi28) * rate(irsiga)
     a(5) = -y(img24) * y(ihe4) * rate(irmgag)
 
-    dydt(img24) = esum(a,5)
+    dydt(img24) = esum5(a)
 
     ! 28si reactions
     a(1) =  0.5d0 * y(ic12) * y(io16) * rate(ir1216)
@@ -281,7 +281,7 @@ contains
     a(5) = -rate(irsi2ni) * y(ihe4)
     a(6) =  rate(irni2si) * y(ini56)
 
-    dydt(isi28) = esum(a,6)
+    dydt(isi28) = esum6(a)
 
     ! ni56 reactions
     a(1) =  rate(irsi2ni) * y(ihe4)
@@ -617,7 +617,7 @@ contains
   subroutine dfdy_isotopes_iso7(y,dfdy,ratdum,dratdumdy1,dratdumdy2)
 
     use network
-    use microphysics_math_module, only: esum
+    use microphysics_math_module, only: esum3, esum4, esum8
 
     implicit none
 
@@ -640,7 +640,7 @@ contains
     b(7) = -7.0d0 * dratdumdy1(irsi2ni) * y(ihe4)
     b(8) =  7.0d0 * dratdumdy1(irni2si) * y(ini56)
 
-    dfdy(ihe4,ihe4) = esum(b,8)
+    dfdy(ihe4,ihe4) = esum8(b)
 
     ! d(he4)/d(c12)
     b(1) =  3.0d0 * ratdum(irg3a)
@@ -648,7 +648,7 @@ contains
     b(3) =  y(ic12) * ratdum(ir1212)
     b(4) =  0.5d0 * y(io16) * ratdum(ir1216)
 
-    dfdy(ihe4,ic12) = esum(b,4)
+    dfdy(ihe4,ic12) = esum4(b)
 
     ! d(he4)/d(o16)
     b(1) =  ratdum(iroga)
@@ -656,7 +656,7 @@ contains
     b(3) =  y(io16) * ratdum(ir1616)
     b(4) = -y(ihe4) * ratdum(iroag)
 
-    dfdy(ihe4,io16) = esum(b,4)
+    dfdy(ihe4,io16) = esum4(b)
 
     ! d(he4)/d(ne20)
     b(1) =  ratdum(irnega)
@@ -696,7 +696,7 @@ contains
     b(3) = -2.0d0 * y(ic12) * ratdum(ir1212)
     b(4) = -y(io16) * ratdum(ir1216)
 
-    dfdy(ic12,ic12) = esum(b,4)
+    dfdy(ic12,ic12) = esum4(b)
 
     ! d(c12)/d(o16)
     b(1) =  ratdum(iroga)
@@ -724,7 +724,7 @@ contains
     b(3) = -2.0d0 * y(io16) * ratdum(ir1616)
     b(4) = -y(ihe4) * ratdum(iroag)
 
-    dfdy(io16,io16) = esum(b,4)
+    dfdy(io16,io16) = esum4(b)
 
     ! d(o16)/d(ne20)
     b(1) =  ratdum(irnega)
@@ -801,7 +801,7 @@ contains
     b(3) = -dratdumdy1(irsi2ni) * y(ihe4)
     b(4) =  dratdumdy1(irni2si) * y(ini56)
 
-    dfdy(isi28,ihe4) = esum(b,4)
+    dfdy(isi28,ihe4) = esum4(b)
 
     ! d(si28)/d(c12)
     b(1) =  0.5d0 * y(io16) * ratdum(ir1216)
@@ -836,7 +836,7 @@ contains
     b(2) =  dratdumdy1(irsi2ni) * y(ihe4)
     b(3) = -dratdumdy1(irni2si) * y(ini56)
 
-    dfdy(ini56,ihe4) = esum(b,3)
+    dfdy(ini56,ihe4) = esum3(b)
 
     ! d(ni56)/d(si28)
     b(1) = dratdumdy2(irsi2ni) * y(ihe4)

--- a/util/BLAS/GPackage.mak
+++ b/util/BLAS/GPackage.mak
@@ -4,3 +4,5 @@ fsources += dcopy.f
 fsources += dscal.f
 fsources += idamax.f
 fsources += dgemm.f
+F90sources += blas_module.F90
+

--- a/util/BLAS/Make.package
+++ b/util/BLAS/Make.package
@@ -4,3 +4,4 @@ fEXE_sources += dcopy.f
 fEXE_sources += dscal.f
 fEXE_sources += idamax.f
 fEXE_sources += dgemm.f
+F90EXE_sources += blas_module.F90

--- a/util/BLAS/blas_module.F90
+++ b/util/BLAS/blas_module.F90
@@ -1,0 +1,805 @@
+module blas_module
+
+  implicit none
+
+contains
+
+  AMREX_DEVICE SUBROUTINE DCOPYN(N,DX,INCX,DY,INCY)
+
+  ! Only operates on vectors of size N
+
+    INTEGER INCX,INCY,N
+    DOUBLE PRECISION DX(N),DY(N)
+! *  Purpose
+! *  =======
+! *
+! *     copies a vector, x, to a vector, y.
+! *     uses unrolled loops for increments equal to one.
+! *     jack dongarra, linpack, 3/11/78.
+! *     modified 12/3/93, array(1) declarations changed to array(*)
+    INTEGER I,IX,IY,M,MP1
+
+    IF (N.LE.0) RETURN
+    IF (INCX.EQ.1 .AND. INCY.EQ.1) GO TO 20
+
+    ! code for unequal increments or equal increments
+    ! not equal to 1
+
+    IX = 1
+    IY = 1
+    IF (INCX.LT.0) IX = (-N+1)*INCX + 1
+    IF (INCY.LT.0) IY = (-N+1)*INCY + 1
+    DO I = 1,N
+       DY(IY) = DX(IX)
+       IX = IX + INCX
+       IY = IY + INCY
+    end do
+    RETURN
+
+    ! code for both increments equal to 1
+
+    ! clean-up loop
+
+20  M = MOD(N,7)
+    IF (M.EQ.0) GO TO 40
+    DO I = 1,M
+       DY(I) = DX(I)
+    end do
+    IF (N.LT.7) RETURN
+40  MP1 = M + 1
+    DO I = MP1,N,7
+       DY(I) = DX(I)
+       DY(I+1) = DX(I+1)
+       DY(I+2) = DX(I+2)
+       DY(I+3) = DX(I+3)
+       DY(I+4) = DX(I+4)
+       DY(I+5) = DX(I+5)
+       DY(I+6) = DX(I+6)
+    end do
+    RETURN
+  end SUBROUTINE DCOPYN
+
+  
+  AMREX_DEVICE SUBROUTINE DCOPY(N,DX,INCX,DY,INCY)
+    INTEGER INCX,INCY,N
+    DOUBLE PRECISION DX(:),DY(:)
+! *  Purpose
+! *  =======
+! *
+! *     copies a vector, x, to a vector, y.
+! *     uses unrolled loops for increments equal to one.
+! *     jack dongarra, linpack, 3/11/78.
+! *     modified 12/3/93, array(1) declarations changed to array(*)
+    INTEGER I,IX,IY,M,MP1
+
+    IF (N.LE.0) RETURN
+    IF (INCX.EQ.1 .AND. INCY.EQ.1) GO TO 20
+
+    ! code for unequal increments or equal increments
+    ! not equal to 1
+
+    IX = 1
+    IY = 1
+    IF (INCX.LT.0) IX = (-N+1)*INCX + 1
+    IF (INCY.LT.0) IY = (-N+1)*INCY + 1
+    DO I = 1,N
+       DY(IY) = DX(IX)
+       IX = IX + INCX
+       IY = IY + INCY
+    end do
+    RETURN
+
+    ! code for both increments equal to 1
+
+    ! clean-up loop
+
+20  M = MOD(N,7)
+    IF (M.EQ.0) GO TO 40
+    DO I = 1,M
+       DY(I) = DX(I)
+    end do
+    IF (N.LT.7) RETURN
+40  MP1 = M + 1
+    DO I = MP1,N,7
+       DY(I) = DX(I)
+       DY(I+1) = DX(I+1)
+       DY(I+2) = DX(I+2)
+       DY(I+3) = DX(I+3)
+       DY(I+4) = DX(I+4)
+       DY(I+5) = DX(I+5)
+       DY(I+6) = DX(I+6)
+    end do
+    RETURN
+  end SUBROUTINE DCOPY
+
+
+  AMREX_DEVICE SUBROUTINE DAXPYN(N,DA,DX,INCX,DY,INCY)
+
+  ! Only operates on vectors of size N
+
+    !$acc routine seq
+    !     .. Scalar Arguments ..
+    DOUBLE PRECISION DA
+    INTEGER INCX,INCY,N
+    !     ..
+    !     .. Array Arguments ..
+    DOUBLE PRECISION DX(N),DY(N)
+    !     ..
+    !
+    !  Purpose
+    !   =======
+    ! 
+    !      constant times a vector plus a vector.
+    !      uses unrolled loops for increments equal to one.
+    !      jack dongarra, linpack, 3/11/78.
+    !      modified 12/3/93, array(1) declarations changed to array(*)
+    ! 
+    ! 
+    !      .. Local Scalars ..
+    INTEGER I,IX,IY,M,MP1
+
+    IF (N.LE.0) RETURN
+    IF (DA.EQ.0.0d0) RETURN
+    IF (INCX.EQ.1 .AND. INCY.EQ.1) GO TO 20
+    ! 
+    !         code for unequal increments or equal increments
+    !           not equal to 1
+    ! 
+    IX = 1
+    IY = 1
+    IF (INCX.LT.0) IX = (-N+1)*INCX + 1
+    IF (INCY.LT.0) IY = (-N+1)*INCY + 1
+    DO I = 1,N
+       DY(IY) = DY(IY) + DA*DX(IX)
+       IX = IX + INCX
+       IY = IY + INCY
+    end do
+    RETURN
+    ! 
+    !         code for both increments equal to 1
+    ! 
+    ! 
+    !         clean-up loop
+    ! 
+20  M = MOD(N,4)
+    IF (M.EQ.0) GO TO 40
+    DO I = 1,M
+       DY(I) = DY(I) + DA*DX(I)
+    end do
+    IF (N.LT.4) RETURN
+40  MP1 = M + 1
+    DO I = MP1,N,4
+       DY(I) = DY(I) + DA*DX(I)
+       DY(I+1) = DY(I+1) + DA*DX(I+1)
+       DY(I+2) = DY(I+2) + DA*DX(I+2)
+       DY(I+3) = DY(I+3) + DA*DX(I+3)
+    end do
+    RETURN
+  END SUBROUTINE DAXPYN
+
+  
+  AMREX_DEVICE SUBROUTINE DAXPY(N,DA,DX,INCX,DY,INCY)
+    !$acc routine seq
+    !     .. Scalar Arguments ..
+    DOUBLE PRECISION DA
+    INTEGER INCX,INCY,N
+    !     ..
+    !     .. Array Arguments ..
+    DOUBLE PRECISION DX(:),DY(:)
+    !     ..
+    !
+    !  Purpose
+    !   =======
+    ! 
+    !      constant times a vector plus a vector.
+    !      uses unrolled loops for increments equal to one.
+    !      jack dongarra, linpack, 3/11/78.
+    !      modified 12/3/93, array(1) declarations changed to array(*)
+    ! 
+    ! 
+    !      .. Local Scalars ..
+    INTEGER I,IX,IY,M,MP1
+
+    IF (N.LE.0) RETURN
+    IF (DA.EQ.0.0d0) RETURN
+    IF (INCX.EQ.1 .AND. INCY.EQ.1) GO TO 20
+    ! 
+    !         code for unequal increments or equal increments
+    !           not equal to 1
+    ! 
+    IX = 1
+    IY = 1
+    IF (INCX.LT.0) IX = (-N+1)*INCX + 1
+    IF (INCY.LT.0) IY = (-N+1)*INCY + 1
+    DO I = 1,N
+       DY(IY) = DY(IY) + DA*DX(IX)
+       IX = IX + INCX
+       IY = IY + INCY
+    end do
+    RETURN
+    ! 
+    !         code for both increments equal to 1
+    ! 
+    ! 
+    !         clean-up loop
+    ! 
+20  M = MOD(N,4)
+    IF (M.EQ.0) GO TO 40
+    DO I = 1,M
+       DY(I) = DY(I) + DA*DX(I)
+    end do
+    IF (N.LT.4) RETURN
+40  MP1 = M + 1
+    DO I = MP1,N,4
+       DY(I) = DY(I) + DA*DX(I)
+       DY(I+1) = DY(I+1) + DA*DX(I+1)
+       DY(I+2) = DY(I+2) + DA*DX(I+2)
+       DY(I+3) = DY(I+3) + DA*DX(I+3)
+    end do
+    RETURN
+  END SUBROUTINE DAXPY
+
+
+  AMREX_DEVICE FUNCTION DDOT(N,DX,INCX,DY,INCY) result(dotval)
+    DOUBLE PRECISION dotval
+    !      .. Scalar Arguments ..
+    INTEGER INCX,INCY,N
+    !      ..
+    !      .. Array Arguments ..
+    DOUBLE PRECISION DX(:),DY(:)
+    !      ..
+    ! 
+    !   Purpose
+    !   =======
+    ! 
+    !      forms the dot product of two vectors.
+    !      uses unrolled loops for increments equal to one.
+    !      jack dongarra, linpack, 3/11/78.
+    !      modified 12/3/93, array(1) declarations changed to array(*)
+    ! 
+    ! 
+    !      .. Local Scalars ..
+    DOUBLE PRECISION DTEMP
+    INTEGER I,IX,IY,M,MP1
+
+    dotval = 0.0d0
+    DTEMP = 0.0d0
+    IF (N.LE.0) RETURN
+    IF (INCX.EQ.1 .AND. INCY.EQ.1) GO TO 20
+    ! 
+    !         code for unequal increments or equal increments
+    !           not equal to 1
+    ! 
+    IX = 1
+    IY = 1
+    IF (INCX.LT.0) IX = (-N+1)*INCX + 1
+    IF (INCY.LT.0) IY = (-N+1)*INCY + 1
+    DO I = 1,N
+       DTEMP = DTEMP + DX(IX)*DY(IY)
+       IX = IX + INCX
+       IY = IY + INCY
+    end do
+    dotval = DTEMP
+    RETURN
+    ! 
+    !         code for both increments equal to 1
+    ! 
+    ! 
+    !         clean-up loop
+    ! 
+20  M = MOD(N,5)
+    IF (M.EQ.0) GO TO 40
+    DO I = 1,M
+       DTEMP = DTEMP + DX(I)*DY(I)
+    end do
+    IF (N.LT.5) GO TO 60
+40  MP1 = M + 1
+    DO I = MP1,N,5
+       DTEMP = DTEMP + DX(I)*DY(I) + DX(I+1)*DY(I+1) + &
+            DX(I+2)*DY(I+2) + DX(I+3)*DY(I+3) + DX(I+4)*DY(I+4)
+    end do
+60  dotval = DTEMP
+    RETURN
+  END FUNCTION DDOT
+
+  AMREX_DEVICE SUBROUTINE DGEMM(TRANSA,TRANSB,M,N,K,ALPHA,A,LDA,B,LDB,BETA,C,LDC)
+    !$acc routine seq
+    !      .. Scalar Arguments ..
+    DOUBLE PRECISION ALPHA,BETA
+    INTEGER K,LDA,LDB,LDC,M,N
+    ! !      CHARACTER TRANSA,TRANSB
+    INTEGER TRANSA,TRANSB
+    !      ..
+    !      .. Array Arguments ..
+    DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
+    !      ..
+    ! 
+    !   Purpose
+    !   =======
+    ! 
+    !   DGEMM  performs one of the matrix-matrix operations
+    ! 
+    !      C := alpha*op( A )*op( B ) + beta*C,
+    ! 
+    !   where  op( X ) is one of
+    ! 
+    !      op( X ) = X   or   op( X ) = X**T,
+    ! 
+    !   alpha and beta are scalars, and A, B and C are matrices, with op( A )
+    !   an m by k matrix,  op( B )  a  k by n matrix and  C an m by n matrix.
+    ! 
+    !   Arguments
+    !   ==========
+    ! 
+    !   TRANSA - CHARACTER*1.
+    !            On entry, TRANSA specifies the form of op( A ) to be used in
+    !            the matrix multiplication as follows:
+    ! 
+    !               TRANSA = 1 --> 'N' or 'n',  op( A ) = A.
+    ! 
+    !               TRANSA = 2 --> 'T' or 't',  op( A ) = A**T.
+    ! 
+    !               TRANSA = 3 --> 'C' or 'c',  op( A ) = A**T.
+    ! 
+    !            Unchanged on exit.
+    ! 
+    !   TRANSB - CHARACTER*1.
+    !            On entry, TRANSB specifies the form of op( B ) to be used in
+    !            the matrix multiplication as follows:
+    ! 
+    !               TRANSB = 1 --> 'N' or 'n',  op( B ) = B.
+    !                              
+    !               TRANSB = 2 --> 'T' or 't',  op( B ) = B**T.
+    !                              
+    !               TRANSB = 3 --> 'C' or 'c',  op( B ) = B**T.
+    ! 
+    !            Unchanged on exit.
+    ! 
+    !   M      - INTEGER.
+    !            On entry,  M  specifies  the number  of rows  of the  matrix
+    !            op( A )  and of the  matrix  C.  M  must  be at least  zero.
+    !            Unchanged on exit.
+    ! 
+    !   N      - INTEGER.
+    !            On entry,  N  specifies the number  of columns of the matrix
+    !            op( B ) and the number of columns of the matrix C. N must be
+    !            at least zero.
+    !            Unchanged on exit.
+    ! 
+    !   K      - INTEGER.
+    !            On entry,  K  specifies  the number of columns of the matrix
+    !            op( A ) and the number of rows of the matrix op( B ). K must
+    !            be at least  zero.
+    !            Unchanged on exit.
+    ! 
+    !   ALPHA  - DOUBLE PRECISION.
+    !            On entry, ALPHA specifies the scalar alpha.
+    !            Unchanged on exit.
+    ! 
+    !   A      - DOUBLE PRECISION array of DIMENSION ( LDA, ka ), where ka is
+    !            k  when  TRANSA = 'N' or 'n',  and is  m  otherwise.
+    !            Before entry with  TRANSA = 'N' or 'n',  the leading  m by k
+    !            part of the array  A  must contain the matrix  A,  otherwise
+    !            the leading  k by m  part of the array  A  must contain  the
+    !            matrix A.
+    !            Unchanged on exit.
+    ! 
+    !   LDA    - INTEGER.
+    !            On entry, LDA specifies the first dimension of A as declared
+    !            in the calling (sub) program. When  TRANSA = 'N' or 'n' then
+    !            LDA must be at least  max( 1, m ), otherwise  LDA must be at
+    !            least  max( 1, k ).
+    !            Unchanged on exit.
+    ! 
+    !   B      - DOUBLE PRECISION array of DIMENSION ( LDB, kb ), where kb is
+    !            n  when  TRANSB = 'N' or 'n',  and is  k  otherwise.
+    !            Before entry with  TRANSB = 'N' or 'n',  the leading  k by n
+    !            part of the array  B  must contain the matrix  B,  otherwise
+    !            the leading  n by k  part of the array  B  must contain  the
+    !            matrix B.
+    !            Unchanged on exit.
+    ! 
+    !   LDB    - INTEGER.
+    !            On entry, LDB specifies the first dimension of B as declared
+    !            in the calling (sub) program. When  TRANSB = 'N' or 'n' then
+    !            LDB must be at least  max( 1, k ), otherwise  LDB must be at
+    !            least  max( 1, n ).
+    !            Unchanged on exit.
+    ! 
+    !   BETA   - DOUBLE PRECISION.
+    !            On entry,  BETA  specifies the scalar  beta.  When  BETA  is
+    !            supplied as zero then C need not be set on input.
+    !            Unchanged on exit.
+    ! 
+    !   C      - DOUBLE PRECISION array of DIMENSION ( LDC, n ).
+    !            Before entry, the leading  m by n  part of the array  C must
+    !            contain the matrix  C,  except when  beta  is zero, in which
+    !            case C need not be set on entry.
+    !            On exit, the array  C  is overwritten by the  m by n  matrix
+    !            ( alpha*op( A )*op( B ) + beta*C ).
+    ! 
+    !   LDC    - INTEGER.
+    !            On entry, LDC specifies the first dimension of C as declared
+    !            in  the  calling  (sub)  program.   LDC  must  be  at  least
+    !            max( 1, m ).
+    !            Unchanged on exit.
+    ! 
+    !   Further Details
+    !   ===============
+    ! 
+    !   Level 3 Blas routine.
+    ! 
+    !   -- Written on 8-February-1989.
+    !      Jack Dongarra, Argonne National Laboratory.
+    !      Iain Duff, AERE Harwell.
+    !      Jeremy Du Croz, Numerical Algorithms Group Ltd.
+    !      Sven Hammarling, Numerical Algorithms Group Ltd.
+    ! 
+    !   =====================================================================
+    ! 
+    !      .. External Functions ..
+    ! LOGICAL LSAME
+    ! EXTERNAL LSAME
+    !      ..
+    !      .. External Subroutines ..
+    ! EXTERNAL XERBLA
+    !      ..
+    !      .. Local Scalars ..
+    DOUBLE PRECISION TEMP
+    INTEGER I,INFO,J,L,NCOLA,NROWA,NROWB
+    LOGICAL NOTA,NOTB
+    !      ..
+    !      .. Parameters ..
+    DOUBLE PRECISION ONE,ZERO
+    PARAMETER (ONE=1.0D+0,ZERO=0.0D+0)
+    !      ..
+    ! 
+    !      Set  NOTA  and  NOTB  as  true if  A  and  B  respectively are not
+    !      transposed and set  NROWA, NCOLA and  NROWB  as the number of rows
+    !      and  columns of  A  and the  number of  rows  of  B  respectively.
+    ! 
+    ! !      NOTA = LSAME(TRANSA,'N')
+    NOTA = TRANSA == 1
+    ! !      NOTB = LSAME(TRANSB,'N')
+    NOTB = TRANSB == 1
+    IF (NOTA) THEN
+       NROWA = M
+       NCOLA = K
+    ELSE
+       NROWA = K
+       NCOLA = M
+    END IF
+    IF (NOTB) THEN
+       NROWB = K
+    ELSE
+       NROWB = N
+    END IF
+    ! 
+    !      Test the input parameters.
+    ! 
+    INFO = 0
+    ! !      IF ((.NOT.NOTA) .AND. (.NOT.LSAME(TRANSA,'C')) .AND. &
+    ! !         (.NOT.LSAME(TRANSA,'T'))) THEN
+    IF ((.NOT.NOTA) .AND. (.NOT.TRANSA==3) .AND. &
+         (.NOT.TRANSA==2)) THEN
+       INFO = 1
+       ! !      ELSE IF ((.NOT.NOTB) .AND. (.NOT.LSAME(TRANSB,'C')) .AND. &
+       ! !              (.NOT.LSAME(TRANSB,'T'))) THEN
+    ELSE IF ((.NOT.NOTB) .AND. (.NOT.TRANSB==3) .AND. &
+         (.NOT.TRANSB==2)) THEN
+       INFO = 2
+    ELSE IF (M.LT.0) THEN
+       INFO = 3
+    ELSE IF (N.LT.0) THEN
+       INFO = 4
+    ELSE IF (K.LT.0) THEN
+       INFO = 5
+    ELSE IF (LDA.LT.MAX(1,NROWA)) THEN
+       INFO = 8
+    ELSE IF (LDB.LT.MAX(1,NROWB)) THEN
+       INFO = 10
+    ELSE IF (LDC.LT.MAX(1,M)) THEN
+       INFO = 13
+    END IF
+    !IF (INFO.NE.0) THEN
+    !    CALL XERBLA('DGEMM ',INFO)
+    !    RETURN
+    !END IF
+    ! 
+    !      Quick return if possible.
+    ! 
+    IF ((M.EQ.0) .OR. (N.EQ.0) .OR. &
+         (((ALPHA.EQ.ZERO).OR. (K.EQ.0)).AND. (BETA.EQ.ONE))) RETURN
+    ! 
+    !      And if  alpha.eq.zero.
+    ! 
+    IF (ALPHA.EQ.ZERO) THEN
+       IF (BETA.EQ.ZERO) THEN
+          DO J = 1,N
+             DO I = 1,M
+                C(I,J) = ZERO
+             end do
+          end do
+       ELSE
+          DO J = 1,N
+             DO I = 1,M
+                C(I,J) = BETA*C(I,J)
+             end do
+          end do
+       END IF
+       RETURN
+    END IF
+    ! 
+    !      Start the operations.
+    ! 
+    IF (NOTB) THEN
+       IF (NOTA) THEN
+          ! 
+          !            Form  C := alpha*A*B + beta*C.
+          ! 
+          DO J = 1,N
+             IF (BETA.EQ.ZERO) THEN
+                DO I = 1,M
+                   C(I,J) = ZERO
+                end do
+             ELSE IF (BETA.NE.ONE) THEN
+                DO I = 1,M
+                   C(I,J) = BETA*C(I,J)
+                end do
+             END IF
+             DO L = 1,K
+                IF (B(L,J).NE.ZERO) THEN
+                   TEMP = ALPHA*B(L,J)
+                   DO I = 1,M
+                      C(I,J) = C(I,J) + TEMP*A(I,L)
+                   end do
+                END IF
+             end do
+          end do
+       ELSE
+          ! 
+          !            Form  C := alpha*A**T*B + beta*C
+          ! 
+          DO J = 1,N
+             DO I = 1,M
+                TEMP = ZERO
+                DO L = 1,K
+                   TEMP = TEMP + A(L,I)*B(L,J)
+                end do
+                IF (BETA.EQ.ZERO) THEN
+                   C(I,J) = ALPHA*TEMP
+                ELSE
+                   C(I,J) = ALPHA*TEMP + BETA*C(I,J)
+                END IF
+             end do
+          end do
+       END IF
+    ELSE
+       IF (NOTA) THEN
+          ! 
+          !            Form  C := alpha*A*B**T + beta*C
+          ! 
+          DO J = 1,N
+             IF (BETA.EQ.ZERO) THEN
+                DO I = 1,M
+                   C(I,J) = ZERO
+                end do
+             ELSE IF (BETA.NE.ONE) THEN
+                DO I = 1,M
+                   C(I,J) = BETA*C(I,J)
+                end do
+             END IF
+             DO L = 1,K
+                IF (B(J,L).NE.ZERO) THEN
+                   TEMP = ALPHA*B(J,L)
+                   DO I = 1,M
+                      C(I,J) = C(I,J) + TEMP*A(I,L)
+                   end do
+                END IF
+             end do
+          end do
+       ELSE
+          ! 
+          !            Form  C := alpha*A**T*B**T + beta*C
+          ! 
+          DO J = 1,N
+             DO I = 1,M
+                TEMP = ZERO
+                DO L = 1,K
+                   TEMP = TEMP + A(L,I)*B(J,L)
+                end do
+                IF (BETA.EQ.ZERO) THEN
+                   C(I,J) = ALPHA*TEMP
+                ELSE
+                   C(I,J) = ALPHA*TEMP + BETA*C(I,J)
+                END IF
+             end do
+          end do
+       END IF
+    END IF
+    ! 
+    RETURN
+    ! 
+    !      End of DGEMM .
+    ! 
+  end SUBROUTINE DGEMM
+
+
+  AMREX_DEVICE SUBROUTINE DSCALN(N,DA,DX,INCX)
+
+  ! Only operates on vectors of size N
+
+    !$acc routine seq
+    !      .. Scalar Arguments ..
+    DOUBLE PRECISION DA
+    INTEGER INCX,N
+    !      ..
+    !      .. Array Arguments ..
+    DOUBLE PRECISION DX(N)
+    !      ..
+    ! 
+    !   Purpose
+    !   =======
+    ! *
+    !      scales a vector by a constant.
+    !      uses unrolled loops for increment equal to one.
+    !      jack dongarra, linpack, 3/11/78.
+    !      modified 3/93 to return if incx .le. 0.
+    !      modified 12/3/93, array(1) declarations changed to array(*)
+    ! 
+    ! 
+    !      .. Local Scalars ..
+    INTEGER I,M,MP1,NINCX
+    !      ..
+    !      .. Intrinsic Functions ..
+    INTRINSIC MOD
+    !      ..
+    IF (N.LE.0 .OR. INCX.LE.0) RETURN
+    IF (INCX.EQ.1) GO TO 20
+    ! 
+    !         code for increment not equal to 1
+    ! 
+    NINCX = N*INCX
+    DO I = 1,NINCX,INCX
+       DX(I) = DA*DX(I)
+    end do
+    RETURN
+    ! 
+    !         code for increment equal to 1
+    ! 
+    ! 
+    !         clean-up loop
+    ! 
+20  M = MOD(N,5)
+    IF (M.EQ.0) GO TO 40
+    DO I = 1,M
+       DX(I) = DA*DX(I)
+    end do
+    IF (N.LT.5) RETURN
+40  MP1 = M + 1
+    DO I = MP1,N,5
+       DX(I) = DA*DX(I)
+       DX(I+1) = DA*DX(I+1)
+       DX(I+2) = DA*DX(I+2)
+       DX(I+3) = DA*DX(I+3)
+       DX(I+4) = DA*DX(I+4)
+    end do
+    RETURN
+  END SUBROUTINE DSCALN
+
+  
+  AMREX_DEVICE SUBROUTINE DSCAL(N,DA,DX,INCX)
+    !$acc routine seq
+    !      .. Scalar Arguments ..
+    DOUBLE PRECISION DA
+    INTEGER INCX,N
+    !      ..
+    !      .. Array Arguments ..
+    DOUBLE PRECISION DX(:)
+    !      ..
+    ! 
+    !   Purpose
+    !   =======
+    ! *
+    !      scales a vector by a constant.
+    !      uses unrolled loops for increment equal to one.
+    !      jack dongarra, linpack, 3/11/78.
+    !      modified 3/93 to return if incx .le. 0.
+    !      modified 12/3/93, array(1) declarations changed to array(*)
+    ! 
+    ! 
+    !      .. Local Scalars ..
+    INTEGER I,M,MP1,NINCX
+    !      ..
+    !      .. Intrinsic Functions ..
+    INTRINSIC MOD
+    !      ..
+    IF (N.LE.0 .OR. INCX.LE.0) RETURN
+    IF (INCX.EQ.1) GO TO 20
+    ! 
+    !         code for increment not equal to 1
+    ! 
+    NINCX = N*INCX
+    DO I = 1,NINCX,INCX
+       DX(I) = DA*DX(I)
+    end do
+    RETURN
+    ! 
+    !         code for increment equal to 1
+    ! 
+    ! 
+    !         clean-up loop
+    ! 
+20  M = MOD(N,5)
+    IF (M.EQ.0) GO TO 40
+    DO I = 1,M
+       DX(I) = DA*DX(I)
+    end do
+    IF (N.LT.5) RETURN
+40  MP1 = M + 1
+    DO I = MP1,N,5
+       DX(I) = DA*DX(I)
+       DX(I+1) = DA*DX(I+1)
+       DX(I+2) = DA*DX(I+2)
+       DX(I+3) = DA*DX(I+3)
+       DX(I+4) = DA*DX(I+4)
+    end do
+    RETURN
+  END SUBROUTINE DSCAL
+
+  AMREX_DEVICE INTEGER FUNCTION IDAMAX(N,DX,INCX)
+    !$acc routine seq
+    !      .. Scalar Arguments ..
+    INTEGER INCX,N
+    !      ..
+    !      .. Array Arguments ..
+    DOUBLE PRECISION DX(:)
+    !      ..
+    ! 
+    !   Purpose
+    !   =======
+    ! 
+    !      finds the index of element having max. absolute value.
+    !      jack dongarra, linpack, 3/11/78.
+    !      modified 3/93 to return if incx .le. 0.
+    !      modified 12/3/93, array(1) declarations changed to array(*)
+    ! 
+    ! 
+    !      .. Local Scalars ..
+    DOUBLE PRECISION DMAX
+    INTEGER I,IX
+    !      ..
+    !      .. Intrinsic Functions ..
+    INTRINSIC DABS
+    !      ..
+    IDAMAX = 0
+    IF (N.LT.1 .OR. INCX.LE.0) RETURN
+    IDAMAX = 1
+    IF (N.EQ.1) RETURN
+    IF (INCX.EQ.1) GO TO 20
+    ! 
+    !         code for increment not equal to 1
+    ! 
+    IX = 1
+    DMAX = DABS(DX(1))
+    IX = IX + INCX
+    DO I = 2,N
+       IF (DABS(DX(IX)).LE.DMAX) GO TO 5
+       IDAMAX = I
+       DMAX = DABS(DX(IX))
+5      IX = IX + INCX
+    end do
+    RETURN
+    ! 
+    !         code for increment equal to 1
+    ! 
+20  DMAX = DABS(DX(1))
+    DO I = 2,N
+       IF (DABS(DX(I)).LE.DMAX) cycle
+       IDAMAX = I
+       DMAX = DABS(DX(I))
+    end do
+    RETURN
+  END FUNCTION IDAMAX
+  
+end module blas_module

--- a/util/LINPACK/GPackage.mak
+++ b/util/LINPACK/GPackage.mak
@@ -3,3 +3,4 @@ fsources += dgefa.f
 fsources += dgesl.f
 fsources += dgbfa.f
 fsources += dgbsl.f
+F90sources += linpack_module.F90

--- a/util/LINPACK/Make.package
+++ b/util/LINPACK/Make.package
@@ -3,3 +3,4 @@ fEXE_sources += dgesl.f
 fEXE_sources += dgbsl.f
 fEXE_sources += dgbfa.f
 fEXE_sources += vddot.f
+F90EXE_sources += linpack_module.F90

--- a/util/LINPACK/linpack_module.F90
+++ b/util/LINPACK/linpack_module.F90
@@ -1,0 +1,627 @@
+module linpack_module
+
+  use blas_module
+  
+  implicit none
+  
+contains
+  
+  AMREX_DEVICE subroutine dgesl (a,lda,n,ipvt,b,job)
+
+    !$acc routine seq
+    !$acc routine(daxpy) seq
+    !$acc routine(vddot) seq
+
+    integer lda,n,ipvt(:),job
+    double precision a(lda,n),b(:)
+    ! 
+    !      dgesl solves the double precision system
+    !      a * x = b  or  trans(a) * x = b
+    !      using the factors computed by dgeco or dgefa.
+    ! 
+    !      on entry
+    ! 
+    !         a       double precision(lda, n)
+    !                 the output from dgeco or dgefa.
+    ! 
+    !         lda     integer
+    !                 the leading dimension of the array  a .
+    ! 
+    !         n       integer
+    !                 the order of the matrix  a .
+    ! 
+    !         ipvt    integer(n)
+    !                 the pivot vector from dgeco or dgefa.
+    ! 
+    !         b       double precision(n)
+    !                 the right hand side vector.
+    ! 
+    !         job     integer
+    !                 = 0         to solve  a*x = b ,
+    !                 = nonzero   to solve  trans(a)*x = b  where
+    !                             trans(a)  is the transpose.
+    ! 
+    !      on return
+    ! 
+    !         b       the solution vector  x .
+    ! 
+    !      error condition
+    ! 
+    !         a division by zero will occur if the input factor contains a
+    !         zero on the diagonal.  technically this indicates singularity
+    !         but it is often caused by improper arguments or improper
+    !         setting of lda .  it will not occur if the subroutines are
+    !         called correctly and if dgeco has set rcond .gt. 0.0
+    !         or dgefa has set info .eq. 0 .
+    ! 
+    !      to compute  inverse(a) * c  where  c  is a matrix
+    !      with  p  columns
+    !            call dgeco(a,lda,n,ipvt,rcond,z)
+    !            if (rcond is too small) go to ...
+    !            do 10 j = 1, p
+    !               call dgesl(a,lda,n,ipvt,c(1,j),0)
+    !         10 continue
+    ! 
+    !      linpack. this version dated 08/14/78 .
+    !      cleve moler, university of new mexico, argonne national lab.
+    ! 
+    !      subroutines and functions
+    ! 
+    !      blas vdaxpy,vddot
+    ! 
+    !      internal variables
+    ! 
+    double precision t
+    integer k,kb,l,nm1
+    ! 
+    nm1 = n - 1
+    if (job .ne. 0) goto 50
+    ! 
+    !         job = 0 , solve  a * x = b
+    !         first solve  l*y = b
+    ! 
+    if (nm1 .lt. 1) goto 30
+    do k = 1, nm1
+       l = ipvt(k)
+       t = b(l)
+       if (l .eq. k) goto 10
+       b(l) = b(k)
+       b(k) = t
+10     continue
+       call daxpy(n-k,t,a(k+1:n,k),1,b(k+1:n),1)
+    enddo
+30  continue
+    ! 
+    !         now solve  u*x = y
+    ! 
+    do kb = 1, n
+       k = n + 1 - kb
+       b(k) = b(k)/a(k,k)
+       t = -b(k)
+       call daxpy(k-1,t,a(1:k-1,k),1,b(1:k-1),1)
+    enddo
+    go to 100
+50  continue
+    ! 
+    !         job = nonzero, solve  trans(a) * x = b
+    !         first solve  trans(u)*y = b
+    ! 
+    do k = 1, n
+       t = vddot(k-1,a(1:k-1,k),1,b(1:k-1),1)
+       b(k) = (b(k) - t)/a(k,k)
+    enddo
+    ! 
+    !         now solve trans(l)*x = y
+    ! 
+    if (nm1 .lt. 1) goto 90
+    do kb = 1, nm1
+       k = n - kb
+       b(k) = b(k) + vddot(n-k,a(k+1:n,k),1,b(k+1:n),1)
+       l = ipvt(k)
+       if (l .eq. k) go to 70
+       t = b(l)
+       b(l) = b(k)
+       b(k) = t
+70     continue
+    enddo
+90  continue
+100 continue
+  end subroutine dgesl
+
+  AMREX_DEVICE SUBROUTINE DGBFA (ABD, LDA, N, ML, MU, IPVT, INFO)
+    ! ***BEGIN PROLOGUE  DGBFA
+    ! ***PURPOSE  Factor a band matrix using Gaussian elimination.
+    ! ***CATEGORY  D2A2
+    ! ***TYPE      DOUBLE PRECISION (SGBFA-S, DGBFA-D, CGBFA-C)
+    ! ***KEYWORDS  BANDED, LINEAR ALGEBRA, LINPACK, MATRIX FACTORIZATION
+    ! ***AUTHOR  Moler, C. B., (U. of New Mexico)
+    ! ***DESCRIPTION
+    ! 
+    !      DGBFA factors a double precision band matrix by elimination.
+    ! 
+    !      DGBFA is usually called by DGBCO, but it can be called
+    !      directly with a saving in time if  RCOND  is not needed.
+    ! 
+    !      On Entry
+    ! 
+    !         ABD     DOUBLE PRECISION(LDA, N)
+    !                 contains the matrix in band storage.  The columns
+    !                 of the matrix are stored in the columns of  ABD  and
+    !                 the diagonals of the matrix are stored in rows
+    !                 ML+1 through 2*ML+MU+1 of  ABD .
+    !                 See the comments below for details.
+    ! 
+    !         LDA     INTEGER
+    !                 the leading dimension of the array  ABD .
+    !                 LDA must be .GE. 2*ML + MU + 1 .
+    ! 
+    !         N       INTEGER
+    !                 the order of the original matrix.
+    ! 
+    !         ML      INTEGER
+    !                 number of diagonals below the main diagonal.
+    !                 0 .LE. ML .LT.  N .
+    ! 
+    !         MU      INTEGER
+    !                 number of diagonals above the main diagonal.
+    !                 0 .LE. MU .LT.  N .
+    !                 More efficient if  ML .LE. MU .
+    !      On Return
+    ! 
+    !         ABD     an upper triangular matrix in band storage and
+    !                 the multipliers which were used to obtain it.
+    !                 The factorization can be written  A = L*U  where
+    !                 L  is a product of permutation and unit lower
+    !                 triangular matrices and  U  is upper triangular.
+    ! 
+    !         IPVT    INTEGER(N)
+    !                 an integer vector of pivot indices.
+    ! 
+    !         INFO    INTEGER
+    !                 = 0  normal value.
+    !                 = K  if  U(K,K) .EQ. 0.0 .  This is not an error
+    !                      condition for this subroutine, but it does
+    !                      indicate that DGBSL will divide by zero if
+    !                      called.  Use  RCOND  in DGBCO for a reliable
+    !                      indication of singularity.
+    ! 
+    !      Band Storage
+    ! 
+    !            If  A  is a band matrix, the following program segment
+    !            will set up the input.
+    ! 
+    !                    ML = (band width below the diagonal)
+    !                    MU = (band width above the diagonal)
+    !                    M = ML + MU + 1
+    !                    DO 20 J = 1, N
+    !                       I1 = MAX(1, J-MU)
+    !                       I2 = MIN(N, J+ML)
+    !                       DO 10 I = I1, I2
+    !                          K = I - J + M
+    !                          ABD(K,J) = A(I,J)
+    !                 10    CONTINUE
+    !                 20 CONTINUE
+    ! 
+    !            This uses rows  ML+1  through  2*ML+MU+1  of  ABD .
+    !            In addition, the first  ML  rows in  ABD  are used for
+    !            elements generated during the triangularization.
+    !            The total number of rows needed in  ABD  is  2*ML+MU+1 .
+    !            The  ML+MU by ML+MU  upper left triangle and the
+    !            ML by ML  lower right triangle are not referenced.
+    ! 
+    ! ***REFERENCES  J. J. Dongarra, J. R. Bunch, C. B. Moler, and G. W.
+    !                  Stewart, LINPACK Users' Guide, SIAM, 1979.
+    ! ***ROUTINES CALLED  DAXPY, DSCAL, IDAMAX
+    ! ***REVISION HISTORY  (YYMMDD)
+    !    780814  DATE WRITTEN
+    !    890531  Changed all specific intrinsics to generic.  (WRB)
+    !    890831  Modified array declarations.  (WRB)
+    !    890831  REVISION DATE from Version 3.2
+    !    891214  Prologue converted to Version 4.0 format.  (BAB)
+    !    900326  Removed duplicate information from DESCRIPTION section.
+    !            (WRB)
+    !    920501  Reformatted the REFERENCES section.  (WRB)
+    ! ***END PROLOGUE  DGBFA
+    INTEGER LDA,N,ML,MU,IPVT(:),INFO
+    DOUBLE PRECISION ABD(LDA, N)
+    ! 
+    DOUBLE PRECISION T
+    INTEGER I,I0,J,JU,JZ,J0,J1,K,KP1,L,LM,M,MM,NM1
+    ! 
+    ! ***FIRST EXECUTABLE STATEMENT  DGBFA
+    M = ML + MU + 1
+    INFO = 0
+    ! 
+    !      ZERO INITIAL FILL-IN COLUMNS
+    ! 
+    J0 = MU + 2
+    J1 = MIN(N,M) - 1
+    IF (J1 .LT. J0) GO TO 30
+    DO JZ = J0, J1
+       I0 = M + 1 - JZ
+       DO I = I0, ML
+          ABD(I,JZ) = 0.0D0
+       end do
+    end do
+30  CONTINUE
+    JZ = J1
+    JU = 0
+    ! 
+    !      GAUSSIAN ELIMINATION WITH PARTIAL PIVOTING
+    ! 
+    NM1 = N - 1
+    IF (NM1 .LT. 1) GO TO 130
+    DO K = 1, NM1
+       KP1 = K + 1
+       ! 
+       !         ZERO NEXT FILL-IN COLUMN
+       ! 
+       JZ = JZ + 1
+       IF (JZ .GT. N) GO TO 50
+       IF (ML .LT. 1) GO TO 50
+       DO I = 1, ML
+          ABD(I,JZ) = 0.0D0
+       end do
+50     CONTINUE
+       ! 
+       !         FIND L = PIVOT INDEX
+       ! 
+       LM = MIN(ML,N-K)
+       L = IDAMAX(LM+1,ABD(M:M+LM,K),1) + M - 1
+       IPVT(K) = L + K - M
+       ! 
+       !         ZERO PIVOT IMPLIES THIS COLUMN ALREADY TRIANGULARIZED
+       ! 
+       IF (ABD(L,K) .EQ. 0.0D0) GO TO 100
+       ! 
+       !            INTERCHANGE IF NECESSARY
+       ! 
+       IF (L .EQ. M) GO TO 60
+       T = ABD(L,K)
+       ABD(L,K) = ABD(M,K)
+       ABD(M,K) = T
+60     CONTINUE
+       ! 
+       !            COMPUTE MULTIPLIERS
+       ! 
+       T = -1.0D0/ABD(M,K)
+       CALL DSCAL(LM,T,ABD(M+1:M+LM,K),1)
+       ! 
+       !            ROW ELIMINATION WITH COLUMN INDEXING
+       ! 
+       JU = MIN(MAX(JU,MU+IPVT(K)),N)
+       MM = M
+       IF (JU .LT. KP1) GO TO 90
+       DO J = KP1, JU
+          L = L - 1
+          MM = MM - 1
+          T = ABD(L,J)
+          IF (L .EQ. MM) GO TO 70
+          ABD(L,J) = ABD(MM,J)
+          ABD(MM,J) = T
+70        CONTINUE
+          CALL DAXPY(LM,T,ABD(M+1:M+LM,K),1,ABD(MM+1:MM+LM,J),1)
+       end do
+90     CONTINUE
+       GO TO 110
+100    CONTINUE
+       INFO = K
+110    CONTINUE
+    end do
+130 CONTINUE
+    IPVT(N) = N
+    IF (ABD(M,N) .EQ. 0.0D0) INFO = N
+    RETURN
+  END SUBROUTINE DGBFA
+
+  AMREX_DEVICE SUBROUTINE DGBSL (ABD, LDA, N, ML, MU, IPVT, B, JOB)
+    ! ***BEGIN PROLOGUE  DGBSL
+    ! ***PURPOSE  Solve the real band system A*X=B or TRANS(A)*X=B using
+    !             the factors computed by DGBCO or DGBFA.
+    ! ***CATEGORY  D2A2
+    ! ***TYPE      DOUBLE PRECISION (SGBSL-S, DGBSL-D, CGBSL-C)
+    ! ***KEYWORDS  BANDED, LINEAR ALGEBRA, LINPACK, MATRIX, SOLVE
+    ! ***AUTHOR  Moler, C. B., (U. of New Mexico)
+    ! ***DESCRIPTION
+    ! 
+    !      DGBSL solves the double precision band system
+    !      A * X = B  or  TRANS(A) * X = B
+    !      using the factors computed by DGBCO or DGBFA.
+    ! 
+    !      On Entry
+    ! 
+    !         ABD     DOUBLE PRECISION(LDA, N)
+    !                 the output from DGBCO or DGBFA.
+    ! 
+    !         LDA     INTEGER
+    !                 the leading dimension of the array  ABD .
+    ! 
+    !         N       INTEGER
+    !                 the order of the original matrix.
+    ! 
+    !         ML      INTEGER
+    !                 number of diagonals below the main diagonal.
+    ! 
+    !         MU      INTEGER
+    !                 number of diagonals above the main diagonal.
+    ! 
+    !         IPVT    INTEGER(N)
+    !                 the pivot vector from DGBCO or DGBFA.
+    ! 
+    !         B       DOUBLE PRECISION(N)
+    !                 the right hand side vector.
+    ! 
+    !         JOB     INTEGER
+    !                 = 0         to solve  A*X = B ,
+    !                 = nonzero   to solve  TRANS(A)*X = B , where
+    !                             TRANS(A)  is the transpose.
+    ! 
+    !      On Return
+    ! 
+    !         B       the solution vector  X .
+    ! 
+    !      Error Condition
+    ! 
+    !         A division by zero will occur if the input factor contains a
+    !         zero on the diagonal.  Technically this indicates singularity
+    !         but it is often caused by improper arguments or improper
+    !         setting of LDA .  It will not occur if the subroutines are
+    !         called correctly and if DGBCO has set RCOND .GT. 0.0
+    !         or DGBFA has set INFO .EQ. 0 .
+    ! 
+    !      To compute  INVERSE(A) * C  where  C  is a matrix
+    !      with  P  columns
+    !            CALL DGBCO(ABD,LDA,N,ML,MU,IPVT,RCOND,Z)
+    !            IF (RCOND is too small) GO TO ...
+    !            DO 10 J = 1, P
+    !               CALL DGBSL(ABD,LDA,N,ML,MU,IPVT,C(1,J),0)
+    !         10 CONTINUE
+    ! 
+    ! ***REFERENCES  J. J. Dongarra, J. R. Bunch, C. B. Moler, and G. W.
+    !                  Stewart, LINPACK Users' Guide, SIAM, 1979.
+    ! ***ROUTINES CALLED  DAXPY, DDOT
+    ! ***REVISION HISTORY  (YYMMDD)
+    !    780814  DATE WRITTEN
+    !    890531  Changed all specific intrinsics to generic.  (WRB)
+    !    890831  Modified array declarations.  (WRB)
+    !    890831  REVISION DATE from Version 3.2
+    !    891214  Prologue converted to Version 4.0 format.  (BAB)
+    !    900326  Removed duplicate information from DESCRIPTION section.
+    !            (WRB)
+    !    920501  Reformatted the REFERENCES section.  (WRB)
+    ! ***END PROLOGUE  DGBSL
+    INTEGER LDA,N,ML,MU,IPVT(:),JOB
+    DOUBLE PRECISION ABD(LDA,N),B(:)
+    ! 
+    DOUBLE PRECISION T
+    INTEGER K,KB,L,LA,LB,LM,M,NM1
+    ! ***FIRST EXECUTABLE STATEMENT  DGBSL
+    M = MU + ML + 1
+    NM1 = N - 1
+    IF (JOB .NE. 0) GO TO 50
+    ! 
+    !         JOB = 0 , SOLVE  A * X = B
+    !         FIRST SOLVE L*Y = B
+    ! 
+    IF (ML .EQ. 0) GO TO 30
+    IF (NM1 .LT. 1) GO TO 30
+    DO K = 1, NM1
+       LM = MIN(ML,N-K)
+       L = IPVT(K)
+       T = B(L)
+       IF (L .EQ. K) GO TO 10
+       B(L) = B(K)
+       B(K) = T
+10     CONTINUE
+       CALL DAXPY(LM,T,ABD(M+1:M+LM,K),1,B(K+1:K+LM),1)
+    end do
+30  CONTINUE
+    ! 
+    !         NOW SOLVE  U*X = Y
+    ! 
+    DO KB = 1, N
+       K = N + 1 - KB
+       B(K) = B(K)/ABD(M,K)
+       LM = MIN(K,M) - 1
+       LA = M - LM
+       LB = K - LM
+       T = -B(K)
+       CALL DAXPY(LM,T,ABD(LA:LA + LM - 1,K),1,B(LB:LB + LM - 1),1)
+    end do
+    GO TO 100
+50  CONTINUE
+    ! 
+    !         JOB = NONZERO, SOLVE  TRANS(A) * X = B
+    !         FIRST SOLVE  TRANS(U)*Y = B
+    ! 
+    DO K = 1, N
+       LM = MIN(K,M) - 1
+       LA = M - LM
+       LB = K - LM
+       T = DDOT(LM,ABD(LA:LA + LM - 1,K),1,B(LB:LB + LM - 1),1)
+       B(K) = (B(K) - T)/ABD(M,K)
+    end do
+    ! 
+    !         NOW SOLVE TRANS(L)*X = Y
+    ! 
+    IF (ML .EQ. 0) GO TO 90
+    IF (NM1 .LT. 1) GO TO 90
+    DO KB = 1, NM1
+       K = N - KB
+       LM = MIN(ML,N-K)
+       B(K) = B(K) + DDOT(LM,ABD(M+1:M+LM,K),1,B(K+1:K+LM),1)
+       L = IPVT(K)
+       IF (L .EQ. K) GO TO 70
+       T = B(L)
+       B(L) = B(K)
+       B(K) = T
+70     CONTINUE
+    end do
+90  CONTINUE
+100 CONTINUE
+    RETURN
+  END SUBROUTINE DGBSL
+
+  AMREX_DEVICE subroutine dgefa (a,lda,n,ipvt,info)
+
+    !$acc routine seq
+    !$acc routine(daxpy) seq
+    !$acc routine(idamax) seq
+    !$acc routine(dscal) seq
+
+    integer lda,n,ipvt(:),info
+    double precision a(lda, n)
+    ! 
+    !      dgefa factors a double precision matrix by gaussian elimination.
+    ! 
+    !      dgefa is usually called by dgeco, but it can be called
+    !      directly with a saving in time if  rcond  is not needed.
+    !      (time for dgeco) = (1 + 9/n)*(time for dgefa) .
+    ! 
+    !      on entry
+    ! 
+    !         a       double precision(lda, n)
+    !                 the matrix to be factored.
+    ! 
+    !         lda     integer
+    !                 the leading dimension of the array  a .
+    ! 
+    !         n       integer
+    !                 the order of the matrix  a .
+    ! 
+    !      on return
+    ! 
+    !         a       an upper triangular matrix and the multipliers
+    !                 which were used to obtain it.
+    !                 the factorization can be written  a = l*u  where
+    !                 l  is a product of permutation and unit lower
+    !                 triangular matrices and  u  is upper triangular.
+    ! 
+    !         ipvt    integer(n)
+    !                 an integer vector of pivot indices.
+    ! 
+    !         info    integer
+    !                 = 0  normal value.
+    !                 = k  if  u(k,k) .eq. 0.0 .  this is not an error
+    !                      condition for this subroutine, but it does
+    !                      indicate that dgesl or dgedi will divide by zero
+    !                      if called.  use  rcond  in dgeco for a reliable
+    !                      indication of singularity.
+    ! 
+    !      linpack. this version dated 08/14/78 .
+    !      cleve moler, university of new mexico, argonne national lab.
+    ! 
+    !      subroutines and functions
+    ! 
+    !      blas vdaxpy,dscal,idamax
+    ! 
+    !      internal variables
+    ! 
+    double precision t
+    integer j,k,kp1,l,nm1
+    ! 
+    ! 
+    !      gaussian elimination with partial pivoting
+    ! 
+
+    info = 0
+    nm1 = n - 1
+
+    if (nm1 .lt. 1) goto 70
+    do k = 1, nm1
+       kp1 = k + 1
+       ! 
+       !         find l = pivot index
+       ! 
+       l = idamax(n-k+1,a(k:n,k),1) + k - 1
+       ipvt(k) = l
+       ! 
+       !         zero pivot implies this column already triangularized
+       ! 
+       if (a(l,k) .eq. 0.0d0) goto 40
+       ! 
+       !            interchange if necessary
+       ! 
+       if (l .eq. k) goto 10
+       t = a(l,k)
+       a(l,k) = a(k,k)
+       a(k,k) = t
+10     continue
+       ! 
+       !            compute multipliers
+       ! 
+       t = -1.0d0/a(k,k)
+       call dscal(n-k,t,a(k+1:n,k),1)
+       ! 
+       !            row elimination with column indexing
+       ! 
+       do j = kp1, n
+          t = a(l,j)
+          if (l .eq. k) goto 20
+          a(l,j) = a(k,j)
+          a(k,j) = t
+20        continue
+          call daxpy(n-k,t,a(k+1:n,k),1,a(k+1:n,j),1)
+       enddo
+       goto 50
+40     continue
+       info = k
+50     continue
+    enddo
+70  continue
+    ipvt(n) = n
+    if (a(n,n) .eq. 0.0d0) info = n
+  end subroutine dgefa
+
+  AMREX_DEVICE function vddot (n,dx,incx,dy,incy) result(dotval)
+
+    !$acc routine seq
+
+    ! 
+    !      forms the dot product of two vectors.
+    !      uses unrolled loops for increments equal to one.
+    !      jack dongarra, linpack, 3/11/78.
+    !
+    double precision dotval
+    double precision dx(:),dy(:),dtemp
+    integer i,incx,incy,ix,iy,m,mp1,n
+    ! 
+    dotval = 0.0d0
+    dtemp = 0.0d0
+    if (n.le.0) return
+    if (incx.eq.1.and.incy.eq.1) go to 20
+    ! 
+    !      code for unequal increments or equal increments not equal to 1
+    ! 
+    ix = 1
+    iy = 1
+    if (incx.lt.0) ix = (-n+1)*incx + 1
+    if (incy.lt.0) iy = (-n+1)*incy + 1
+    do i = 1,n
+       dtemp = dtemp + dx(ix)*dy(iy)
+       ix = ix + incx
+       iy = iy + incy
+    enddo
+    dotval = dtemp
+    return
+    ! 
+    !      code for both increments equal to 1
+    ! 
+    ! 
+    !      clean-up loop
+    ! 
+20  m = mod(n,5)
+    if ( m .eq. 0 ) go to 40
+    do i = 1,m
+       dtemp = dtemp + dx(i)*dy(i)
+    enddo
+    if( n .lt. 5 ) go to 60
+40  mp1 = m + 1
+    do i = mp1,n,5
+       dtemp = dtemp + dx(i)*dy(i) + dx(i + 1)*dy(i + 1) + &
+            dx(i + 2)*dy(i + 2) + dx(i + 3)*dy(i + 3) + dx(i + 4)*dy(i + 4)
+    enddo
+60  dotval = dtemp
+  end function vddot
+  
+end module linpack_module

--- a/util/microphysics_math.F90
+++ b/util/microphysics_math.F90
@@ -123,7 +123,7 @@ contains
 
     enddo
 
-#ifndef ACC
+#if !(defined(ACC) || defined(CUDA))
     if (j > n - 1) then
        call amrex_error("Error: too many partials created in esum.")
     endif
@@ -132,5 +132,1085 @@ contains
     esum = sum(partials(0:j))
 
   end function esum
+
+
+  AMREX_DEVICE function esum10(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:9)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 10
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum10
+
+
+  AMREX_DEVICE function esum12(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:11)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 12
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum12
+
+
+  AMREX_DEVICE function esum13(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:12)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 13
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum13
+
+
+  AMREX_DEVICE function esum15(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:14)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 15
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum15
+
+
+  AMREX_DEVICE function esum17(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:16)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 17
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum17
+
+
+  AMREX_DEVICE function esum20(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:19)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 20
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum20
+
+
+  AMREX_DEVICE function esum25(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:24)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 25
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum25
+
+
+  AMREX_DEVICE function esum26(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:25)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 26
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum26
+
+
+  AMREX_DEVICE function esum3(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:2)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 3
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum3
+
+
+  AMREX_DEVICE function esum4(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:3)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 4
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum4
+
+
+  AMREX_DEVICE function esum5(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:4)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 5
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum5
+
+
+  AMREX_DEVICE function esum6(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:5)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 6
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum6
+
+
+  AMREX_DEVICE function esum7(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:6)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 7
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum7
+
+
+  AMREX_DEVICE function esum8(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:7)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 8
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum8
+
+
+  AMREX_DEVICE function esum9(array) result(esum)
+
+    !$acc routine seq
+
+    use bl_error_module, only: bl_error
+    use bl_types, only: dp_t
+
+    implicit none
+
+    real(dp_t), intent(in) :: array(:)
+    real(dp_t) :: esum
+
+    integer :: i, j, k, km
+
+    ! Note that for performance reasons we are not
+    ! initializing the unused values in this array.
+
+    real(dp_t) :: partials(0:8)
+    real(dp_t) :: x, y, z, hi, lo
+
+    ! j keeps track of how many entries in partials are actually used.
+    ! The algorithm we model this off of, written in Python, simply
+    ! deletes array entries at the end of every outer loop iteration.
+    ! The Fortran equivalent to this might be to just zero them out,
+    ! but this results in a huge performance hit given how often
+    ! this routine is called during in a burn. So we opt instead to
+    ! just track how many of the values are meaningful, which j does
+    ! automatically, and ignore any data in the remaining slots.
+
+    j = 0
+
+    ! The first partial is just the first term.
+    partials(j) = array(1)
+
+    do i = 2, 9
+
+       km = j
+       j = 0
+
+       x = array(i)
+
+       do k = 0, km
+          y = partials(k)
+
+          if (abs(x) < abs(y)) then
+             ! Swap x, y
+             z = y
+             y = x
+             x = z
+          endif
+
+          hi = x + y
+          lo = y - (hi - x)
+
+          if (lo .ne. 0.0_dp_t) then
+             partials(j) = lo
+             j = j + 1
+          endif
+
+          x = hi
+
+       enddo
+
+       partials(j) = x
+
+    enddo
+
+    esum = sum(partials(0:j))
+
+  end function esum9
 
 end module microphysics_math_module

--- a/util/microphysics_math.F90
+++ b/util/microphysics_math.F90
@@ -138,21 +138,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real    
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:9)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:9)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -188,7 +188,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -210,21 +210,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:11)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:11)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -260,7 +260,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -282,21 +282,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:12)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:12)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -332,7 +332,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -354,21 +354,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:14)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:14)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -404,7 +404,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -426,21 +426,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:16)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:16)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -476,7 +476,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -498,21 +498,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:19)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:19)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -548,7 +548,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -570,21 +570,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:24)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:24)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -620,7 +620,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -642,21 +642,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:25)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:25)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -692,7 +692,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -714,21 +714,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:2)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:2)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -764,7 +764,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -786,21 +786,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:3)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:3)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -836,7 +836,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -858,21 +858,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:4)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:4)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -908,7 +908,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -930,21 +930,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:5)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:5)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -980,7 +980,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -1002,21 +1002,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:6)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:6)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -1052,7 +1052,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -1074,21 +1074,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:7)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:7)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -1124,7 +1124,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif
@@ -1146,21 +1146,21 @@ contains
 
     !$acc routine seq
 
-    use bl_error_module, only: bl_error
-    use bl_types, only: dp_t
+    use amrex_error_module, only: amrex_error
+    use amrex_fort_module, only : rt => amrex_real
 
     implicit none
 
-    real(dp_t), intent(in) :: array(:)
-    real(dp_t) :: esum
+    real(rt), intent(in) :: array(:)
+    real(rt) :: esum
 
     integer :: i, j, k, km
 
     ! Note that for performance reasons we are not
     ! initializing the unused values in this array.
 
-    real(dp_t) :: partials(0:8)
-    real(dp_t) :: x, y, z, hi, lo
+    real(rt) :: partials(0:8)
+    real(rt) :: x, y, z, hi, lo
 
     ! j keeps track of how many entries in partials are actually used.
     ! The algorithm we model this off of, written in Python, simply
@@ -1196,7 +1196,7 @@ contains
           hi = x + y
           lo = y - (hi - x)
 
-          if (lo .ne. 0.0_dp_t) then
+          if (lo .ne. 0.0_rt) then
              partials(j) = lo
              j = j + 1
           endif


### PR DESCRIPTION
This adds the CUDA-marked up utility modules for BLAS and LINPACK from cudadevice.

This also adds the specialized esums to microphysics math and replaces `esum` in the aprox networks with the specialized versions.