### PR TITLE
Copy over some microphysics from Castro

### DIFF
--- a/EOS/gamma_law/Make.package
+++ b/EOS/gamma_law/Make.package
@@ -1,0 +1,1 @@
+F90EXE_sources += gamma_law.F90

--- a/EOS/gamma_law/_parameters
+++ b/EOS/gamma_law/_parameters
@@ -1,0 +1,2 @@
+eos_gamma            real     5.d0/3.d0
+eos_assume_neutral   logical  .true.

--- a/EOS/gamma_law/gamma_law.F90
+++ b/EOS/gamma_law/gamma_law.F90
@@ -1,0 +1,178 @@
+! This is a constant gamma equation of state, using an ideal gas.
+!
+! This a simplified version of the more general eos_gamma_general.
+!
+
+module actual_eos_module
+
+  use amrex_fort_module, only : rt => amrex_real
+  use castro_error_module
+  use amrex_constants_module
+  use eos_type_module
+
+  implicit none
+
+  character (len=64) :: eos_name = "gamma_law"
+
+  double precision, allocatable, save :: gamma_const
+
+  logical, allocatable, save :: assume_neutral
+
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: gamma_const, assume_neutral
+#endif
+
+  !$acc declare create(gamma_const, assume_neutral)
+
+contains
+
+  subroutine actual_eos_init
+
+    use extern_probin_module, only: eos_gamma, eos_assume_neutral
+
+    implicit none
+
+    allocate(gamma_const)
+    allocate(assume_neutral)
+
+    ! constant ratio of specific heats
+    if (eos_gamma .gt. 0.d0) then
+       gamma_const = eos_gamma
+    else
+       call castro_error("gamma_const cannot be < 0")
+    end if
+
+    assume_neutral = eos_assume_neutral
+
+    !$acc update device(gamma_const, assume_neutral)
+
+  end subroutine actual_eos_init
+
+  subroutine actual_eos_finalize()
+
+    implicit none
+
+  end subroutine actual_eos_finalize
+
+  subroutine actual_eos(input, state)
+
+    !$acc routine seq
+
+    use fundamental_constants_module, only: k_B, n_A
+    use network, only: aion, zion
+
+    implicit none
+
+    integer,      intent(in   ) :: input
+    type (eos_t), intent(inout) :: state
+
+    double precision, parameter :: R = k_B*n_A
+
+    double precision :: poverrho
+
+    !$gpu
+
+    ! Calculate mu.
+
+    if (assume_neutral) then
+       state % mu = state % abar
+    else
+       state % mu = ONE / sum( (ONE + zion(:)) * state % xn(:) / aion(:) )
+    endif
+
+    select case (input)
+
+    case (eos_input_rt)
+
+       ! dens, temp and xmass are inputs
+       state % cv = R / (state % mu * (gamma_const-ONE))
+       state % e = state % cv * state % T
+       state % p = (gamma_const-ONE) * state % rho * state % e
+       state % gam1 = gamma_const
+
+    case (eos_input_rh)
+
+       ! dens, enthalpy, and xmass are inputs
+
+#if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
+       call castro_error('EOS: eos_input_rh is not supported in this EOS.')
+#endif
+
+    case (eos_input_tp)
+
+       ! temp, pres, and xmass are inputs
+
+#if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
+       call castro_error('EOS: eos_input_tp is not supported in this EOS.')
+#endif
+
+    case (eos_input_rp)
+
+       ! dens, pres, and xmass are inputs
+
+       poverrho = state % p / state % rho
+       state % T = poverrho * state % mu * (ONE/R)
+       state % e = poverrho * (ONE/(gamma_const-ONE))
+       state % gam1 = gamma_const
+
+    case (eos_input_re)
+
+       ! dens, energy, and xmass are inputs
+
+       poverrho = (gamma_const - ONE) * state % e
+
+       state % p = poverrho * state % rho
+       state % T = poverrho * state % mu * (ONE/R)
+       state % gam1 = gamma_const
+
+       ! sound speed
+       state % cs = sqrt(gamma_const * poverrho)
+
+       state % dpdr_e = poverrho
+       state % dpde = (gamma_const-ONE) * state % rho
+
+       ! Try to avoid the expensive log function.  Since we don't need entropy
+       ! in hydro solver, set it to an invalid but "nice" value for the plotfile.
+       state % s = ONE
+
+    case (eos_input_ps)
+
+       ! pressure entropy, and xmass are inputs
+
+#if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
+       call castro_error('EOS: eos_input_ps is not supported in this EOS.')
+#endif
+
+    case (eos_input_ph)
+
+       ! pressure, enthalpy and xmass are inputs
+
+#if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
+       call castro_error('EOS: eos_input_ph is not supported in this EOS.')
+#endif
+
+    case (eos_input_th)
+
+       ! temperature, enthalpy and xmass are inputs
+
+       ! This system is underconstrained.
+
+#if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
+       call castro_error('EOS: eos_input_th is not a valid input for the gamma law EOS.')
+#endif
+
+    case default
+
+#if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
+       call castro_error('EOS: invalid input.')
+#endif
+
+    end select
+
+    ! Give dpdr a value for the purposes of the composition_derivatives routine.
+
+    state % dPdr = ZERO
+
+  end subroutine actual_eos
+
+end module actual_eos_module

