### PR TITLE
Modify the Jacobian contributions from the neutrino cooling

### DIFF
--- a/networks/ECSN/actual_rhs.F90
+++ b/networks/ECSN/actual_rhs.F90
@@ -426,7 +426,7 @@ contains
     call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - state % abar) * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
+       b1 = (-state % abar * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
        call get_jac_entry(state, net_ienuc, j, scratch)
        scratch = scratch - b1
        call set_jac_entry(state, net_ienuc, j, scratch)

--- a/networks/aprox13/actual_rhs.F90
+++ b/networks/aprox13/actual_rhs.F90
@@ -187,7 +187,7 @@ contains
     call sneut5(temp, rho, abar, zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - abar) * abar * snuda + (zion(j) - zbar) * abar * snudz)
+       b1 = (-abar * abar * snuda + (zion(j) - zbar) * abar * snudz)
        call get_jac_entry(state, net_ienuc, j, scratch)
        scratch = scratch - b1
        call set_jac_entry(state, net_ienuc, j, scratch)

--- a/networks/aprox19/actual_rhs.F90
+++ b/networks/aprox19/actual_rhs.F90
@@ -149,7 +149,7 @@ contains
     call sneut5(temp, rho, abar, zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - abar) * abar * snuda + (zion(j) - zbar) * abar * snudz)
+       b1 = (-abar * abar * snuda + (zion(j) - zbar) * abar * snudz)
        state % jac(net_ienuc,j) = state % jac(net_ienuc,j) - b1
     enddo
 

--- a/networks/aprox21/actual_rhs.F90
+++ b/networks/aprox21/actual_rhs.F90
@@ -148,7 +148,7 @@ contains
     call sneut5(temp, rho, abar, zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - abar) * abar * snuda + (zion(j) - zbar) * abar * snudz)
+       b1 = (-abar * abar * snuda + (zion(j) - zbar) * abar * snudz)
        call get_jac_entry(state, net_ienuc, j, scratch)
        scratch = scratch - b1
        call set_jac_entry(state, net_ienuc, j, scratch)

--- a/networks/ignition_reaclib/C-burn-simple/actual_rhs.F90
+++ b/networks/ignition_reaclib/C-burn-simple/actual_rhs.F90
@@ -277,7 +277,7 @@ contains
     call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - state % abar) * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
+       b1 = (-state % abar * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
        call get_jac_entry(state, net_ienuc, j, scratch)
        scratch = scratch - b1
        call set_jac_entry(state, net_ienuc, j, scratch)

--- a/networks/ignition_reaclib/C-test/actual_rhs.F90
+++ b/networks/ignition_reaclib/C-test/actual_rhs.F90
@@ -242,7 +242,7 @@ contains
     call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - state % abar) * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
+       b1 = (-state % abar * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
        call get_jac_entry(state, net_ienuc, j, scratch)
        scratch = scratch - b1
        call set_jac_entry(state, net_ienuc, j, scratch)

--- a/networks/ignition_reaclib/URCA-simple/actual_rhs.F90
+++ b/networks/ignition_reaclib/URCA-simple/actual_rhs.F90
@@ -295,7 +295,7 @@ contains
        call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
        do j = 1, nspec
-          b1 = ((aion(j) - state % abar) * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
+          b1 = (-state % abar * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
           call get_jac_entry(state, net_ienuc, j, scratch)
           scratch = scratch - b1
           call set_jac_entry(state, net_ienuc, j, scratch)

--- a/networks/iso7/actual_rhs.F90
+++ b/networks/iso7/actual_rhs.F90
@@ -345,7 +345,7 @@ contains
     call sneut5(temp, rho, abar, zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - abar) * abar * snuda + (zion(j) - zbar) * abar * snudz)
+       b1 = (-abar * abar * snuda + (zion(j) - zbar) * abar * snudz)
        state % jac(net_ienuc,j) = state % jac(net_ienuc,j) - b1
     enddo
 

--- a/networks/nova/actual_rhs.f90
+++ b/networks/nova/actual_rhs.f90
@@ -365,7 +365,7 @@ contains
     ! Account for the thermal neutrino losses
     call sneut5(temp, dens, state%abar, state%zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
     do j = 1, nspec
-       b1 = ((aion(j) - state%abar) * state%abar * snuda + (zion(j) - state%zbar) * state%abar * snudz)
+       b1 = (-state%abar * state%abar * snuda + (zion(j) - state%zbar) * state%abar * snudz)
        state % jac(net_ienuc,j) = state % jac(net_ienuc,j) - b1
     enddo
 

--- a/networks/sn160/actual_rhs.F90
+++ b/networks/sn160/actual_rhs.F90
@@ -7726,7 +7726,7 @@ contains
     call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - state % abar) * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
+       b1 = (-state % abar * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
        call get_jac_entry(state, net_ienuc, j, scratch)
        scratch = scratch - b1
        call set_jac_entry(state, net_ienuc, j, scratch)

--- a/networks/subch/actual_rhs.F90
+++ b/networks/subch/actual_rhs.F90
@@ -259,7 +259,7 @@ contains
     ! Account for the thermal neutrino losses
     call sneut5(temp, dens, state%abar, state%zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
     do j = 1, nspec
-       b1 = ((aion(j) - state%abar) * state%abar * snuda + (zion(j) - state%zbar) * state%abar * snudz)
+       b1 = (-state%abar * state%abar * snuda + (zion(j) - state%zbar) * state%abar * snudz)
        state % jac(net_ienuc,j) = state % jac(net_ienuc,j) - b1
     enddo
 

--- a/networks/subch2/actual_rhs.F90
+++ b/networks/subch2/actual_rhs.F90
@@ -825,7 +825,7 @@ contains
     call sneut5(state % T, state % rho, state % abar, state % zbar, sneut, dsneutdt, dsneutdd, snuda, snudz)
 
     do j = 1, nspec
-       b1 = ((aion(j) - state % abar) * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
+       b1 = (-state % abar * state % abar * snuda + (zion(j) - state % zbar) * state % abar * snudz)
        call get_jac_entry(state, net_ienuc, j, scratch)
        scratch = scratch - b1
        call set_jac_entry(state, net_ienuc, j, scratch)


### PR DESCRIPTION
The neutrino cooling term returns d(S_nu)/dT, d(S_nu)/d(Abar), and d(S_nu)/d(Zbar). Since we're interested in dE/dY_j, we need to use the chain rule to obtain -dE/dY_j = d(Abar)/dY_j * d(S_nu)/d(Abar) + d(Zbar)/dY_j * d(S_nu)/d(Zbar). The latter term is correctly computed by all networks, since an analytic calculation reveals that d(Zbar)/dY_j is (Z_j - Zbar) * Abar. For the former term, it can either be -Abar^2, or (A_j - Abar) * Abar, depending on whether you enforce that sum(X) = 1 prior to taking the derivative.

Out of Frank Timmes' public networks as of this date, the 7 isotope and 34 isotope networks do it the way recommended by this PR, but the 13, 19 and 21 isotope networks do it the other way (the way that Microphysics does it, prior to this PR).