### PR TITLE
add the aux names and 1/aion to the network auto generated stuff

### DIFF
--- a/interfaces/network.F90
+++ b/interfaces/network.F90
@@ -1,16 +1,6 @@
 ! the network module provides the information about the species we are
 ! advecting:
 !
-! nspec      -- the number of species
-!
-! aion       -- atomic number
-! zion       -- proton number
-!
-! aion_inv   -- 1/aion
-!
-! spec_names -- the name of the isotope
-! short_spec_names -- the abbreviated name of the isotope
-!
 ! This module contains the following routines:
 !
 !  network_init          -- initialize the isotope properties
@@ -28,15 +18,6 @@ module network
 
   logical :: network_initialized = .false.
 
-  ! this will be computed here, not in the actual network
-  real(rt), allocatable :: aion_inv(:)
-
-  !$acc declare create(aion_inv)
-
-#ifdef AMREX_USE_CUDA
-  attributes(managed) :: aion_inv
-#endif
-
 contains
 
   subroutine network_init()
@@ -45,8 +26,6 @@ contains
     use amrex_constants_module, only : ONE
 
     implicit none
-
-    allocate(aion_inv(nspec))
 
     ! First, we call the specific network initialization.
     ! This should set the number of species and number of
@@ -65,10 +44,6 @@ contains
     if ( naux .lt. 0 ) then
        call amrex_error("Network cannot have a negative number of auxiliary variables.")
     endif
-
-    aion_inv(:) = ONE/aion(:)
-
-    !$acc update device(aion_inv)
 
     network_initialized = .true.
 
@@ -135,10 +110,6 @@ contains
     implicit none
 
     call actual_network_finalize()
-
-    if (allocated(aion_inv)) then
-       deallocate(aion_inv)
-    endif
 
   end subroutine network_finalize
 

--- a/networks/general_null/gammalaw_aux.net
+++ b/networks/general_null/gammalaw_aux.net
@@ -1,0 +1,8 @@
+# this is the null description for a network containing H only
+#
+
+# name short-name aion zion
+ X X        1.0 1.0
+
+# auxillary variables
+__aux_Ye

--- a/networks/general_null/network.template
+++ b/networks/general_null/network.template
@@ -29,12 +29,12 @@ module actual_network
   character (len=16), save :: aux_names(naux)
   character (len= 5), save :: short_aux_names(naux)
 
-  real(rt), allocatable, save :: aion(:), zion(:)
+  real(rt), allocatable, save :: aion(:), aion_inv(:), zion(:)
 
-  !$acc declare create(aion, zion)
+  !$acc declare create(aion, aion_inv, zion)
 
 #ifdef AMREX_USE_CUDA
-  attributes(managed) :: aion, zion
+  attributes(managed) :: aion, aion_inv, zion
 #endif
 
   integer, parameter :: nrates = 0
@@ -51,15 +51,20 @@ contains
     @@SHORT_SPEC_NAMES@@
 
     allocate(aion(nspec))
+    allocate(aion_inv(nspec))
     allocate(zion(nspec))
 
     @@AION@@
+
+    @@AION_INV@@
 
     @@ZION@@
 
     @@AUX_NAMES@@
 
-    !$acc update device(aion, zion)
+    @@SHORT_AUX_NAMES@@
+
+    !$acc update device(aion, aion_inv, zion)
 
   end subroutine actual_network_init
 
@@ -70,6 +75,7 @@ contains
     implicit none
 
     deallocate(aion)
+    deallocate(aion_inv)
     deallocate(zion)
 
   end subroutine actual_network_finalize

--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -16,6 +16,10 @@ constexpr amrex::Real aion[NumSpec] = {
    @@AION@@
   };
 
+constexpr amrex::Real aion_inv[NumSpec] = {
+   @@AION_INV@@
+  };
+
 constexpr amrex::Real zion[NumSpec] = {
    @@ZION@@
   };
