### PR TITLE
keep only a single specific heat

### DIFF
--- a/integration/BS/bs_type.F90
+++ b/integration/BS/bs_type.F90
@@ -144,10 +144,10 @@ contains
        call eos(eos_input_rt, eos_state)
 
        if (do_constant_volume_burn) then
-          state % burn_s % dcxdt = (eos_state % cv - state % burn_s % cv) / &
+          state % burn_s % dcxdt = (eos_state % cv - state % burn_s % cx) / &
                (eos_state % T - state % burn_s % T_old)
        else
-          state % burn_s % dcxdt = (eos_state % cp - state % burn_s % cp) / &
+          state % burn_s % dcxdt = (eos_state % cp - state % burn_s % cx) / &
                (eos_state % T - state % burn_s % T_old)
        end if
        state % burn_s % T_old  = eos_state % T
@@ -225,6 +225,7 @@ contains
     use eos_type_module, only: eos_t
     use bs_rpar_indices, only: irp_nspec, n_not_evolved
     use burn_type_module, only: net_itemp
+    use extern_probin_module, only: do_constant_volume_burn
 
     implicit none
 

--- a/integration/CVODE/cvode_rpar.F90
+++ b/integration/CVODE/cvode_rpar.F90
@@ -22,9 +22,8 @@ module cvode_rpar_indices
   integer, parameter :: n_not_evolved = nspec - nspec_evolve
 
   integer, parameter :: irp_dens = 1
-  integer, parameter :: irp_cv = irp_dens + 1
-  integer, parameter :: irp_cp = irp_cv + 1
-  integer, parameter :: irp_nspec = irp_cp + 1
+  integer, parameter :: irp_cx = irp_dens + 1
+  integer, parameter :: irp_nspec = irp_cx + 1
   integer, parameter :: irp_abar = irp_nspec + n_not_evolved
   integer, parameter :: irp_zbar = irp_abar + 1
   integer, parameter :: irp_eta = irp_zbar + 1
@@ -35,9 +34,8 @@ module cvode_rpar_indices
   integer, parameter :: irp_y_init = irp_t_sound + 1
   integer, parameter :: irp_self_heat = irp_y_init + neqs
   integer, parameter :: irp_Told = irp_self_heat + 1
-  integer, parameter :: irp_dcvdt = irp_Told + 1
-  integer, parameter :: irp_dcpdt = irp_dcvdt + 1
-  integer, parameter :: irp_t0 = irp_dcpdt + 1
+  integer, parameter :: irp_dcxdt = irp_Told + 1
+  integer, parameter :: irp_t0 = irp_dcxdt + 1
   integer, parameter :: irp_energy_offset = irp_t0 + 1
 
   integer, parameter :: n_rpar_comps = irp_energy_offset

--- a/integration/CVODE/cvode_type.F90
+++ b/integration/CVODE/cvode_type.F90
@@ -106,10 +106,10 @@ contains
        call eos(eos_input_rt, eos_state)
 
        if (do_constant_volume_burn) then
-          rpar(irp_dcxdt) = (eos_state % cv - rpar(irp_cv)) / &
+          rpar(irp_dcxdt) = (eos_state % cv - rpar(irp_cx)) / &
                (eos_state % T - rpar(irp_Told))
        else
-          rpar(irp_dcxdt) = (eos_state % cp - rpar(irp_cp)) / &
+          rpar(irp_dcxdt) = (eos_state % cp - rpar(irp_cx)) / &
                (eos_state % T - rpar(irp_Told))
        end if
        rpar(irp_Told)  = eos_state % T

--- a/integration/VBDF/vbdf_integrator.F90
+++ b/integration/VBDF/vbdf_integrator.F90
@@ -45,7 +45,7 @@ contains
                                     atol_spec, atol_temp, atol_enuc, &
                                     burning_mode, burning_mode_factor, &
                                     retry_burn, retry_burn_factor, retry_burn_max_change, &