--- a/EOS/gamma_law/gamma_law.F90
+++ b/EOS/gamma_law/gamma_law.F90
@@ -6,7 +6,7 @@
 module actual_eos_module
 
   use amrex_fort_module, only : rt => amrex_real
-  use castro_error_module
+  use amrex_error_module
   use amrex_constants_module
   use eos_type_module
 
@@ -39,7 +39,7 @@ contains
     if (eos_gamma .gt. 0.d0) then
        gamma_const = eos_gamma
     else
-       call castro_error("gamma_const cannot be < 0")
+       call amrex_error("gamma_const cannot be < 0")
     end if
 
     assume_neutral = eos_assume_neutral
@@ -95,7 +95,7 @@ contains
        ! dens, enthalpy, and xmass are inputs
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call castro_error('EOS: eos_input_rh is not supported in this EOS.')
+       call amrex_error('EOS: eos_input_rh is not supported in this EOS.')
 #endif
 
     case (eos_input_tp)
@@ -103,7 +103,7 @@ contains
        ! temp, pres, and xmass are inputs
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call castro_error('EOS: eos_input_tp is not supported in this EOS.')
+       call amrex_error('EOS: eos_input_tp is not supported in this EOS.')
 #endif
 
     case (eos_input_rp)
@@ -140,7 +140,7 @@ contains
        ! pressure entropy, and xmass are inputs
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call castro_error('EOS: eos_input_ps is not supported in this EOS.')
+       call amrex_error('EOS: eos_input_ps is not supported in this EOS.')
 #endif
 
     case (eos_input_ph)
@@ -148,7 +148,7 @@ contains
        ! pressure, enthalpy and xmass are inputs
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call castro_error('EOS: eos_input_ph is not supported in this EOS.')
+       call amrex_error('EOS: eos_input_ph is not supported in this EOS.')
 #endif
 
     case (eos_input_th)
@@ -158,13 +158,13 @@ contains
        ! This system is underconstrained.
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call castro_error('EOS: eos_input_th is not a valid input for the gamma law EOS.')
+       call amrex_error('EOS: eos_input_th is not a valid input for the gamma law EOS.')
 #endif
 
     case default
 
 #if (!(defined(AMREX_USE_ACC) || defined(AMREX_USE_CUDA)))
-       call castro_error('EOS: invalid input.')
+       call amrex_error('EOS: invalid input.')
 #endif
 
     end select

--- a/EOS/rad_power_law/Make.package
+++ b/EOS/rad_power_law/Make.package
@@ -1,0 +1,1 @@
+F90EXE_sources += rad_power_law.F90

--- a/EOS/rad_power_law/_parameters
+++ b/EOS/rad_power_law/_parameters
@@ -1,0 +1,3 @@
+eos_const_c_v        real     -1.d0
+eos_c_v_exp_m        real      0.d0
+eos_c_v_exp_n        real      0.d0

--- a/EOS/rad_power_law/rad_power_law.F90
+++ b/EOS/rad_power_law/rad_power_law.F90
@@ -31,7 +31,7 @@ contains
   subroutine actual_eos_init
 
     use extern_probin_module, only: eos_const_c_v, eos_c_v_exp_m, eos_c_v_exp_n