@@ -26,6 +30,14 @@ static const std::vector<std::string> short_spec_names_cxx = {
 
 static const std::vector<std::string> spec_names_cxx = {
    @@SPEC_NAMES@@
+  };
+
+static const std::vector<std::string> short_aux_names_cxx = {
+   @@SHORT_AUX_NAMES@@
+  };
+
+static const std::vector<std::string> aux_names_cxx = {
+   @@AUX_NAMES@@
   };
 
 #endif

--- a/networks/general_null/network_properties.template
+++ b/networks/general_null/network_properties.template
@@ -6,6 +6,7 @@
 !
 ! aion             -- atomic number
 ! zion             -- proton number
+! aion_inv         -- 1/atomic number
 !
 ! spec_names       -- the name of the isotope
 ! short_spec_names -- an abbreviated form of the species name
@@ -28,12 +29,12 @@ module network_properties
   character (len=16), save :: aux_names(naux)
   character (len= 5), save :: short_aux_names(naux)
 
-  real(rt), allocatable, save :: aion(:), zion(:), nion(:)
+  real(rt), allocatable, save :: aion(:), aion_inv(:), zion(:), nion(:)
 
-  !$acc declare create(aion, zion, nion)
+  !$acc declare create(aion, aion_inv, zion, nion)
 
 #ifdef AMREX_USE_CUDA
-  attributes(managed) :: aion, zion, nion
+  attributes(managed) :: aion, aion_inv, zion, nion
 #endif
 
 contains
@@ -45,6 +46,7 @@ contains
     @@SHORT_SPEC_NAMES@@
 
     allocate(aion(nspec))
+    allocate(aion_inv(nspec))
     allocate(zion(nspec))
     allocate(nion(nspec))
 
@@ -52,11 +54,15 @@ contains
 
     @@ZION@@
 
+    @@AION_INV@@
+
     ! Set the number of neutrons
     nion(:) = aion(:) - zion(:)
 
 
     @@AUX_NAMES@@
+
+    @@SHORT_AUX_NAMES@@
 
     !$acc update device(aion, zion)
 
@@ -70,6 +76,10 @@ contains
 
     if (allocated(aion)) then
        deallocate(aion)
+    end if
+
+    if (allocated(aion_inv)) then
+       deallocate(aion_inv)
     end if
 
     if (allocated(zion)) then

--- a/networks/general_null/write_network.py
+++ b/networks/general_null/write_network.py
@@ -229,6 +229,15 @@ def write_network(network_template, header_template,
                         for n, spec in enumerate(species):
                             fout.write("{}{},   // {} \n".format(indent, spec.A, n))
 
+                elif keyword == "AION_INV":
+                    if lang == "Fortran":
+                        for n, spec in enumerate(species):
+                            fout.write("{}aion_inv({}) = 1.0_rt/{}_rt\n".format(indent, n+1, spec.A))
+
+                    elif lang == "C++":
+                        for n, spec in enumerate(species):
+                            fout.write("{}1.0/{},   // {} \n".format(indent, spec.A, n))
+
                 elif keyword == "ZION":
                     if lang == "Fortran":
                         for n, spec in enumerate(species):
@@ -239,9 +248,22 @@ def write_network(network_template, header_template,
                             fout.write("{}{},   // {}\n".format(indent, spec.Z, n))
 
                 elif keyword == "AUX_NAMES":
-                    for n, aux in enumerate(aux_vars):
-                        fout.write("{}aux_names({}) = \"{}\"\n".format(indent, n+1, aux.name))
-                        fout.write("{}short_aux_names({}) = \"{}\"\n".format(indent, n+1, aux.name))
+                    if lang == "Fortran":
+                        for n, aux in enumerate(aux_vars):
+                            fout.write("{}aux_names({}) = \"{}\"\n".format(indent, n+1, aux.name))
+
+                    elif lang == "C++":
+                        for n, aux in enumerate(aux_vars):
+                            fout.write("{}\"{}\",   // {} \n".format(indent, aux.name, n))
+
+                elif keyword == "SHORT_AUX_NAMES":
+                    if lang == "Fortran":
+                        for n, aux in enumerate(aux_vars):
+                            fout.write("{}short_aux_names({}) = \"{}\"\n".format(indent, n+1, aux.name))
+
+                    elif lang == "C++":
+                        for n, aux in enumerate(aux_vars):
+                            fout.write("{}\"{}\",   // {} \n".format(indent, aux.name, n))
 
             else:
                 fout.write(line)


### PR DESCRIPTION
this adds the aux names to the C++ header, and 1/aion to all of the autogenerated net stuff (including general_null).

Closes #252 #254 