### PR TITLE
fix an index bug in the Jacobian temperature element

### DIFF
--- a/integration/utils/temperature_integration.F90
+++ b/integration/utils/temperature_integration.F90
@@ -149,7 +149,7 @@ contains
        ! d(itemp)/d(yi)
        
        do k = 1, nspec_evolve
-          call get_jac_entry(state, net_ienuc, k, scratch)
+          call get_jac_entry(state, net_itemp, k, scratch)
           scratch = scratch * cspecInv
           call set_jac_entry(state, net_itemp, k, scratch)
        enddo


### PR DESCRIPTION
The temperature element was being accessed incorrectly and we were overwriting with the nuclear energy generation