-                                    call_eos_in_rhs, dT_crit
+                                    call_eos_in_rhs, dT_crit, do_constant_volume_burn
     use actual_rhs_module, only : update_unevolved_species
     use temperature_integration_module, only: self_heat
 
@@ -156,8 +156,11 @@ contains
 
        call eos(eos_input_rt, eos_state_temp)
 
-       ts % upar(irp_dcvdt,1) = (eos_state_temp % cv - eos_state_in % cv) / (eos_state_temp % T - eos_state_in % T)
-       ts % upar(irp_dcpdt,1) = (eos_state_temp % cp - eos_state_in % cp) / (eos_state_temp % T - eos_state_in % T)
+       if (do_constant_volume_burn) then
+          ts % upar(irp_dcxdt,1) = (eos_state_temp % cv - eos_state_in % cv) / (eos_state_temp % T - eos_state_in % T)
+       else
+          ts % upar(irp_dcxdt,1) = (eos_state_temp % cp - eos_state_in % cp) / (eos_state_temp % T - eos_state_in % T)
+       end if
 
     endif
 
@@ -198,8 +201,11 @@ contains
        ts % upar(irp_Told,1) = eos_state_in % T
 
        if (dT_crit < 1.0e19_rt) then
-          ts % upar(irp_dcvdt,1) = (eos_state_temp % cv - eos_state_in % cv) / (eos_state_temp % T - eos_state_in % T)
-          ts % upar(irp_dcpdt,1) = (eos_state_temp % cp - eos_state_in % cp) / (eos_state_temp % T - eos_state_in % T)
+          if (do_constant_volume_burn) then
+             ts % upar(irp_dcxdt,1) = (eos_state_temp % cv - eos_state_in % cv) / (eos_state_temp % T - eos_state_in % T)
+          else
+             ts % upar(irp_dcxdt,1) = (eos_state_temp % cp - eos_state_in % cp) / (eos_state_temp % T - eos_state_in % T)
+          end if
        endif
 
        do n = 1, neqs
@@ -252,8 +258,11 @@ contains
              ts % upar(irp_Told,1) = eos_state_in % T
 
              if (dT_crit < 1.0e19_rt) then
-                ts % upar(irp_dcvdt,1) = (eos_state_temp % cv - eos_state_in % cv) / (eos_state_temp % T - eos_state_in % T)
-                ts % upar(irp_dcpdt,1) = (eos_state_temp % cp - eos_state_in % cp) / (eos_state_temp % T - eos_state_in % T)
+                if (do_constant_volume_burn) then
+                   ts % upar(irp_dcxdt,1) = (eos_state_temp % cv - eos_state_in % cv) / (eos_state_temp % T - eos_state_in % T)
+                else
+                   ts % upar(irp_dcxdt,1) = (eos_state_temp % cp - eos_state_in % cp) / (eos_state_temp % T - eos_state_in % T)
+                end if
              endif
 
              do n = 1, neqs

--- a/integration/VBDF/vbdf_rpar.F90
+++ b/integration/VBDF/vbdf_rpar.F90
@@ -13,9 +13,8 @@ module vbdf_rpar_indices
   integer, parameter :: n_not_evolved = nspec - nspec_evolve
 
   integer, parameter :: irp_dens = 1
-  integer, parameter :: irp_cv = irp_dens + 1
-  integer, parameter :: irp_cp = irp_cv + 1
-  integer, parameter :: irp_nspec = irp_cp + 1
+  integer, parameter :: irp_cx = irp_dens + 1
+  integer, parameter :: irp_nspec = irp_cx + 1
   integer, parameter :: irp_abar = irp_nspec + n_not_evolved
   integer, parameter :: irp_zbar = irp_abar + 1
   integer, parameter :: irp_eta = irp_zbar + 1
@@ -26,9 +25,8 @@ module vbdf_rpar_indices
   integer, parameter :: irp_y_init = irp_t_sound + 1
   integer, parameter :: irp_self_heat = irp_y_init + neqs
   integer, parameter :: irp_Told = irp_self_heat + 1