-    use castro_error_module, only: castro_error
+    use amrex_error_module, only: amrex_error
 
     implicit none
 
@@ -44,11 +44,11 @@ contains
     c_v_exp_n = eos_c_v_exp_n
 
     if (const_c_v .le. 0.e0_rt) then
-       call castro_error("eos_const_c_v must be > 0")
+       call amrex_error("eos_const_c_v must be > 0")
     end if
 
     if (c_v_exp_n .eq. 1.0e0_rt) then
-       call castro_error("eos_c_v_exp_n == 1 is unsupported")
+       call amrex_error("eos_c_v_exp_n == 1 is unsupported")
     end if
 
   end subroutine actual_eos_init
@@ -70,7 +70,7 @@ contains
   subroutine actual_eos(input, state)
 
 #ifndef AMREX_USE_GPU
-    use castro_error_module, only: castro_error
+    use amrex_error_module, only: amrex_error
 #endif
 
     implicit none
@@ -95,7 +95,7 @@ contains
     case default
 
 #ifndef AMREX_USE_GPU
-       call castro_error('EOS: invalid input.')
+       call amrex_error('EOS: invalid input.')
 #endif
 
     end select

--- a/EOS/rad_power_law/rad_power_law.F90
+++ b/EOS/rad_power_law/rad_power_law.F90
@@ -1,0 +1,118 @@
+! This is an artificial equation of state used primarily for radiation tests.
+!
+! It is defined by the relationship:
+! c_v = K * rho**m * T**(-n)
+! where K, m, and n are user-defined constant parameters.
+!
+! Ignoring the integration constant, we thus have the relationships:
+! e = K * rho**m * T**(1-n) / (1 - n)
+! T = ((1 - n) * e * rho**(-m) / K)**(1/(1-n))
+!
+! Consequently the only input modes supported are eos_input_rt and eos_input_re.
+! Pressure and Gamma_1 are not defined, so this EOS cannot be used for hydro.
+
+module actual_eos_module
+
+  use amrex_fort_module, only: rt => amrex_real
+  use eos_type_module, only: eos_t, eos_input_rt, eos_input_re
+
+  implicit none
+
+  character (len=64) :: eos_name = "rad_power_law"
+
+  real(rt), allocatable, save :: const_c_v, c_v_exp_m, c_v_exp_n
+
+#ifdef AMREX_USE_CUDA
+  attributes(managed) :: const_c_v, c_v_exp_m, c_v_exp_n
+#endif
+
+contains
+
+  subroutine actual_eos_init
+
+    use extern_probin_module, only: eos_const_c_v, eos_c_v_exp_m, eos_c_v_exp_n
+    use castro_error_module, only: castro_error
+
+    implicit none
+
+    allocate(const_c_v)
+    allocate(c_v_exp_m)
+    allocate(c_v_exp_n)
+
+    const_c_v = eos_const_c_v
+    c_v_exp_m = eos_c_v_exp_m
+    c_v_exp_n = eos_c_v_exp_n
+
+    if (const_c_v .le. 0.e0_rt) then
+       call castro_error("eos_const_c_v must be > 0")
+    end if
+
+    if (c_v_exp_n .eq. 1.0e0_rt) then
+       call castro_error("eos_c_v_exp_n == 1 is unsupported")
+    end if
+
+  end subroutine actual_eos_init
+
+
+
+  subroutine actual_eos_finalize()
+
+    implicit none
+
+    deallocate(const_c_v)
+    deallocate(c_v_exp_m)
+    deallocate(c_v_exp_n)
+
+  end subroutine actual_eos_finalize
+
+
+
+  subroutine actual_eos(input, state)
+
+#ifndef AMREX_USE_GPU
+    use castro_error_module, only: castro_error
+#endif
+
+    implicit none
+
+    integer,      intent(in   ) :: input
+    type (eos_t), intent(inout) :: state
+
+    !$gpu
+
+    select case (input)
+
+    case (eos_input_rt)
+
+       state % cv = const_c_v * state % rho**c_v_exp_m * state % T**(-c_v_exp_n)
+       state % e = const_c_v * state % rho**c_v_exp_m * state % T**(1 - c_v_exp_n) / (1 - c_v_exp_n)
+
+    case (eos_input_re)
+
+       state % T = ((1 - c_v_exp_n) * state % e * state % rho**(-c_v_exp_m) / const_c_v)**(1 / (1 - c_v_exp_n))
+       state % cv = const_c_v * state % rho**c_v_exp_m * state % T**(-c_v_exp_n)
+
+    case default
+
+#ifndef AMREX_USE_GPU
+       call castro_error('EOS: invalid input.')
+#endif
+
+    end select
+
+    ! Set some data to nonsense values so that things intentionally go wrong
+    ! if this EOS is somehow used for hydro.
+
+    state % p    = -1.e0_rt
+    state % gam1 = -1.e0_rt
+    state % cs   = -1.e0_rt
+    state % s    = -1.e0_rt
+    state % h    = -1.e0_rt
+
+    ! Give dpdr a value for the purposes of the composition_derivatives routine.
+
+    state % dPdr = 0.e0_rt
+
+  end subroutine actual_eos
+
+end module actual_eos_module

