### PR TITLE
Fixing indexing in iso7 screening

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # changes since the last release
 
+   * An indexing bug in iso7 was fixed, affecting the screening term
+     on the O16+O16 reaction rate.
+
    * The test_eos unit test now outputs all of the variables in the
      eos_t type.
 

--- a/networks/iso7/actual_rhs.F90
+++ b/networks/iso7/actual_rhs.F90
@@ -680,9 +680,9 @@ contains
     jscr = jscr + 1
     call screen5(pstate,jscr,sc1a,sc1adt,sc1add)
 
-    ratdum(ir1216)    = ratraw(ir1216) * sc1a
-    dratdumdt(ir1216) = dratrawdt(ir1216)*sc1a + ratraw(ir1216)*sc1adt
-    !dratdumdd(ir1216) = dratrawdd(ir1216)*sc1a + ratraw(ir1216)*sc1add
+    ratdum(ir1616)    = ratraw(ir1616) * sc1a
+    dratdumdt(ir1616) = dratrawdt(ir1616)*sc1a + ratraw(ir1616)*sc1adt
+    !dratdumdd(ir1616) = dratrawdd(ir1616)*sc1a + ratraw(ir1616)*sc1add
 
 
 


### PR DESCRIPTION
The screening term on O16 + O16 was incorrectly being applied to the C12 + O16 rate.