### PR TITLE
Bugfixes for VODE's simplified SDC interface when nspec_evolve != nspec

### DIFF
--- a/integration/VODE/cuVODE/source/rpar.F90.template
+++ b/integration/VODE/cuVODE/source/rpar.F90.template
@@ -1,7 +1,7 @@
 ! rpar is a set of real quantities that we use to convert auxiliary data back
 ! and forth between the rhs and jacobian routines and the calling scope for dvode.
 !
-! This module is a stub for the user to extend, use this to store indices.
+! This module is a template for the user to extend, use this to store indices.
 !
 module vode_rpar_indices
 

--- a/integration/VODE/vode_type_simplified_sdc.F90
+++ b/integration/VODE/vode_type_simplified_sdc.F90
@@ -4,7 +4,7 @@ module vode_type_module
   use amrex_constants_module
   use cuvode_parameters_module, only : VODE_NEQS
 
-  use network, only : nspec, aion, aion_inv
+  use network, only : nspec, nspec_evolve, aion, aion_inv
 
   use vode_rpar_indices
   use sdc_type_module
@@ -234,8 +234,8 @@ contains
     ydot(:) = rpar(irp_ydot_a:irp_ydot_a-1+SVAR_EVOLVE)
 
     ! add in the reacting terms -- here we convert from dY/dt to dX/dt
-    ydot(SFS:SFS-1+nspec) = ydot(SFS:SFS-1+nspec) + &
-         rpar(irp_SRHO) * aion(1:nspec) * burn_state % ydot(1:nspec)
+    ydot(SFS:SFS-1+nspec_evolve) = ydot(SFS:SFS-1+nspec_evolve) + &
+         rpar(irp_SRHO) * aion(1:nspec_evolve) * burn_state % ydot(1:nspec_evolve)
 
 #if defined(SDC_EVOLVE_ENERGY)
 
@@ -267,26 +267,28 @@ contains
 
     !$gpu
 
+    jac(:,:) = ZERO
+
 #if defined(SDC_EVOLVE_ENERGY)
 
-    jac(SFS:SFS+nspec-1,SFS:SFS+nspec-1) = burn_state % jac(1:nspec,1:nspec)
-    jac(SFS:SFS+nspec-1,SEDEN) = burn_state % jac(1:nspec,net_ienuc)
-    jac(SFS:SFS+nspec-1,SEINT) = burn_state % jac(1:nspec,net_ienuc)
+    jac(SFS:SFS+nspec_evolve-1,SFS:SFS+nspec_evolve-1) = burn_state % jac(1:nspec_evolve,1:nspec_evolve)
+    jac(SFS:SFS+nspec_evolve-1,SEDEN) = burn_state % jac(1:nspec_evolve,net_ienuc)
+    jac(SFS:SFS+nspec_evolve-1,SEINT) = burn_state % jac(1:nspec_evolve,net_ienuc)
 
-    jac(SEDEN,SFS:SFS+nspec-1) = burn_state % jac(net_ienuc,1:nspec)
+    jac(SEDEN,SFS:SFS+nspec_evolve-1) = burn_state % jac(net_ienuc,1:nspec_evolve)
     jac(SEDEN,SEDEN) = burn_state % jac(net_ienuc,net_ienuc)
     jac(SEDEN,SEINT) = burn_state % jac(net_ienuc,net_ienuc)
 
-    jac(SEINT,SFS:SFS+nspec-1) = burn_state % jac(net_ienuc,1:nspec)
+    jac(SEINT,SFS:SFS+nspec_evolve-1) = burn_state % jac(net_ienuc,1:nspec_evolve)
     jac(SEINT,SEDEN) = burn_state % jac(net_ienuc,net_ienuc)
     jac(SEINT,SEINT) = burn_state % jac(net_ienuc,net_ienuc)
 
 #elif defined(SDC_EVOLVE_ENTHALPY)
 
-    jac(SFS:SFS+nspec-1,SFS:SFS+nspec-1) = burn_state % jac(1:nspec,1:nspec)
-    jac(SFS:SFS+nspec-1,SENTH) = burn_state % jac(1:nspec,net_ienuc)
+    jac(SFS:SFS+nspec_evolve-1,SFS:SFS+nspec_evolve-1) = burn_state % jac(1:nspec_evolve,1:nspec_evolve)
+    jac(SFS:SFS+nspec_evolve-1,SENTH) = burn_state % jac(1:nspec_evolve,net_ienuc)
 
-    jac(SENTH,SFS:SFS+nspec-1) = burn_state % jac(net_ienuc,1:nspec)
+    jac(SENTH,SFS:SFS+nspec_evolve-1) = burn_state % jac(net_ienuc,1:nspec_evolve)
     jac(SENTH,SENTH) = burn_state % jac(net_ienuc,net_ienuc)
 
 #endif

--- a/integration/VODE/vode_type_simplified_sdc.F90
+++ b/integration/VODE/vode_type_simplified_sdc.F90
@@ -267,8 +267,6 @@ contains
 
     !$gpu
 
-    jac(:,:) = ZERO
-
 #if defined(SDC_EVOLVE_ENERGY)
 
     jac(SFS:SFS+nspec_evolve-1,SFS:SFS+nspec_evolve-1) = burn_state % jac(1:nspec_evolve,1:nspec_evolve)


### PR DESCRIPTION
VODE's simplified SDC interface assumed that `nspec_evolve == nspec` by accessing `nspec` species elements of `burn_t % ydot` and `burn_t % jac` in the `rhs_to_vode` and `jac_to_vode` subroutines.

For simplified SDC, the integrator integrates all the species along with the energy terms, the unevolved species just see the advective sources. So accessing `nspec` elements from `ydot` and `jac` like we were doing yielded incorrect right hand side terms seen by the integrator for the unevolved species.

This is a likely culprit for the `NaN` in electron fraction observed in MAESTROeX simplified SDC tests with `ignition_simple`.

The BS integrator did this correctly.