--- a/interfaces/Make.package
+++ b/interfaces/Make.package
@@ -10,6 +10,7 @@ endif
 
 ifeq ($(USE_REACT), TRUE)
   F90EXE_sources += burn_type.F90
+  F90EXE_sources += burner.F90
 endif
 ifeq ($(USE_SIMPLIFIED_SDC), TRUE)
   F90EXE_sources += sdc_type.F90

--- a/interfaces/Make.package
+++ b/interfaces/Make.package
@@ -3,7 +3,10 @@ F90EXE_sources += network.F90
 F90EXE_sources += eos.F90
 F90EXE_sources += eos_override.F90
 F90EXE_sources += eos_type.F90
-F90EXE_sources += conductivity.F90
+
+ifeq ($(USE_CONDUCTIVITY), TRUE)
+  F90EXE_sources += conductivity.F90
+endif
 
 ifeq ($(USE_REACT), TRUE)
   F90EXE_sources += burn_type.F90

--- a/interfaces/Make.package
+++ b/interfaces/Make.package
@@ -3,6 +3,7 @@ F90EXE_sources += network.F90
 F90EXE_sources += eos.F90
 F90EXE_sources += eos_override.F90
 F90EXE_sources += eos_type.F90
+F90EXE_sources += conductivity.F90
 
 ifeq ($(USE_REACT), TRUE)
   F90EXE_sources += burn_type.F90

--- a/interfaces/burner.F90
+++ b/interfaces/burner.F90
@@ -1,0 +1,50 @@
+module burner_module
+
+  use amrex_fort_module, only: rt => amrex_real
+  use burn_type_module, only: burn_t
+
+  logical, save :: burner_initialized = .false.
+
+contains
+
+  subroutine burner_init() bind(C, name="burner_init")
+
+#ifdef SIMPLIFIED_SDC
+    use integrator_module, only: integrator_init
+#else
+    use actual_burner_module, only: actual_burner_init
+#endif
+
+    implicit none
+
+#ifdef SIMPLIFIED_SDC
+    call integrator_init()
+#else
+    call actual_burner_init()
+#endif
+
+    burner_initialized = .true.
+
+  end subroutine burner_init
+
+
+
+#ifndef SIMPLIFIED_SDC
+  subroutine burner(state_in, state_out, dt, time)
+
+    use actual_burner_module, only: actual_burner
+
+    implicit none
+
+    type (burn_t), intent(inout) :: state_in
+    type (burn_t), intent(inout) :: state_out
+    real(rt), intent(in) :: dt, time
+
+    !$gpu
+
+    call actual_burner(state_in, state_out, dt, time)
+
+  end subroutine burner
+#endif
+
+end module burner_module

--- a/interfaces/conductivity.F90
+++ b/interfaces/conductivity.F90
@@ -26,7 +26,7 @@ contains
 
   ! a generic wrapper that calls the EOS and then the conductivity
 
-  subroutine conducteos(input, state, cond)
+  subroutine conducteos(input, state)
 
     use actual_conductivity_module
     use eos_type_module, only : eos_t
@@ -36,26 +36,28 @@ contains
 
     integer       , intent(in   ) :: input
     type (eos_t)  , intent(inout) :: state