-  integer, parameter :: irp_dcvdt = irp_Told + 1
-  integer, parameter :: irp_dcpdt = irp_dcvdt + 1
-  integer, parameter :: irp_t0 = irp_dcpdt + 1
+  integer, parameter :: irp_dcxdt = irp_Told + 1
+  integer, parameter :: irp_t0 = irp_dcxdt + 1
 
   integer, parameter :: n_rpar_comps = irp_t0
 

--- a/integration/VODE/vode_integrator.F90
+++ b/integration/VODE/vode_integrator.F90
@@ -34,7 +34,7 @@ contains
          atol_spec, atol_temp, atol_enuc, &
          burning_mode, burning_mode_factor, &
          retry_burn, retry_burn_factor, retry_burn_max_change, &
-         call_eos_in_rhs, dt_crit, ode_max_steps
+         call_eos_in_rhs, dt_crit, ode_max_steps, do_constant_volume_burn
     use actual_rhs_module, only : update_unevolved_species
     use cuvode_module, only: dvode
     use eos_module, only: eos
@@ -199,11 +199,13 @@ contains
        eos_state_temp % T = eos_state_in % T * (ONE + sqrt(epsilon(ONE)))
 
        call eos(eos_input_rt, eos_state_temp)
-
-       dvode_state % rpar(irp_dcvdt) = (eos_state_temp % cv - eos_state_in % cv) / &
-                                       (eos_state_temp % T - eos_state_in % T)
-       dvode_state % rpar(irp_dcpdt) = (eos_state_temp % cp - eos_state_in % cp) / &
-                                       (eos_state_temp % T - eos_state_in % T)
+       if (do_constant_volume_burn) then
+          dvode_state % rpar(irp_dcxdt) = (eos_state_temp % cv - eos_state_in % cv) / &
+               (eos_state_temp % T - eos_state_in % T)
+       else
+          dvode_state % rpar(irp_dcxdt) = (eos_state_temp % cp - eos_state_in % cp) / &
+               (eos_state_temp % T - eos_state_in % T)
+       end if
 
     endif
 
@@ -243,11 +245,13 @@ contains
        dvode_state % rpar(irp_Told) = eos_state_in % T
 
        if (dT_crit < 1.0e19_rt) then
-
-          dvode_state % rpar(irp_dcvdt) = (eos_state_temp % cv - eos_state_in % cv) / &
-                                          (eos_state_temp % T - eos_state_in % T)
-          dvode_state % rpar(irp_dcpdt) = (eos_state_temp % cp - eos_state_in % cp) / &
-                                          (eos_state_temp % T - eos_state_in % T)
+          if (do_constant_volume_burn) then
+             dvode_state % rpar(irp_dcxdt) = (eos_state_temp % cv - eos_state_in % cv) / &
+                  (eos_state_temp % T - eos_state_in % T)
+          else
+             dvode_state % rpar(irp_dcxdt) = (eos_state_temp % cp - eos_state_in % cp) / &
+                  (eos_state_temp % T - eos_state_in % T)
+          end if
 
        endif
 

--- a/integration/VODE/vode_rpar.F90
+++ b/integration/VODE/vode_rpar.F90
@@ -107,9 +107,8 @@ module vode_rpar_indices
   integer, parameter :: n_not_evolved = nspec - nspec_evolve
 
   integer, parameter :: irp_dens = 1
-  integer, parameter :: irp_cv = irp_dens + 1
-  integer, parameter :: irp_cp = irp_cv + 1
-  integer, parameter :: irp_nspec = irp_cp + 1
+  integer, parameter :: irp_cx = irp_dens + 1
+  integer, parameter :: irp_nspec = irp_cx + 1
   integer, parameter :: irp_abar = irp_nspec + n_not_evolved
   integer, parameter :: irp_zbar = irp_abar + 1
   integer, parameter :: irp_eta = irp_zbar + 1
