### PR TITLE
Enable the retry mechanism for simplified SDC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # changes since the last release
 
+   * Simplified SDC integration now uses the same retry strategy
+     as the default (non-SDC) integration. (#215)
+
    * VODE90 can now participate in the retry strategy that was
      previously available to the VODE integrator, where it can
      switch to the BS integrator if loosening the tolerances

--- a/integration/BS/bs_integrator.F90
+++ b/integration/BS/bs_integrator.F90
@@ -200,7 +200,7 @@ contains
 
     if (ierr /= IERR_NONE) then
 
-#ifndef ACC
+#ifndef CUDA
        print *, 'ERROR: integration failed in net'
        print *, 'ierr = ', ierr
        print *, 'dt = ', dt

--- a/integration/VODE90/vode_integrator_true_sdc.F90
+++ b/integration/VODE90/vode_integrator_true_sdc.F90
@@ -16,7 +16,9 @@ contains
   end subroutine vode_integrator_init
 
 
-  subroutine vode_integrator(state_in, state_out, dt, time)
+  subroutine vode_integrator(state_in, state_out, dt, time, status)
+
+    use integration_data, only: integration_status_t
 
     implicit none
 
@@ -25,6 +27,7 @@ contains
     type (burn_t), intent(in   ) :: state_in
     type (burn_t), intent(inout) :: state_out
     real(rt),    intent(in   ) :: dt, time
+    type (integration_status_t), intent(inout) :: status
 
   end subroutine vode_integrator
 

--- a/integration/integrator_sdc.F90
+++ b/integration/integrator_sdc.F90
@@ -48,10 +48,13 @@ contains
     use amrex_error_module, only: amrex_error
 #endif
     use amrex_fort_module, only : rt => amrex_real
+    use amrex_constants_module, only: ZERO, ONE
     use integration_data, only: integration_status_t
     use sdc_type_module, only: sdc_t
     use extern_probin_module, only: rtol_spec, rtol_temp, rtol_enuc, &
-                                    atol_spec, atol_temp, atol_enuc
+                                    atol_spec, atol_temp, atol_enuc, &
+                                    abort_on_failure, &
+                                    retry_burn, retry_burn_factor, retry_burn_max_change
 
     implicit none
 
@@ -60,26 +63,127 @@ contains
     real(rt),    intent(in   ) :: dt, time
 
     type (integration_status_t) :: status
+    real(rt) :: retry_change_factor
+    integer :: current_integrator
 
     !$gpu
 
-    status % atol_spec = atol_spec
-    status % rtol_spec = rtol_spec
+    ! Loop through all available integrators. Our strategy will be to
+    ! try the default integrator first. If the burn fails, we loosen
+    ! the tolerance and try again, and keep doing so until we succed.
+    ! If we keep failing and hit the threshold for how much tolerance
+    ! loosening we will accept, then we restart with the original tolerance
+    ! and switch to another integrator.
 
-    status % atol_temp = atol_temp
-    status % rtol_temp = rtol_temp
+    do current_integrator = 0, 1
 
-    status % atol_enuc = atol_enuc
-    status % rtol_enuc = rtol_enuc
+       retry_change_factor = ONE
+
+       status % atol_spec = atol_spec
+       status % rtol_spec = rtol_spec
+
+       status % atol_temp = atol_temp
+       status % rtol_temp = rtol_temp
+
+       status % atol_enuc = atol_enuc
+       status % rtol_enuc = rtol_enuc
+
+       ! Loop until we either succeed at the integration, or run
+       ! out of tolerance loosening to try.
+
+       do
 
 #if (INTEGRATOR == 0 || INTEGRATOR == 3)
-    call vode_integrator(state_in, state_out, dt, time, status)
-#elif INTEGRATOR == 1
-    call bs_integrator(state_in, state_out, dt, time, status)
-#ifndef AMREX_USE_CUDA
-    call amrex_error("Unknown integrator.")
+#ifndef CUDA
+          if (current_integrator == 0) then
+#endif
+             call vode_integrator(state_in, state_out, dt, time, status)
+#ifndef CUDA
+          else if (current_integrator == 1) then
+             call bs_integrator(state_in, state_out, dt, time, status)
+          endif
+#endif
+#elif (INTEGRATOR == 1)
+#ifndef CUDA
+          if (current_integrator == 0) then
+             call bs_integrator(state_in, state_out, dt, time, status)
+          else if (current_integrator == 1) then
+#endif
+             call vode_integrator(state_in, state_out, dt, time, status)
+#ifndef CUDA
+          endif
 #endif
 #endif
+
+          if (state_out % success) exit
+
+          if (.not. retry_burn) exit
+
+          ! If we got here, the integration failed; loosen the tolerances.
+
+          if (retry_change_factor < retry_burn_max_change) then
+
+             print *, "Retrying burn with looser tolerances in zone ", state_in % i, state_in % j, state_in % k
+
+             retry_change_factor = retry_change_factor * retry_burn_factor
+
+             status % atol_spec = status % atol_spec * retry_burn_factor
+             status % rtol_spec = status % rtol_spec * retry_burn_factor
+
+             status % atol_temp = status % atol_temp * retry_burn_factor
+             status % rtol_temp = status % rtol_temp * retry_burn_factor
+
+             status % atol_enuc = status % atol_enuc * retry_burn_factor
+             status % rtol_enuc = status % rtol_enuc * retry_burn_factor
+
+             print *, "New tolerance loosening factor = ", retry_change_factor
+
+          else
+
+             if (current_integrator < 1) then
+
+#ifndef CUDA
+#if (INTEGRATOR == 0 || INTEGRATOR == 3)
+                print *, "Retrying burn with BS integrator"
+#elif (INTEGRATOR == 1)
+                print *, "Retrying burn with VODE integrator"
+#endif
+#endif
+
+             end if
+
+             ! Switch to the next integrator (if there is one).
+
+             exit
+
+          end if
+
+       end do
+
+       ! No need to do the next integrator if we have already succeeded.
+
+       if (state_out % success) exit
+
+       if (.not. retry_burn) exit
+
+    end do
+
+    ! If we get to this point and have not succeded, all available integrators have
+    ! failed at all available tolerances; we must either abort, or return to the
+    ! driver routine calling the burner, and attempt some other approach such as
+    ! subcycling the main advance.
+
+    if (.not. state_out % success) then
+
+       if (abort_on_failure) then
+#ifndef CUDA
+          call amrex_error("ERROR in burner: integration failed")
+#else
+          stop
+#endif
+       end if
+
+    endif
 
   end subroutine integrator
 

--- a/interfaces/sdc_type.F90
+++ b/interfaces/sdc_type.F90
@@ -38,6 +38,8 @@ module sdc_type_module
      integer :: n_jac
 
      integer :: sdc_iter
+
+     logical :: success
   end type sdc_t
 
 end module sdc_type_module


### PR DESCRIPTION
This is in conjunction with #695 for Castro. MAESTROeX will need a minor update since the `sdc_t` has had a field added.