### PR TITLE
Fix bug in stellarcollapse EOS and improve input sanitation

### DIFF
--- a/EOS/stellarcollapse/actual_eos.F90
+++ b/EOS/stellarcollapse/actual_eos.F90
@@ -23,13 +23,13 @@ contains
   ! This reads in the HDF5 file containing the tabulated data
   subroutine actual_eos_init
 
-    use parallel
+    use amrex_paralleldescriptor_module, only: amrex_pd_ioprocessor
     use extern_probin_module, only: eos_file, use_energy_shift
     use network, only: network_species_index
 
     implicit none
  
-    if (parallel_IOProcessor()) print *, 'Reading HDF5 file', eos_file
+    if (amrex_pd_ioprocessor()) print *, 'Reading HDF5 file', eos_file
     call read_stellarcollapse_file(eos_file,use_energy_shift)
 
   end subroutine actual_eos_init
@@ -322,7 +322,7 @@ contains
     state%rho = rho
     state%T = T
     state%y_e = ye
-    call convert_to_table_format(state)
+    call convert_to_table_format(eos_input_rt, state)
 
     ! look it up
     call tri_interpolate(state%rho,state%T,state%y_e,&

--- a/EOS/stellarcollapse/actual_eos.F90
+++ b/EOS/stellarcollapse/actual_eos.F90
@@ -59,7 +59,7 @@ contains
     integer :: ierr
 
     ! Convert to the units used by the table.
-    call convert_to_table_format(state)
+    call convert_to_table_format(input, state)
 
     ierr = 0
 

--- a/EOS/stellarcollapse/eos_aux_data.f90
+++ b/EOS/stellarcollapse/eos_aux_data.f90
@@ -43,7 +43,7 @@ contains
 
     use amrex_error_module
     use hdf5
-    use parallel
+    use amrex_paralleldescriptor_module, only: amrex_pd_ioprocessor
     use eos_type_module, only: mindens, mintemp, minye, maxdens, maxtemp, maxye
     use fundamental_constants_module, only: k_B, ev2erg, MeV2eV, n_A
 
@@ -274,7 +274,7 @@ contains
        total_error = total_error + error
     endif
 
-    if (parallel_IOProcessor()) print *, 'energy_shift', energy_shift
+    if (amrex_pd_ioprocessor()) print *, 'energy_shift', energy_shift
 
     if (total_error .ne. 0) call amrex_error("EOS: Error reading EOS table")
     
@@ -344,7 +344,6 @@ contains
     use fundamental_constants_module
     use eos_type_module
     use amrex_constants_module, only: TEN
-    use parallel
     
     implicit none
 

--- a/EOS/stellarcollapse/eos_aux_data.f90
+++ b/EOS/stellarcollapse/eos_aux_data.f90
@@ -274,7 +274,7 @@ contains
        total_error = total_error + error
     endif
 
-    if (amrex_pd_ioprocessor()) print *, 'energy_shift', energy_shift
+    if (amrex_pd_ioprocessor()) print *, 'stellarcollapse EOS energy_shift', energy_shift
 
     if (total_error .ne. 0) call amrex_error("EOS: Error reading EOS table")
     
@@ -320,17 +320,17 @@ contains
     ! for entropy
 
     ! Only take logs of quantities we can assume are defined
-    if (state % rho > ZERO .and. eos_input_has_var(input, idens)) then
-       state % rho = dlog10(state % rho)
+    if (eos_input_has_var(input, idens)) then
+       state % rho = dlog10(max(state % rho, ONE))
     endif
-    if (state % p > ZERO .and. eos_input_has_var(input, ipres)) then
-       state % p = dlog10(state % p)
+    if (eos_input_has_var(input, ipres)) then
+       state % p = dlog10(max(state % p, ONE))
     endif
-    if (state % e > ZERO .and. eos_input_has_var(input, iener)) then
-       state % e = dlog10(state % e - energy_shift)
+    if (eos_input_has_var(input, iener)) then
+       state % e = dlog10(max(state % e + energy_shift, ONE))
     endif
-    if (state % T > ZERO .and. eos_input_has_var(input, itemp)) then
-       state % T = dlog10(state % T * temp_conv)
+    if (eos_input_has_var(input, itemp)) then
+       state % T = dlog10(max(state % T * temp_conv, ONE))
     endif
     ! assuming baryon mass to be ~ 1 amu = 1/N_A
     state % s = state % s * k_B / n_A
@@ -351,7 +351,7 @@ contains
 
     state%rho = TEN**state%rho
     state%p   = TEN**state%p
-    state%e   = TEN**state%e + energy_shift
+    state%e   = TEN**state%e - energy_shift
     state%T = (TEN**state%T) / temp_conv
     state%s = state%s * n_A / k_B
 

--- a/EOS/stellarcollapse/eos_aux_data.f90
+++ b/EOS/stellarcollapse/eos_aux_data.f90
@@ -304,7 +304,7 @@ contains
 
 
   ! Convert from the units used in Castro to the units of the table.
-  subroutine convert_to_table_format(state)
+  subroutine convert_to_table_format(input, state)
 
     use eos_type_module
     use fundamental_constants_module, only: k_B, ev2erg, MeV2eV, n_A
@@ -312,21 +312,24 @@ contains
 
     implicit none
 
+    integer,     intent(in   ) :: input
     type(eos_t), intent(inout) :: state
 
     ! the stellarcollapse.org tables use some log10 variables, as well as 
     ! units of MeV for temperature and chemical potential, and k_B / baryon 
     ! for entropy
-    if (state % rho > ZERO) then
+
+    ! Only take logs of quantities we can assume are defined
+    if (state % rho > ZERO .and. eos_input_has_var(input, idens)) then
        state % rho = dlog10(state % rho)
     endif
-    if (state % p > ZERO) then
+    if (state % p > ZERO .and. eos_input_has_var(input, ipres)) then
        state % p = dlog10(state % p)
     endif
-    if (state % e > ZERO) then
+    if (state % e > ZERO .and. eos_input_has_var(input, iener)) then
        state % e = dlog10(state % e - energy_shift)
     endif
-    if (state % T > ZERO) then
+    if (state % T > ZERO .and. eos_input_has_var(input, itemp)) then
        state % T = dlog10(state % T * temp_conv)
     endif
     ! assuming baryon mass to be ~ 1 amu = 1/N_A

--- a/interfaces/eos_type.F90
+++ b/interfaces/eos_type.F90
@@ -408,4 +408,92 @@ contains
 
   end subroutine eos_get_max_dens
 
+
+  ! Check to see if variable ivar is a valid
+  ! independent variable for the given input
+  function eos_input_has_var(input, ivar) result(has)
+
+    use eos_type_module
+
+    implicit none
+
+    integer, intent(in) :: input
+    logical :: has
+
+    !$gpu
+
+    has = .false.
+    
+    select case (ivar)
+
+    case (itemp)
+
+       if (input == eos_input_rt .or. &
+           input == eos_input_tp .or. &
+           input == eos_input_th) then
+
+          has = .true.
+
+       endif
+
+    case (idens)
+
+       if (input == eos_input_rt .or. &
+           input == eos_input_rh .or. &
+           input == eos_input_rp .or. &
+           input == eos_input_re) then
+
+          has = .true.
+
+       endif
+
+    case (iener)
+
+       if (input == eos_input_re) then
+
+          has = .true.
+
+       endif
+       
+    case (ienth)
+
+       if (input == eos_input_rh .or. &
+           input == eos_input_ph .or. &
+           input == eos_input_th) then
+
+          has = .true.
+
+       endif
+
+    case (ientr)
+
+       if (input == eos_input_ps) then
+
+          has = .true.
+
+       endif
+
+    case (ipres)
+
+       if (input == eos_input_tp .or. &
+           input == eos_input_rp .or. &
+           input == eos_input_ps .or. &
+           input == eos_input_ph) then
+
+          has = .true.
+
+       endif
+
+    case default
+
+#ifdef AMREX_USE_CUDA
+       stop
+#else
+       call amrex_error("EOS: invalid independent variable")
+#endif
+
+    end select
+
+  end function eos_input_has_var
+
 end module eos_type_module

--- a/interfaces/eos_type.F90
+++ b/interfaces/eos_type.F90
@@ -1,5 +1,6 @@
 module eos_type_module
 
+  use amrex_error_module, only: amrex_error
   use amrex_fort_module, only : rt => amrex_real
   use network, only: nspec, naux
 
@@ -413,11 +414,9 @@ contains
   ! independent variable for the given input
   function eos_input_has_var(input, ivar) result(has)
 
-    use eos_type_module
-
     implicit none
 
-    integer, intent(in) :: input
+    integer, intent(in) :: input, ivar
     logical :: has
 
     !$gpu


### PR DESCRIPTION
These changes fixed the energy shift bug in the Stellar Collapse EOS and also add input checking to detect which eos type variables to convert to table units depending on the eos input type.

Adds functionality to the EOS type module to support checking what input variables different input types support.

The Stellar Collapse energy shift bug was that previously we were converting to table units by subtracting the energy shift from the input internal energy. And to convert from table units we added the energy shift.

However, the Stellar Collapse tables were designed such that the energy shift ensures the input specific internal energy is always positive. This requires us to add the energy shift to convert to table units and subtract the energy shift to convert from table units.

For an explanation, download the EOS driver routine from the [Stellar Collapse EOS webpage](https://stellarcollapse.org/equationofstate) and look at the README and lines 75 and 117 of `nuc_eos.F90`.

The relevant section of the README is:

> ! * energy shift:                                                                                                                                                                             
!                                                                                                                                                                                             
! In some regions the negative nuclear binding energy                                                                                                                                         
! is larger in magnitude than the thermal/excitation energy. In this                                                                                                                          
! case the specific internal energy (eps) becomes negative. To allow for                                                                                                                      
! storage and interpolation of eps in logarithmic fashion, the energy                                                                                                                         
! is shifted up by an energy shift specified in the variable "energy_shift".                                                                                                                  
! This energy shift is handled internally in the EOS routines.