@@ -120,9 +119,8 @@ module vode_rpar_indices
   integer, parameter :: irp_y_init = irp_t_sound + 1
   integer, parameter :: irp_self_heat = irp_y_init + neqs
   integer, parameter :: irp_Told = irp_self_heat + 1
-  integer, parameter :: irp_dcvdt = irp_Told + 1
-  integer, parameter :: irp_dcpdt = irp_dcvdt + 1
-  integer, parameter :: irp_t0 = irp_dcpdt + 1
+  integer, parameter :: irp_dcxdt = irp_Told + 1
+  integer, parameter :: irp_t0 = irp_dcxdt + 1
 
   integer, parameter :: n_rpar_comps = irp_t0 + 1
 #endif

--- a/integration/VODE/vode_type.F90
+++ b/integration/VODE/vode_type.F90
@@ -160,7 +160,7 @@ contains
     use vode_rpar_indices, only: irp_dens, irp_nspec, irp_cx, irp_abar, irp_zbar, &
                             irp_eta, irp_ye, irp_cs, n_rpar_comps, n_not_evolved
     use burn_type_module, only: neqs, net_itemp
-
+    use extern_probin_module, only : do_constant_volume_burn
     implicit none
 
     type (eos_t) :: state
@@ -175,6 +175,13 @@ contains
     state % xn(1:nspec_evolve) = y(1:nspec_evolve)
     state % xn(nspec_evolve+1:nspec) = &
          rpar(irp_nspec:irp_nspec+n_not_evolved-1)
+
+    ! is this needed?
+    if (do_constant_volume_burn) then
+       state % cv = rpar(irp_cx)
+    else
+       state % cp = rpar(irp_cx)
+    end if
 
     state % abar    = rpar(irp_abar)
     state % zbar    = rpar(irp_zbar)

--- a/integration/VODE/vode_type.F90
+++ b/integration/VODE/vode_type.F90
@@ -77,7 +77,7 @@ contains
     !$acc routine seq
     
     use amrex_constants_module, only: ZERO
-    use extern_probin_module, only: call_eos_in_rhs, dT_crit
+    use extern_probin_module, only: call_eos_in_rhs, dT_crit, do_constant_volume_burn
     use eos_type_module, only: eos_t, eos_input_rt
     use eos_composition_module, only : composition
     use eos_module, only: eos
@@ -176,7 +176,6 @@ contains
     state % xn(nspec_evolve+1:nspec) = &
          rpar(irp_nspec:irp_nspec+n_not_evolved-1)
 
-    state % cx      = rpar(irp_cx)
     state % abar    = rpar(irp_abar)
     state % zbar    = rpar(irp_zbar)
     state % eta     = rpar(irp_eta)
@@ -199,6 +198,7 @@ contains
     use vode_rpar_indices, only: irp_dens, irp_nspec, irp_cx, irp_abar, irp_zbar, &
                             irp_eta, irp_ye, irp_cs, n_rpar_comps, n_not_evolved
     use burn_type_module, only: neqs, net_itemp
+    use extern_probin_module, only : do_constant_volume_burn
 
     implicit none
 
@@ -215,7 +215,11 @@ contains
     rpar(irp_nspec:irp_nspec+n_not_evolved-1) = &
          state % xn(nspec_evolve+1:nspec)
 
-    rpar(irp_cx)                    = state % cx
+    if (do_constant_volume_burn) then
+       rpar(irp_cx)                    = state % cv
+    else
+       rpar(irp_cx)                    = state % cp
+    end if
     rpar(irp_abar)                  = state % abar
     rpar(irp_zbar)                  = state % zbar
     rpar(irp_eta)                   = state % eta

--- a/integration/utils/temperature_integration.F90
+++ b/integration/utils/temperature_integration.F90
@@ -101,7 +101,7 @@ contains
 
        if (.not. call_eos_in_rhs .and. dT_crit < 1.0e19_rt) then
 