-    real(rt) , intent(inout) :: cond
+
+    !$gpu
 
     ! call the EOS, passing through the arguments we called conducteos with
     call eos(input, state)
 
-    call actual_conductivity(state, cond)
+    call actual_conductivity(state)
 
   end subroutine conducteos
 
-  subroutine conductivity(state, cond)
+  subroutine conductivity(state)
 
     use actual_conductivity_module
     use eos_type_module, only : eos_t
 
     implicit none
 
-    type (eos_t)  , intent(inout) :: state
-    real(rt) , intent(inout) :: cond
+    !$gpu
 
-    call actual_conductivity(state, cond)
+    type (eos_t)  , intent(inout) :: state
+
+    call actual_conductivity(state)
 
   end subroutine conductivity
 

--- a/opacity/Readme
+++ b/opacity/Readme
@@ -1,0 +1,14 @@
+
+An opacity module must include 
+
+* subroutine init_opacity_table()
+
+* module opacity_table_module
+  that must include the following subroutines (which 
+** subroutine get_opacities()
+   for photon simulations
+** subroutines get_opacity_emissivity() & prep_opacity()
+   for neutrino simulations
+
+Note that these subroutines could be empty if they are not being used.
+But they must be there, otherwise the code won't compile. 

--- a/opacity/breakout/Make.package
+++ b/opacity/breakout/Make.package
@@ -1,0 +1,1 @@
+F90EXE_sources += opacity_table_module.F90

--- a/opacity/breakout/opacity_table_module.F90
+++ b/opacity/breakout/opacity_table_module.F90
@@ -1,0 +1,93 @@
+module opacity_table_module
+
+  implicit none
+
+contains
+
+!     ============================================
+!
+!     opacity for a given temperature and density
+!
+!     input:   nu    - radiation frequency (Hz)
+!              temp  - temperature  (K)
+!              rhoYe - rho*Ye
+!              rho   - density    (g cm^-3)
+!     output:  kp    - Planck mean opacity  (1/cm)
+!              kr    - Rosseland mean opacity  (1/cm)
+
+  subroutine get_opacities(kp, kr, rho, temp, rhoYe, nu, get_Planck_mean, get_Rosseland_mean)
+
+    implicit none
+
+    logical, intent(in) :: get_Planck_mean, get_Rosseland_mean
+    double precision, intent(in) :: rho, temp, rhoYe, nu
+    double precision, intent(out) :: kp, kr
+
+    double precision, parameter :: Ksc = 0.4d0 ! Thomson scattering 
+    double precision, parameter :: fac = 1.d-4 ! Planck mean is assumed to be fac*Ksc
+
+    !$gpu
+
+    if (get_planck_mean) then
+       kp = rhoYe*Ksc * fac
+    end if
+
+    if (get_Rosseland_mean) then
+       kr = rhoYe*Ksc
+    end if
+
+  end subroutine get_opacities
+
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  ! dummies
+
+  subroutine get_opacity_emissivity( &
+       ab, sc, delta, eta,           &
+       rho, rdummy, temp, nu, idummy, comp_ab, comp_sc, ldummy)
+
+    implicit none
+
+    integer, intent(in) :: idummy
+    logical, intent(in) :: comp_ab, comp_sc, ldummy
+    double precision, intent(in) :: rho, rdummy, temp, nu
+    double precision, intent(out) :: ab, sc, delta, eta
+
+    !$gpu
+
+    ab = 0.d0
+    sc = 0.d0
+    delta = 0.d0
+    eta = 0.d0
+
+  end subroutine get_opacity_emissivity
+
+
+  subroutine prep_opacity(g, inu, er, der)
+
+    implicit none
+
+    integer, intent(in) :: g
+    integer, intent(out) :: inu
+    double precision, intent(out) :: er, der
+
+    inu = -1
+    er = 0.d0
+    der = 0.d0
+
+  end subroutine prep_opacity
+
+end module opacity_table_module
+
+
+! dummy
+subroutine init_opacity_table(iverb)
+
+  implicit none
+
+  integer :: iverb
+
+end subroutine init_opacity_table
+
+

--- a/opacity/rad_power_law/Make.package
+++ b/opacity/rad_power_law/Make.package
@@ -1,0 +1,1 @@
+F90EXE_sources += opacity_table_module.F90

--- a/opacity/rad_power_law/_parameters
+++ b/opacity/rad_power_law/_parameters
@@ -1,0 +1,41 @@
+# Opacity constant (Planck)
+const_kappa_p                real           -1.0d0
+
+# Density exponent (Planck)
+kappa_p_exp_m                real            0.0d0
+
+# Temperature exponent (Planck)
+kappa_p_exp_n                real            0.0d0
+
+# Frequency exponent (Planck)
+kappa_p_exp_p                real            0.0d0
+
+# Opacity constant (Rosseland)
+const_kappa_r                real           -1.0d0
+
+# Density exponent (Rosseland)
+kappa_r_exp_m                real            0.0d0
+
+# Temperature exponent (Rosseland)
+kappa_r_exp_n                real            0.0d0
+
+# Frequency exponent (Rosseland)
+kappa_r_exp_p                real            0.0d0
+
+# Opacity constant (scattering)
+const_scatter                real            0.0d0
+
+# Density exponent (scattering)
+scatter_exp_m                real            0.0d0
+
+# Temperature exponent (scattering)
+scatter_exp_n                real            0.0d0
+
+# Frequency exponent (scattering)
+scatter_exp_p                real            0.0d0
+
+# Opacity floor
+kappa_floor                  real            0.0d0
+
+# Temperature floor
+rad_temp_floor               real            1.d-10

--- a/opacity/rad_power_law/opacity_table_module.F90
+++ b/opacity/rad_power_law/opacity_table_module.F90
@@ -29,7 +29,7 @@ contains
   subroutine get_opacities(kp, kr, rho, temp, rhoYe, nu, get_Planck_mean, get_Rosseland_mean)
 
 #ifndef AMREX_USE_GPU
-    use castro_error_module, only: castro_error
+    use amrex_error_module, only: amrex_error
 #endif
 
     implicit none
@@ -54,7 +54,7 @@ contains
     if (get_Planck_mean) then
 #ifndef AMREX_USE_GPU
        if (const_kappa_p < 0.0_rt) then
-          call castro_error("Must set Planck opacity constant")
+          call amrex_error("Must set Planck opacity constant")
        end if
 #endif
        kp = const_kappa_p * (rho**kappa_p_exp_m) * (teff**(-kappa_p_exp_n)) * nup_kpp
@@ -64,7 +64,7 @@ contains
     if (get_Rosseland_mean) then
 #ifndef AMREX_USE_GPU
        if (const_kappa_r < 0.0_rt) then
-          call castro_error("Must set Rosseland opacity constant")
+          call amrex_error("Must set Rosseland opacity constant")
        end if
 #endif
        kr = const_kappa_r * (rho**kappa_r_exp_m) * (teff**(-kappa_r_exp_n)) * nup_kpr

--- a/opacity/rad_power_law/opacity_table_module.F90
+++ b/opacity/rad_power_law/opacity_table_module.F90
@@ -1,0 +1,128 @@
+! This is an artificial opacity designed for use with radiation
+! testing problems.
+
+module opacity_table_module
+
+  use amrex_fort_module, only: rt => amrex_real
+  use extern_probin_module, only: const_kappa_p, kappa_p_exp_m, kappa_p_exp_n, kappa_p_exp_p, &
+                                  const_kappa_r, kappa_r_exp_m, kappa_r_exp_n, kappa_r_exp_p, &
+                                  const_scatter, scatter_exp_m, scatter_exp_n, scatter_exp_p, &
+                                  kappa_floor, rad_temp_floor
+
+  implicit none
+
+  real(rt), parameter, private :: tiny = 1.e-50_rt
+
+contains
+
+  ! ============================================
+  !
+  ! opacity for a given temperature and density
+  !
+  ! input:   nu    - radiation frequency (Hz)
+  !          temp  - temperature  (K)
+  !          rho   - density    (g cm^-3)
+  !          rhoYe - rho*Ye
+  ! output:  kp    - Planck mean opacity  (1/cm)
+  !          kr    - Rosseland mean opacity  (1/cm)
+
+  subroutine get_opacities(kp, kr, rho, temp, rhoYe, nu, get_Planck_mean, get_Rosseland_mean)
+
+#ifndef AMREX_USE_GPU
+    use castro_error_module, only: castro_error
+#endif
+
+    implicit none
+
+    logical,  intent(in   ) :: get_Planck_mean, get_Rosseland_mean
+    real(rt), intent(in   ) :: rho, temp, rhoYe, nu
+    real(rt), intent(inout) :: kp, kr
+
+    real(rt) :: teff, nup_kpp, nup_kpr, nup_kps, ks
+
+    !$gpu
+
+    nup_kpp = nu**kappa_p_exp_p
+    nup_kpr = nu**kappa_r_exp_p
+    nup_kps = nu**scatter_exp_p
+
+    teff = max(temp, tiny)
+    teff = teff + rad_temp_floor * exp(-teff / (rad_temp_floor + tiny))
+
+    ks = const_scatter * (rho**scatter_exp_m) * (teff**(-scatter_exp_n)) * nup_kps
+
+    if (get_Planck_mean) then
+#ifndef AMREX_USE_GPU
+       if (const_kappa_p < 0.0_rt) then
+          call castro_error("Must set Planck opacity constant")
+       end if
+#endif
+       kp = const_kappa_p * (rho**kappa_p_exp_m) * (teff**(-kappa_p_exp_n)) * nup_kpp
+       kp = max(kp, kappa_floor)
+    end if
+
+    if (get_Rosseland_mean) then
+#ifndef AMREX_USE_GPU
+       if (const_kappa_r < 0.0_rt) then
+          call castro_error("Must set Rosseland opacity constant")
+       end if
+#endif
+       kr = const_kappa_r * (rho**kappa_r_exp_m) * (teff**(-kappa_r_exp_n)) * nup_kpr
+       kr = max(kr + ks, kappa_floor)
+    end if
+
+  end subroutine get_opacities
+
+
+
+  ! dummies
+
+  subroutine get_opacity_emissivity( &
+       ab, sc, delta, eta,           &
+       rho, rdummy, temp, nu, idummy, comp_ab, comp_sc, ldummy)
+
+    implicit none
+
+    integer,  intent(in   ) :: idummy
+    logical,  intent(in   ) :: comp_ab, comp_sc, ldummy
+    real(rt), intent(in   ) :: rho, rdummy, temp, nu
+    real(rt), intent(inout) :: ab, sc, delta, eta
+
+    !$gpu
+
+    ab = 0.d0
+    sc = 0.d0
+    delta = 0.d0
+    eta = 0.d0
+
+  end subroutine get_opacity_emissivity
+
+
+
+  subroutine prep_opacity(g, inu, er, der)
+
+    implicit none
+
+    integer,  intent(in   ) :: g
+    integer,  intent(inout) :: inu
+    real(rt), intent(inout) :: er, der
+
+    inu = -1
+    er = 0.d0
+    der = 0.d0
+
+  end subroutine prep_opacity
+
+end module opacity_table_module
+
+
+
+subroutine init_opacity_table(iverb)
+
+  use opacity_table_module
+
+  implicit none
+
+  integer :: iverb
+
+end subroutine init_opacity_table

--- a/viscosity/constant/Make.package
+++ b/viscosity/constant/Make.package
@@ -1,0 +1,2 @@
+f90EXE_sources += constant_viscosity.f90
+

--- a/viscosity/constant/_parameters
+++ b/viscosity/constant/_parameters
@@ -1,0 +1,3 @@
+const_viscosity      real     1.0d-4
+
+

--- a/viscosity/constant/constant_viscosity.f90
+++ b/viscosity/constant/constant_viscosity.f90
@@ -1,0 +1,23 @@
+module viscosity_module
+
+  use amrex_fort_module, only : rt => amrex_real
+  use network
+  use eos_type_module
+  use eos_module
+
+  implicit none
+
+contains
+
+  subroutine viscous_coeff(eos_state, visc_coeff)
+    
+    use extern_probin_module, only: const_viscosity
+
+    type (eos_t), intent(in) :: eos_state
+    real (rt), intent(inout) :: visc_coeff
+
+    visc_coeff = const_viscosity
+    
+  end subroutine viscous_coeff
+
+end module viscosity_module


### PR DESCRIPTION
This includes the `opacity` and `viscosity` directories, as well as two toy equations of state (`gamma_law` and `rad_power_law`). A few interfaces are updated, including the EOS, burner, and conductivity.