### PR TITLE
Always tabulate rates for iso7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # changes since the last release
 
+   * iso7 now always uses rate tabulation instead of direct rate
+     evaluation when the RHS and Jacobian are evaluated. The iso7
+     rate table was made twice as dense, as well, since the tabulated
+     rates were not accurate enough.
+
    * The test_eos unit test now outputs all of the variables in the
      eos_t type.
 

--- a/networks/iso7/actual_rhs.F90
+++ b/networks/iso7/actual_rhs.F90
@@ -680,9 +680,9 @@ contains
     jscr = jscr + 1
     call screen5(pstate,jscr,sc1a,sc1adt,sc1add)
 
-    ratdum(ir1216)    = ratraw(ir1216) * sc1a
-    dratdumdt(ir1216) = dratrawdt(ir1216)*sc1a + ratraw(ir1216)*sc1adt
-    !dratdumdd(ir1216) = dratrawdd(ir1216)*sc1a + ratraw(ir1216)*sc1add
+    ratdum(ir1616)    = ratraw(ir1616) * sc1a
+    dratdumdt(ir1616) = dratrawdt(ir1616)*sc1a + ratraw(ir1616)*sc1adt
+    !dratdumdd(ir1616) = dratrawdd(ir1616)*sc1a + ratraw(ir1616)*sc1add
 
 
 

--- a/networks/iso7/actual_rhs.F90
+++ b/networks/iso7/actual_rhs.F90
@@ -13,7 +13,7 @@ module actual_rhs_module
   ! Table interpolation data
 
   double precision, parameter :: tab_tlo = 6.0d0, tab_thi = 10.0d0
-  integer, parameter :: tab_per_decade = 500
+  integer, parameter :: tab_per_decade = 1000
   integer, parameter :: nrattab = int(tab_thi - tab_tlo) * tab_per_decade + 1
   integer, parameter :: tab_imax = int(tab_thi - tab_tlo) * tab_per_decade + 1
   double precision, parameter :: tab_tstp = (tab_thi - tab_tlo) / dble(tab_imax - 1)
@@ -32,7 +32,6 @@ contains
   subroutine actual_rhs_init()
 
     use aprox_rates_module, only: rates_init
-    use extern_probin_module, only: use_tables
     use screening_module, only: screening_init
     use amrex_paralleldescriptor_module, only: parallel_IOProcessor => amrex_pd_ioprocessor
 
@@ -44,24 +43,12 @@ contains
 
     call screening_init()
 
-    if (use_tables) then
-
-       if (parallel_IOProcessor()) then
-          print *, ""
-          print *, "Initializing iso7 rate table"
-          print *, ""
-       endif
-
-       call create_rates_table()
-
-    endif
+    call create_rates_table()
 
   end subroutine actual_rhs_init
 
 
   subroutine get_rates(state, rr)
-
-    use extern_probin_module, only: use_tables
 
     implicit none
 
@@ -84,11 +71,7 @@ contains
     y    = state % xn * aion_inv
 
     ! Get the raw reaction rates
-    if (use_tables) then
-       call iso7tab(temp, rho, ratraw, dratrawdt, dratrawdd)
-    else
-       call iso7rat(temp, rho, ratraw, dratrawdt, dratrawdd)
-    endif
+    call iso7tab(temp, rho, ratraw, dratrawdt, dratrawdd)
 
     ! Do the screening here because the corrections depend on the composition
     call screen_iso7(temp, rho, y,                 &

--- a/networks/iso7/actual_rhs.F90
+++ b/networks/iso7/actual_rhs.F90
@@ -663,9 +663,9 @@ contains
     jscr = jscr + 1
     call screen5(pstate,jscr,sc1a,sc1adt,sc1add)
 
-    ratdum(ir1616)    = ratraw(ir1616) * sc1a
-    dratdumdt(ir1616) = dratrawdt(ir1616)*sc1a + ratraw(ir1616)*sc1adt
-    !dratdumdd(ir1616) = dratrawdd(ir1616)*sc1a + ratraw(ir1616)*sc1add
+    ratdum(ir1216)    = ratraw(ir1216) * sc1a
+    dratdumdt(ir1216) = dratrawdt(ir1216)*sc1a + ratraw(ir1216)*sc1adt
+    !dratdumdd(ir1216) = dratrawdd(ir1216)*sc1a + ratraw(ir1216)*sc1add
 
 
 


### PR DESCRIPTION
Rates should always be tabulated -- this is faster by a wide margin on both CPUs and GPUs. Also, tabulated rates leave the door open for future changes that are easier to implement than with the direct rate evaluation. We'll start with iso7 and do it to the other networks soon.

Additionally, the iso7 table density is doubled, due to test_react not being able to handle the iso7 test problem at the current table density.