-          cspec = state % cx + (state % T - state % T_old) * state % dxvdt
+          cspec = state % cx + (state % T - state % T_old) * state % dcxdt
 
        else
 
@@ -115,7 +115,7 @@ contains
 
        do k = 1, nspec_evolve
           call get_jac_entry(jac, net_ienuc, k, scratch)
-          scratch = scratch * cspecInv
+          scratch = scratch * cspec_inv
           call set_jac_entry(jac, net_itemp, k, scratch)
        enddo
 

--- a/interfaces/burn_type.F90
+++ b/interfaces/burn_type.F90
@@ -186,6 +186,7 @@ contains
     !$acc routine seq
 
     use eos_type_module, only: eos_t
+    use extern_probin_module, only : do_constant_volume_burn
 
     implicit none
 
@@ -201,6 +202,11 @@ contains
 #if naux > 0
     eos_state % aux  = burn_state % aux
 #endif
+    if (do_constant_volume_burn) then
+       eos_state % cv = burn_state % cx
+    else
+       eos_state % cp = burn_state % cx
+    end if
     eos_state % y_e  = burn_state % y_e
     eos_state % eta  = burn_state % eta
     eos_state % cs   = burn_state % cs

--- a/interfaces/burn_type.F90
+++ b/interfaces/burn_type.F90
@@ -44,8 +44,7 @@ module burn_type_module
     real(rt) :: aux(naux)
 #endif
 
-    real(rt) :: cv
-    real(rt) :: cp
+    real(rt) :: cx
     real(rt) :: y_e
     real(rt) :: eta
     real(rt) :: cs
@@ -57,8 +56,7 @@ module burn_type_module
     real(rt) :: T_old
 
     ! Temperature derivatives of specific heat
-    real(rt) :: dcvdT
-    real(rt) :: dcpdT
+    real(rt) :: dcxdT
 
     ! The following are the actual integration data.
     ! To avoid potential incompatibilities we won't
@@ -114,8 +112,7 @@ contains
     to_state % aux(1:naux) = from_state % aux(1:naux)
 #endif
 
-    to_state % cv  = from_state % cv
-    to_state % cp  = from_state % cp
+    to_state % cx  = from_state % cx
     to_state % y_e = from_state % y_e
     to_state % eta = from_state % eta
     to_state % cs  = from_state % cs
@@ -126,8 +123,7 @@ contains
 
     to_state % T_old = from_state % T_old
 
-    to_state % dcvdT = from_state % dcvdT
-    to_state % dcpdT = from_state % dcpdT
+    to_state % dcxdT = from_state % dcxdT
 
     to_state % self_heat = from_state % self_heat
 
@@ -152,6 +148,7 @@ contains
     !$acc routine seq
 
     use eos_type_module, only: eos_t
+    use extern_probin_module, only : do_constant_volume_burn
 
     implicit none
 
@@ -167,8 +164,11 @@ contains
 #if naux > 0
     burn_state % aux  = eos_state % aux
 #endif
-    burn_state % cv   = eos_state % cv
-    burn_state % cp   = eos_state % cp
+    if (do_constant_volume_burn) then
+       burn_state % cx   = eos_state % cv
+    else
+       burn_state % cx   = eos_state % cp
+    endif
     burn_state % y_e  = eos_state % y_e
     burn_state % eta  = eos_state % eta
     burn_state % cs   = eos_state % cs
@@ -201,8 +201,6 @@ contains
 #if naux > 0
     eos_state % aux  = burn_state % aux
 #endif
-    eos_state % cv   = burn_state % cv
-    eos_state % cp   = burn_state % cp
     eos_state % y_e  = burn_state % y_e
     eos_state % eta  = burn_state % eta
     eos_state % cs   = burn_state % cs


### PR DESCRIPTION
We don't need both cv and cp, just whichever one is being used for T evolution.