### PR TITLE
get rid of nspec_evolve

### DIFF
--- a/integration/BS/bs_integrator.F90
+++ b/integration/BS/bs_integrator.F90
@@ -36,7 +36,6 @@ contains
 
     use bs_rpar_indices
     use extern_probin_module, only: burner_verbose, burning_mode, burning_mode_factor, dT_crit
-    use actual_rhs_module, only : update_unevolved_species
     use integration_data, only: integration_status_t
     use temperature_integration_module, only: self_heat
 

--- a/integration/BS/bs_integrator.F90
+++ b/integration/BS/bs_integrator.F90
@@ -70,13 +70,13 @@ contains
     ! to (a) decrease dT_crit, (b) increase the maximum number of
     ! steps allowed.
 
-    atol(1:nspec_evolve) = status % atol_spec ! mass fractions
-    atol(net_itemp)      = status % atol_temp ! temperature
-    atol(net_ienuc)      = status % atol_enuc ! energy generated
+    atol(1:nspec)   = status % atol_spec ! mass fractions
+    atol(net_itemp) = status % atol_temp ! temperature
+    atol(net_ienuc) = status % atol_enuc ! energy generated
 
-    rtol(1:nspec_evolve) = status % rtol_spec ! mass fractions
-    rtol(net_itemp)      = status % rtol_temp ! temperature
-    rtol(net_ienuc)      = status % rtol_enuc ! energy generated
+    rtol(1:nspec)   = status % rtol_spec ! mass fractions
+    rtol(net_itemp) = status % rtol_temp ! temperature
+    rtol(net_ienuc) = status % rtol_enuc ! energy generated
 
     ! Note that at present, we use a uniform error tolerance chosen
     ! to be the largest of the relative error tolerances for any
@@ -161,10 +161,6 @@ contains
             (eos_state_temp % T - eos_state_in % T)
     endif
 
-    ! Save the initial state.
-
-    bs % upar(irp_y_init:irp_y_init + neqs - 1) = bs % y
-
     ! Call the integration routine.
     call ode(bs, t0, t1, maxval(rtol), ierr)
 
@@ -210,8 +206,7 @@ contains
        print *, 'temp start = ', state_in % T
        print *, 'xn start = ', state_in % xn
        print *, 'temp current = ', bs % y(net_itemp)
-       print *, 'xn current = ', bs % y(1:nspec_evolve), &
-            bs % upar(irp_nspec:irp_nspec+n_not_evolved-1)
+       print *, 'xn current = ', bs % y(1:nspec)
        print *, 'energy generated = ', bs % y(net_ienuc) - ener_offset
 #endif
 
@@ -233,10 +228,6 @@ contains
     state_out = bs % burn_s
 
     state_out % success = success
-
-    if (nspec_evolve < nspec) then
-       call update_unevolved_species(state_out)
-    endif
 
     ! For burning_mode == 3, limit the burning.
 

--- a/integration/BS/bs_jac.F90
+++ b/integration/BS/bs_jac.F90
@@ -9,14 +9,14 @@ contains
 
     !$acc routine seq
 
-    use network, only: aion, aion_inv, nspec_evolve
+    use network, only: aion, aion_inv, nspec
     use amrex_constants_module, only: ZERO, ONE
     use network_rhs_module, only: network_jac
     use numerical_jac_module, only: numerical_jac
     use extern_probin_module, only: jacobian, integrate_temperature, integrate_energy, react_boost
     use burn_type_module, only: burn_t, net_ienuc, net_itemp, neqs
     use bs_type_module, only: bs_t, bs_to_burn, burn_to_bs
-    use bs_rpar_indices, only: irp_y_init, irp_t0
+    use bs_rpar_indices, only: irp_t0
 
     implicit none
 
@@ -37,7 +37,7 @@ contains
        call network_jac(bs % burn_s, bs % jac, bs % upar(irp_t0))
 
        ! We integrate X, not Y
-       do n = 1, nspec_evolve
+       do n = 1, nspec
           bs % jac(n,:) = bs % jac(n,:) * aion(n)
           bs % jac(:,n) = bs % jac(:,n) * aion_inv(n)
        enddo

--- a/integration/BS/bs_rhs.F90
+++ b/integration/BS/bs_rhs.F90
@@ -10,7 +10,7 @@ contains
 
     !$acc routine seq
 
-    use actual_network, only: aion, nspec_evolve
+    use actual_network, only: aion, nspec
     use amrex_fort_module, only : rt => amrex_real
     use burn_type_module, only: burn_t, net_ienuc, net_itemp
     use amrex_constants_module, only: ZERO, ONE
@@ -18,7 +18,7 @@ contains
     use extern_probin_module, only: integrate_temperature, integrate_energy, react_boost
     use bs_type_module, only: bs_t, clean_state, renormalize_species, update_thermodynamics, &
                               burn_to_bs, bs_to_burn
-    use bs_rpar_indices, only: irp_y_init, irp_t0
+    use bs_rpar_indices, only: irp_t0
 
     implicit none
 
@@ -26,7 +26,7 @@ contains
 
     ! We are integrating a system of
     !
-    ! y(1:nspec_evolve) = dX/dt
+    ! y(1:nspec)    = dX/dt
     ! y(net_itemp) = dT/dt
     ! y(net_ienuc) = denuc/dt
 
@@ -45,8 +45,7 @@ contains
     call network_rhs(bs % burn_s, bs % ydot, bs % upar(irp_t0))
 
     ! We integrate X, not Y
-    bs % ydot(1:nspec_evolve) = &
-         bs % ydot(1:nspec_evolve) * aion(1:nspec_evolve)
+    bs % ydot(1:nspec) = bs % ydot(1:nspec) * aion(1:nspec)
 
     ! Allow temperature and energy integration to be disabled.
     if (.not. integrate_temperature) then

--- a/integration/BS/bs_rpar.F90
+++ b/integration/BS/bs_rpar.F90
@@ -5,7 +5,7 @@
 module bs_rpar_indices
 
 #ifndef SIMPLIFIED_SDC
-  use actual_network, only: nspec, nspec_evolve
+  use actual_network, only: nspec
   use burn_type_module, only: neqs
 #else
   use sdc_type_module, only: SVAR_EVOLVE
@@ -15,11 +15,7 @@ module bs_rpar_indices
   implicit none
 
 #ifndef SIMPLIFIED_SDC
-  integer, parameter :: n_not_evolved = nspec - nspec_evolve
-
-  integer, parameter :: irp_nspec = 1
-  integer, parameter :: irp_y_init = irp_nspec + n_not_evolved
-  integer, parameter :: irp_t_sound = irp_y_init + neqs
+  integer, parameter :: irp_t_sound = 1
   integer, parameter :: irp_t0 = irp_t_sound + 1
 
   integer, parameter :: n_rpar_comps = irp_t0

--- a/integration/BS/bs_type_sdc.F90
+++ b/integration/BS/bs_type_sdc.F90
@@ -281,7 +281,7 @@ contains
 
     !$acc routine seq
 
-    use actual_network, only: nspec_evolve, aion
+    use actual_network, only: nspec, aion
     use burn_type_module, only: burn_t, net_ienuc, neqs
 
 #if defined(SDC_EVOLVE_ENERGY)
@@ -308,8 +308,8 @@ contains
 
     ! Add in the reacting terms from the burn_t
 
-    bs % ydot(SFS:SFS+nspec_evolve-1) = bs % ydot(SFS:SFS+nspec_evolve-1) + &
-                                        bs % u(irp_SRHO) * ydot_react(1:nspec_evolve) * aion(1:nspec_evolve)
+    bs % ydot(SFS:SFS+nspec-1) = bs % ydot(SFS:SFS+nspec-1) + &
+                                 bs % u(irp_SRHO) * ydot_react(1:nspec) * aion(1:nspec)
 
 #if defined(SDC_EVOLVE_ENERGY)
 
@@ -330,7 +330,7 @@ contains
 
     !$acc routine seq
 
-    use network, only: nspec_evolve, aion, aion_inv
+    use network, only: nspec, aion, aion_inv
     use burn_type_module, only: net_ienuc, neqs
 
 #if defined(SDC_EVOLVE_ENERGY)
@@ -350,24 +350,24 @@ contains
 
 #if defined(SDC_EVOLVE_ENERGY)
 
-    bs % jac(SFS:SFS+nspec_evolve-1,SFS:SFS+nspec_evolve-1) = jac(1:nspec_evolve,1:nspec_evolve)
-    bs % jac(SFS:SFS+nspec_evolve-1,SEDEN) = jac(1:nspec_evolve,net_ienuc)
-    bs % jac(SFS:SFS+nspec_evolve-1,SEINT) = jac(1:nspec_evolve,net_ienuc)
+    bs % jac(SFS:SFS+nspec-1,SFS:SFS+nspec-1) = jac(1:nspec,1:nspec)
+    bs % jac(SFS:SFS+nspec-1,SEDEN) = jac(1:nspec,net_ienuc)
+    bs % jac(SFS:SFS+nspec-1,SEINT) = jac(1:nspec,net_ienuc)
 
-    bs % jac(SEDEN,SFS:SFS+nspec_evolve-1) = jac(net_ienuc,1:nspec_evolve)
+    bs % jac(SEDEN,SFS:SFS+nspec-1) = jac(net_ienuc,1:nspec)
     bs % jac(SEDEN,SEDEN) = jac(net_ienuc,net_ienuc)
     bs % jac(SEDEN,SEINT) = jac(net_ienuc,net_ienuc)
 
-    bs % jac(SEINT,SFS:SFS+nspec_evolve-1) = jac(net_ienuc,1:nspec_evolve)
+    bs % jac(SEINT,SFS:SFS+nspec-1) = jac(net_ienuc,1:nspec)
     bs % jac(SEINT,SEDEN) = jac(net_ienuc,net_ienuc)
     bs % jac(SEINT,SEINT) = jac(net_ienuc,net_ienuc)
 
 #elif defined(SDC_EVOLVE_ENTHALPY)
 
-    bs % jac(SFS:SFS+nspec_evolve-1,SFS:SFS+nspec_evolve-1) = jac(1:nspec_evolve,1:nspec_evolve)
-    bs % jac(SFS:SFS+nspec_evolve-1,SENTH) = jac(1:nspec_evolve,net_ienuc)
+    bs % jac(SFS:SFS+nspec-1,SFS:SFS+nspec-1) = jac(1:nspec,1:nspec)
+    bs % jac(SFS:SFS+nspec-1,SENTH) = jac(1:nspec,net_ienuc)
 
-    bs % jac(SENTH,SFS:SFS+nspec_evolve-1) = jac(net_ienuc,1:nspec_evolve)
+    bs % jac(SENTH,SFS:SFS+nspec-1) = jac(net_ienuc,1:nspec)
     bs % jac(SENTH,SENTH) = jac(net_ienuc,net_ienuc)
 
 #endif
@@ -376,7 +376,7 @@ contains
     ! dependence, since every one of the SDC variables is linear in rho, so
     ! we just need to focus on the Y --> X conversion.
 
-    do n = 1, nspec_evolve
+    do n = 1, nspec
        bs % jac(SFS+n-1,:) = bs % jac(SFS+n-1,:) * aion(n)
        bs % jac(:,SFS+n-1) = bs % jac(:,SFS+n-1) * aion_inv(n)
     enddo

--- a/integration/CVODE/cvode_rhs.F90
+++ b/integration/CVODE/cvode_rhs.F90
@@ -13,7 +13,7 @@ contains
 
     !$acc routine seq
     
-    use actual_network, only: aion, nspec_evolve
+    use actual_network, only: aion, nspec
     use burn_type_module, only: burn_t, net_ienuc, net_itemp
     use amrex_constants_module, only: ZERO, ONE
     use network_rhs_module, only: network_rhs
@@ -36,7 +36,7 @@ contains
 
     ! We are integrating a system of
     !
-    ! y(1:nspec_evolve) = dX/dt
+    ! y(1:nspec)   = dX/dt
     ! y(net_itemp) = dT/dt
     ! y(net_ienuc) = denuc/dt
 
@@ -64,8 +64,7 @@ contains
     call network_rhs(burn_state)
 
     ! We integrate X, not Y
-    burn_state % ydot(1:nspec_evolve) = &
-         burn_state % ydot(1:nspec_evolve) * aion(1:nspec_evolve)
+    burn_state % ydot(1:nspec) = burn_state % ydot(1:nspec) * aion(1:nspec)
 
     ! Allow temperature and energy integration to be disabled.
     if (.not. integrate_temperature) then
@@ -87,7 +86,7 @@ contains
 
     !$acc routine seq
     
-    use network, only: aion, aion_inv, nspec_evolve, NETWORK_SPARSE_JAC_NNZ
+    use network, only: aion, aion_inv, nspec, NETWORK_SPARSE_JAC_NNZ
     use amrex_constants_module, only: ZERO
     use network_rhs_module, only: network_jac
     use burn_type_module, only: burn_t, net_ienuc, net_itemp
@@ -119,7 +118,7 @@ contains
     call network_jac(state)
 
     ! We integrate X, not Y
-    do n = 1, nspec_evolve
+    do n = 1, nspec
        do i = 1, VODE_NEQS
           call scale_jac_entry(state, n, i, aion(n))
           call scale_jac_entry(state, i, n, aion_inv(n))

--- a/integration/CVODE/cvode_rpar.F90
+++ b/integration/CVODE/cvode_rpar.F90
@@ -8,7 +8,7 @@
 module cvode_rpar_indices
 
 #ifndef SIMPLIFIED_SDC
-  use actual_network, only: nspec, nspec_evolve
+  use actual_network, only: nspec
   use burn_type_module, only: neqs
 #else
   use sdc_type_module, only: SVAR, SVAR_EVOLVE
@@ -19,13 +19,10 @@ module cvode_rpar_indices
 
 
 #ifndef SIMPLIFIED_SDC
-  integer, parameter :: n_not_evolved = nspec - nspec_evolve
-
   integer, parameter :: irp_dens = 1
   integer, parameter :: irp_cv = irp_dens + 1
   integer, parameter :: irp_cp = irp_cv + 1
-  integer, parameter :: irp_nspec = irp_cp + 1
-  integer, parameter :: irp_abar = irp_nspec + n_not_evolved
+  integer, parameter :: irp_abar = irp_cp+1
   integer, parameter :: irp_zbar = irp_abar + 1
   integer, parameter :: irp_eta = irp_zbar + 1
   integer, parameter :: irp_ye = irp_eta + 1

--- a/integration/CVODE/cvode_type.F90
+++ b/integration/CVODE/cvode_type.F90
@@ -420,7 +420,6 @@ contains
     use integrator_scaling_module, only: dens_scale, temp_scale, ener_scale
     use extern_probin_module, only: burning_mode
     use network, only: nspec
-    use actual_rhs_module, only : update_unevolved_species
     use burn_type_module, only: neqs, burn_t, net_ienuc, net_itemp, normalize_abundances_burn
     use cvode_rpar_indices, only: n_rpar_comps, irp_energy_offset, irp_dens
 

--- a/integration/CVODE/cvode_type.F90
+++ b/integration/CVODE/cvode_type.F90
@@ -14,7 +14,7 @@ contains
 
     !$acc routine seq
     
-    use actual_network, only: aion, nspec, nspec_evolve
+    use actual_network, only: aion, nspec
     use burn_type_module, only: neqs
     use cvode_rpar_indices, only: n_rpar_comps
 
@@ -26,7 +26,7 @@ contains
 
     ! Ensure that mass fractions always stay positive.
 
-    y(1:nspec_evolve) = max(y(1:nspec_evolve), 1.e-200_rt)
+    y(1:nspec) = max(y(1:nspec), 1.e-200_rt)
 
   end subroutine sk_clean_state
 
@@ -35,9 +35,9 @@ contains
 
     !$acc routine seq
     
-    use network, only: aion, aion_inv, nspec, nspec_evolve
+    use network, only: aion, aion_inv, nspec
     use burn_type_module, only: neqs
-    use cvode_rpar_indices, only: n_rpar_comps, irp_nspec, n_not_evolved
+    use cvode_rpar_indices, only: n_rpar_comps
     use extern_probin_module, only: renormalize_abundances
 
     implicit none
@@ -48,13 +48,8 @@ contains
 
     !$gpu
 
-    nspec_sum = &
-         sum(y(1:nspec_evolve)) + &
-         sum(rpar(irp_nspec:irp_nspec+n_not_evolved-1))
-
-    y(1:nspec_evolve) = y(1:nspec_evolve) / nspec_sum
-    rpar(irp_nspec:irp_nspec+n_not_evolved-1) = &
-         rpar(irp_nspec:irp_nspec+n_not_evolved-1) / nspec_sum
+    nspec_sum = sum(y(1:nspec))
+    y(1:nspec) = y(1:nspec) / nspec_sum
 
   end subroutine sk_renormalize_species
 
@@ -137,10 +132,10 @@ contains
     !$acc routine seq
 
     use integrator_scaling_module, only: dens_scale, temp_scale
-    use network, only: nspec, nspec_evolve, aion, aion_inv
+    use network, only: nspec, aion, aion_inv
     use eos_type_module, only: eos_t
-    use cvode_rpar_indices, only: irp_dens, irp_nspec, irp_cp, irp_cv, irp_abar, irp_zbar, &
-                            irp_eta, irp_ye, irp_cs, n_rpar_comps, n_not_evolved
+    use cvode_rpar_indices, only: irp_dens, irp_cp, irp_cv, irp_abar, irp_zbar, &
+                            irp_eta, irp_ye, irp_cs, n_rpar_comps
     use burn_type_module, only: neqs, net_itemp
 
     implicit none
@@ -154,9 +149,7 @@ contains
     state % rho     = rpar(irp_dens) * dens_scale
     state % T       = y(net_itemp) * temp_scale
 
-    state % xn(1:nspec_evolve) = y(1:nspec_evolve)
-    state % xn(nspec_evolve+1:nspec) = &
-         rpar(irp_nspec:irp_nspec+n_not_evolved-1)
+    state % xn(1:nspec) = y(1:nspec)
 
     state % cp      = rpar(irp_cp)
     state % cv      = rpar(irp_cv)
@@ -176,10 +169,10 @@ contains
     !$acc routine seq
 
     use integrator_scaling_module, only: inv_dens_scale, inv_temp_scale
-    use network, only: nspec, nspec_evolve, aion, aion_inv
+    use network, only: nspec, aion, aion_inv
     use eos_type_module, only: eos_t
-    use cvode_rpar_indices, only: irp_dens, irp_nspec, irp_cp, irp_cv, irp_abar, irp_zbar, &
-                            irp_eta, irp_ye, irp_cs, n_rpar_comps, n_not_evolved
+    use cvode_rpar_indices, only: irp_dens, irp_cp, irp_cv, irp_abar, irp_zbar, &
+                            irp_eta, irp_ye, irp_cs, n_rpar_comps
     use burn_type_module, only: neqs, net_itemp, net_ienuc
 
     implicit none
@@ -193,9 +186,7 @@ contains
     rpar(irp_dens) = state % rho * inv_dens_scale
     y(net_itemp) = state % T * inv_temp_scale
 
-    y(1:nspec_evolve) = state % xn(1:nspec_evolve)
-    rpar(irp_nspec:irp_nspec+n_not_evolved-1) = &
-         state % xn(nspec_evolve+1:nspec)
+    y(1:nspec) = state % xn(1:nspec)
 
     rpar(irp_cp)                    = state % cp
     rpar(irp_cv)                    = state % cv
@@ -216,11 +207,11 @@ contains
 
     use integrator_scaling_module, only: inv_dens_scale, inv_temp_scale, inv_ener_scale, temp_scale, ener_scale
     use amrex_constants_module, only: ONE
-    use network, only: nspec, nspec_evolve, aion, aion_inv, NETWORK_SPARSE_JAC_NNZ
-    use cvode_rpar_indices, only: irp_dens, irp_nspec, irp_cp, irp_cv, irp_abar, irp_zbar, &
+    use network, only: nspec, aion, aion_inv, NETWORK_SPARSE_JAC_NNZ
+    use cvode_rpar_indices, only: irp_dens, irp_cp, irp_cv, irp_abar, irp_zbar, &
                             irp_ye, irp_eta, irp_cs, irp_dx, &
                             irp_Told, irp_dcvdt, irp_dcpdt, irp_self_heat, &
-                            n_rpar_comps, n_not_evolved
+                            n_rpar_comps
     use burn_type_module, only: neqs, burn_t, net_itemp, net_ienuc
     use jacobian_sparsity_module, only: scale_csr_jac_entry
 
@@ -244,8 +235,7 @@ contains
     rpar(irp_dens) = state % rho * inv_dens_scale
     y(net_itemp) = state % T * inv_temp_scale
 
-    y(1:nspec_evolve) = state % xn(1:nspec_evolve)
-    rpar(irp_nspec:irp_nspec+n_not_evolved-1) = state % xn(nspec_evolve+1:nspec)
+    y(1:nspec) = state % xn(1:nspec)
 
     y(net_ienuc)                             = state % e * inv_ener_scale
 
@@ -303,11 +293,11 @@ contains
 
     use integrator_scaling_module, only: dens_scale, temp_scale, ener_scale
     use amrex_constants_module, only: ZERO
-    use network, only: nspec, nspec_evolve, aion, aion_inv
-    use cvode_rpar_indices, only: irp_dens, irp_nspec, irp_cp, irp_cv, irp_abar, irp_zbar, &
+    use network, only: nspec, aion, aion_inv
+    use cvode_rpar_indices, only: irp_dens, irp_cp, irp_cv, irp_abar, irp_zbar, &
                             irp_ye, irp_eta, irp_cs, irp_dx, &
                             irp_Told, irp_dcvdt, irp_dcpdt, irp_self_heat, &
-                            n_rpar_comps, n_not_evolved
+                            n_rpar_comps
     use burn_type_module, only: neqs, burn_t, net_itemp, net_ienuc
 
     implicit none
@@ -324,9 +314,7 @@ contains
     state % T        = y(net_itemp) * temp_scale
     state % e        = y(net_ienuc) * ener_scale
 
-    state % xn(1:nspec_evolve) = y(1:nspec_evolve)
-    state % xn(nspec_evolve+1:nspec) = &
-         rpar(irp_nspec:irp_nspec+n_not_evolved-1)
+    state % xn(1:nspec) = y(1:nspec)
 
     state % cp       = rpar(irp_cp)
     state % cv       = rpar(irp_cv)
@@ -360,7 +348,7 @@ contains
     use temperature_integration_module, only: self_heat
     use eos_type_module, only: eos_t, eos_input_rt, copy_eos_t
     use eos_module, only: eos
-    use network, only: nspec_evolve, aion_inv
+    use network, only: nspec, aion_inv
     use cvode_rpar_indices, only: n_rpar_comps, irp_self_heat, irp_t_sound, irp_dx, irp_dens, &
                             irp_Told, irp_dcvdt, irp_dcpdt, irp_y_init, irp_energy_offset
 
@@ -431,7 +419,7 @@ contains
 
     use integrator_scaling_module, only: dens_scale, temp_scale, ener_scale
     use extern_probin_module, only: burning_mode
-    use network, only: nspec, nspec_evolve
+    use network, only: nspec
     use actual_rhs_module, only : update_unevolved_species
     use burn_type_module, only: neqs, burn_t, net_ienuc, net_itemp, normalize_abundances_burn
     use cvode_rpar_indices, only: n_rpar_comps, irp_energy_offset, irp_dens
@@ -451,11 +439,6 @@ contains
     ! Convert to burn state out
     call vode_to_burn(y, rpar, burn_state)
     
-    ! Update unevolved species
-    if (nspec_evolve < nspec) then
-       call update_unevolved_species(burn_state)
-    endif
-
     ! TODO: support burning mode 3 limiting
     
     ! Normalize abundances

--- a/integration/VBDF/bdf_rhs.f90
+++ b/integration/VBDF/bdf_rhs.f90
@@ -12,7 +12,7 @@ contains
 
     !$acc routine seq
 
-    use actual_network, only: aion, nspec_evolve
+    use actual_network, only: aion, nspec
     use burn_type_module, only: burn_t, net_ienuc, net_itemp
     use amrex_constants_module, only: ZERO, ONE
     use network_rhs_module, only: network_rhs
@@ -31,7 +31,7 @@ contains
 
     ! We are integrating a system of
     !
-    ! y(1:nspec_evolve) = dX/dt
+    ! y(1:nspec)   = dX/dt
     ! y(net_itemp) = dT/dt
     ! y(net_ienuc) = denuc/dt
 
@@ -59,7 +59,7 @@ contains
     call network_rhs(burn_state, ts % yd(:,1), ts % upar(irp_t0,1))
 
     ! We integrate X not Y, so convert here
-    ts % yd(1:nspec_evolve,1) = ts % yd(1:nspec_evolve,1) * aion(1:nspec_evolve)
+    ts % yd(1:nspec,1) = ts % yd(1:nspec,1) * aion(1:nspec)
 
     ! Allow temperature and energy integration to be disabled.
 
@@ -92,7 +92,7 @@ contains
 
     !$acc routine seq
 
-    use network, only: aion, aion_inv, nspec_evolve
+    use network, only: aion, aion_inv, nspec
     use amrex_constants_module, only: ZERO, ONE
     use network_rhs_module, only: network_jac
     use numerical_jac_module, only: numerical_jac
@@ -124,7 +124,7 @@ contains
        call network_jac(state, ts % J(:,:,1), ts % upar(irp_t0,1))
 
        ! We integrate X, not Y
-       do n = 1, nspec_evolve
+       do n = 1, nspec
           ts % J(n,:,1) = ts % J(n,:,1) * aion(n)
           ts % J(:,n,1) = ts % J(:,n,1) * aion_inv(n)
        enddo

--- a/integration/VBDF/bdf_type.f90
+++ b/integration/VBDF/bdf_type.f90
@@ -86,7 +86,7 @@ contains
     !$acc routine seq
 
     use amrex_constants_module, only: ONE
-    use actual_network, only: nspec, nspec_evolve, aion
+    use actual_network, only: nspec, aion
     use burn_type_module, only: net_itemp
     use eos_type_module, only : eos_get_small_temp
 
@@ -106,7 +106,7 @@ contains
 
     ! Ensure that mass fractions always stay positive.
 
-    state % y(1:nspec_evolve,1) = max(state % y(1:nspec_evolve,1), SMALL_X_SAFE)
+    state % y(1:nspec,1) = max(state % y(1:nspec,1), SMALL_X_SAFE)
 
     ! Ensure that the temperature always stays within reasonable limits.
     call eos_get_small_temp(small_temp)
@@ -121,8 +121,7 @@ contains
 
     !$acc routine seq
 
-    use actual_network, only: nspec, nspec_evolve, aion
-    use vbdf_rpar_indices, only: irp_nspec, n_not_evolved
+    use actual_network, only: nspec, aion
 
     implicit none
 
@@ -130,13 +129,8 @@ contains
 
     real(rt) :: nspec_sum
 
-    nspec_sum = &
-         sum(state % y(1:nspec_evolve,1)) + &
-         sum(state % upar(irp_nspec:irp_nspec+n_not_evolved-1,1))
-
-    state % y(1:nspec_evolve,1) = state % y(1:nspec_evolve,1) / nspec_sum
-    state % upar(irp_nspec:irp_nspec+n_not_evolved-1,1) = &
-         state % upar(irp_nspec:irp_nspec+n_not_evolved-1,1) / nspec_sum
+    nspec_sum = sum(state % y(1:nspec,1))
+    state % y(1:nspec,1) = state % y(1:nspec,1) / nspec_sum
 
   end subroutine renormalize_species
 
@@ -218,10 +212,10 @@ contains
 
     !$acc routine seq
 
-    use network, only: nspec, nspec_evolve, aion, aion_inv
+    use network, only: nspec, aion, aion_inv
     use eos_type_module, only: eos_t
-    use vbdf_rpar_indices, only: irp_dens, irp_nspec, irp_cp, irp_cv, irp_abar, irp_zbar, &
-                            irp_eta, irp_ye, irp_cs, n_not_evolved
+    use vbdf_rpar_indices, only: irp_dens, irp_cp, irp_cv, irp_abar, irp_zbar, &
+                            irp_eta, irp_ye, irp_cs
     use burn_type_module, only: net_itemp
 
     implicit none
@@ -232,9 +226,7 @@ contains
     state % rho     = ts % upar(irp_dens,1)
     state % T       = ts % y(net_itemp,1)
 
-    state % xn(1:nspec_evolve) = ts % y(1:nspec_evolve,1)
-    state % xn(nspec_evolve+1:nspec) = &
-         ts % upar(irp_nspec:irp_nspec+n_not_evolved-1,1)
+    state % xn(1:nspec) = ts % y(1:nspec,1)
 
     state % cp      = ts % upar(irp_cp,1)
     state % cv      = ts % upar(irp_cv,1)
@@ -254,10 +246,10 @@ contains
 
     !$acc routine seq
 
-    use network, only: nspec, nspec_evolve, aion, aion_inv
+    use network, only: nspec, aion, aion_inv
     use eos_type_module, only: eos_t
-    use vbdf_rpar_indices, only: irp_dens, irp_nspec, irp_cp, irp_cv, irp_abar, irp_zbar, &
-                            irp_eta, irp_ye, irp_cs, n_not_evolved
+    use vbdf_rpar_indices, only: irp_dens, irp_cp, irp_cv, irp_abar, irp_zbar, &
+                            irp_eta, irp_ye, irp_cs
     use burn_type_module, only: net_itemp
 
     implicit none
@@ -268,9 +260,7 @@ contains
     ts % upar(irp_dens,1)                  = state % rho
     ts % y(net_itemp,1)                    = state % T
 
-    ts % y(1:nspec_evolve,1) = state % xn(1:nspec_evolve)
-    ts % upar(irp_nspec:irp_nspec+n_not_evolved-1,1) = &
-         state % xn(nspec_evolve+1:nspec)
+    ts % y(1:nspec,1) = state % xn(1:nspec)
 
     ts % upar(irp_cp,1)                    = state % cp
     ts % upar(irp_cv,1)                    = state % cv
@@ -290,11 +280,10 @@ contains
 
     !$acc routine seq
 
-    use network, only: nspec, nspec_evolve, aion, aion_inv, nrates
-    use vbdf_rpar_indices, only: irp_dens, irp_nspec, irp_cp, irp_cv, irp_abar, irp_zbar, &
+    use network, only: nspec, aion, aion_inv, nrates
+    use vbdf_rpar_indices, only: irp_dens, irp_cp, irp_cv, irp_abar, irp_zbar, &
                             irp_ye, irp_eta, irp_cs, irp_dx, &
-                            irp_Told, irp_dcvdt, irp_dcpdt, irp_self_heat, &
-                            n_not_evolved
+                            irp_Told, irp_dcvdt, irp_dcpdt, irp_self_heat
     use burn_type_module, only: burn_t, net_itemp, net_ienuc
     use amrex_constants_module, only: ONE
 
@@ -308,9 +297,7 @@ contains
     ts % upar(irp_dens,1)                           = state % rho
     ts % y(net_itemp,1)                             = state % T
 
-    ts % y(1:nspec_evolve,1) = state % xn(1:nspec_evolve)
-    ts % upar(irp_nspec:irp_nspec+n_not_evolved-1,1) = &
-         state % xn(nspec_evolve+1:nspec)
+    ts % y(1:nspec,1) = state % xn(1:nspec)
 
     ts % y(net_ienuc,1)                             = state % e
     ts % upar(irp_cp,1)                             = state % cp
@@ -341,11 +328,10 @@ contains
 
     !$acc routine seq
 
-    use network, only: nspec, nspec_evolve, aion, aion_inv, nrates
-    use vbdf_rpar_indices, only: irp_dens, irp_nspec, irp_cp, irp_cv, irp_abar, irp_zbar, &
+    use network, only: nspec, aion, aion_inv, nrates
+    use vbdf_rpar_indices, only: irp_dens, irp_cp, irp_cv, irp_abar, irp_zbar, &
                             irp_ye, irp_eta, irp_cs, irp_dx, &
-                            irp_Told, irp_dcvdt, irp_dcpdt, irp_self_heat, &
-                            n_not_evolved
+                            irp_Told, irp_dcvdt, irp_dcpdt, irp_self_heat
     use burn_type_module, only: burn_t, net_itemp, net_ienuc
     use amrex_constants_module, only: ZERO
 
@@ -360,9 +346,7 @@ contains
     state % T        = ts % y(net_itemp,1)
     state % e        = ts % y(net_ienuc,1)
 
-    state % xn(1:nspec_evolve) = ts % y(1:nspec_evolve,1)
-    state % xn(nspec_evolve+1:nspec) = &
-         ts % upar(irp_nspec:irp_nspec+n_not_evolved-1,1)
+    state % xn(1:nspec) = ts % y(1:nspec,1)
 
     state % cp       = ts % upar(irp_cp,1)
     state % cv       = ts % upar(irp_cv,1)

--- a/integration/VBDF/vbdf_integrator.F90
+++ b/integration/VBDF/vbdf_integrator.F90
@@ -46,7 +46,6 @@ contains
                                     burning_mode, burning_mode_factor, &
                                     retry_burn, retry_burn_factor, retry_burn_max_change, &
                                     call_eos_in_rhs, dT_crit
-    use actual_rhs_module, only : update_unevolved_species
     use temperature_integration_module, only: self_heat
 
     implicit none

--- a/integration/VBDF/vbdf_integrator.F90
+++ b/integration/VBDF/vbdf_integrator.F90
@@ -84,13 +84,13 @@ contains
     ! to (a) decrease dT_crit, (b) increase the maximum number of
     ! steps allowed.
 
-    atol(1:nspec_evolve) = atol_spec ! mass fractions
-    atol(net_itemp)      = atol_temp ! temperature
-    atol(net_ienuc)      = atol_enuc ! energy generated
+    atol(1:nspec)   = atol_spec ! mass fractions
+    atol(net_itemp) = atol_temp ! temperature
+    atol(net_ienuc) = atol_enuc ! energy generated
 
-    rtol(1:nspec_evolve) = rtol_spec ! mass fractions
-    rtol(net_itemp)      = rtol_temp ! temperature
-    rtol(net_ienuc)      = rtol_enuc ! energy generated
+    rtol(1:nspec)   = rtol_spec ! mass fractions
+    rtol(net_itemp) = rtol_temp ! temperature
+    rtol(net_ienuc) = rtol_enuc ! energy generated
 
     ts % atol = atol
     ts % rtol = rtol
@@ -224,8 +224,7 @@ contains
        print *, 'temp start = ', state_in % T
        print *, 'xn start = ', state_in % xn
        print *, 'temp current = ', ts % y(net_itemp,1)
-       print *, 'xn current = ', ts % y(1:nspec_evolve,1), &
-            ts % upar(irp_nspec:irp_nspec+n_not_evolved-1,1)
+       print *, 'xn current = ', ts % y(1:nspec,1)
        print *, 'energy generated = ', ts % y(net_ienuc,1) - ener_offset
 #endif
        if (.not. retry_burn) then
@@ -283,10 +282,6 @@ contains
 
     ! Store the final data, and then normalize abundances.
     call vbdf_to_burn(ts, state_out)
-
-    if (nspec_evolve < nspec) then
-       call update_unevolved_species(state_out)
-    endif
 
     ! For burning_mode == 3, limit the burning.
 

--- a/integration/VBDF/vbdf_rpar.F90
+++ b/integration/VBDF/vbdf_rpar.F90
@@ -4,19 +4,16 @@
 
 module vbdf_rpar_indices
 
-  use actual_network, only: nspec, nspec_evolve
+  use actual_network, only: nspec
   use burn_type_module, only: neqs
 
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
-  integer, parameter :: n_not_evolved = nspec - nspec_evolve
-
   integer, parameter :: irp_dens = 1
   integer, parameter :: irp_cv = irp_dens + 1
   integer, parameter :: irp_cp = irp_cv + 1
-  integer, parameter :: irp_nspec = irp_cp + 1
-  integer, parameter :: irp_abar = irp_nspec + n_not_evolved
+  integer, parameter :: irp_abar = irp_cp + 1
   integer, parameter :: irp_zbar = irp_abar + 1
   integer, parameter :: irp_eta = irp_zbar + 1
   integer, parameter :: irp_ye = irp_eta + 1

--- a/integration/VODE/cuvode_parameters.F90
+++ b/integration/VODE/cuvode_parameters.F90
@@ -4,13 +4,13 @@ module cuvode_parameters_module
 #ifdef SIMPLIFIED_SDC
   use sdc_type_module, only : SVAR_EVOLVE
 #endif
-  use network, only : nspec_evolve
+  use network, only : nspec
 
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
 #ifdef TRUE_SDC
-  integer, parameter :: VODE_NEQS = nspec_evolve + 2
+  integer, parameter :: VODE_NEQS = nspec + 2
 #elif SIMPLIFIED_SDC
   integer, parameter :: VODE_NEQS = SVAR_EVOLVE
 #else

--- a/integration/VODE/vode_integrator.F90
+++ b/integration/VODE/vode_integrator.F90
@@ -35,7 +35,6 @@ contains
          burning_mode, burning_mode_factor, &
          retry_burn, retry_burn_factor, retry_burn_max_change, &
          call_eos_in_rhs, dt_crit, ode_max_steps
-    use actual_rhs_module, only : update_unevolved_species
     use cuvode_module, only: dvode
     use eos_module, only: eos
     use eos_type_module, only: eos_t, copy_eos_t

--- a/integration/VODE/vode_integrator.F90
+++ b/integration/VODE/vode_integrator.F90
@@ -108,13 +108,13 @@ contains
     ! to (a) decrease dT_crit, (b) increase the maximum number of
     ! steps allowed.
 
-    dvode_state % atol(1:nspec_evolve) = status % atol_spec ! mass fractions
-    dvode_state % atol(net_itemp)      = status % atol_temp ! temperature
-    dvode_state % atol(net_ienuc)      = status % atol_enuc ! energy generated
+    dvode_state % atol(1:nspec)   = status % atol_spec ! mass fractions
+    dvode_state % atol(net_itemp) = status % atol_temp ! temperature
+    dvode_state % atol(net_ienuc) = status % atol_enuc ! energy generated
 
-    dvode_state % rtol(1:nspec_evolve) = status % rtol_spec ! mass fractions
-    dvode_state % rtol(net_itemp)      = status % rtol_temp ! temperature
-    dvode_state % rtol(net_ienuc)      = status % rtol_enuc ! energy generated
+    dvode_state % rtol(1:nspec)   = status % rtol_spec ! mass fractions
+    dvode_state % rtol(net_itemp) = status % rtol_temp ! temperature
+    dvode_state % rtol(net_ienuc) = status % rtol_enuc ! energy generated
 
     ! We want VODE to re-initialize each time we call it.
 
@@ -266,11 +266,11 @@ contains
        integration_failed = .true.
     end if
 
-    if (any(dvode_state % y(1:nspec_evolve) < -failure_tolerance)) then
+    if (any(dvode_state % y(1:nspec) < -failure_tolerance)) then
        integration_failed = .true.
     end if
 
-    if (any(dvode_state % y(1:nspec_evolve) > 1.e0_rt + failure_tolerance)) then
+    if (any(dvode_state % y(1:nspec) > 1.e0_rt + failure_tolerance)) then
        integration_failed = .true.
     end if
 
@@ -285,8 +285,7 @@ contains
        print *, 'temp start = ', state_in % T
        print *, 'xn start = ', state_in % xn
        print *, 'temp current = ', dvode_state % y(net_itemp) * temp_scale
-       print *, 'xn current = ', dvode_state % y(1:nspec_evolve) * aion(1:nspec_evolve), &
-            dvode_state % rpar(irp_nspec:irp_nspec+n_not_evolved-1) * aion(nspec_evolve+1:)
+       print *, 'xn current = ', dvode_state % y(1:nspec) * aion(1:nspec)
        print *, 'energy generated = ', (dvode_state % y(net_ienuc) - ener_offset) * ener_scale
 #endif
 
@@ -306,10 +305,6 @@ contains
     state_out % n_jac = iwork(13)
 
     state_out % time = dvode_state % t
-
-    if (nspec_evolve < nspec) then
-       call update_unevolved_species(state_out)
-    endif
 
     ! For burning_mode == 3, limit the burning.
 

--- a/integration/VODE/vode_rhs.F90
+++ b/integration/VODE/vode_rhs.F90
@@ -10,7 +10,7 @@ contains
 
     !$acc routine seq
     
-    use actual_network, only: aion, nspec_evolve
+    use actual_network, only: aion, nspec
     use amrex_fort_module, only: rt => amrex_real
     use burn_type_module, only: burn_t, net_ienuc, net_itemp
     use amrex_constants_module, only: ZERO, ONE
@@ -32,7 +32,7 @@ contains
 
     ! We are integrating a system of
     !
-    ! y(1:nspec_evolve) = dX/dt
+    ! y(1:nspec)   = dX/dt
     ! y(net_itemp) = dT/dt
     ! y(net_ienuc) = denuc/dt
 
@@ -54,7 +54,7 @@ contains
     call network_rhs(burn_state, ydot, rpar(irp_t0))
 
     ! We integrate X, not Y
-    ydot(1:nspec_evolve) = ydot(1:nspec_evolve) * aion(1:nspec_evolve)
+    ydot(1:nspec) = ydot(1:nspec) * aion(1:nspec)
 
     ! Allow temperature and energy integration to be disabled.
     if (.not. integrate_temperature) then
@@ -82,7 +82,7 @@ contains
 
     !$acc routine seq
     
-    use network, only: aion, aion_inv, nspec_evolve
+    use network, only: aion, aion_inv, nspec
     use amrex_constants_module, only: ZERO
     use network_rhs_module, only: network_jac
     use burn_type_module, only: burn_t, net_ienuc, net_itemp
@@ -109,7 +109,7 @@ contains
     call network_jac(state, pd, rpar(irp_t0))
 
     ! We integrate X, not Y
-    do n = 1, nspec_evolve
+    do n = 1, nspec
        pd(n,:) = pd(n,:) * aion(n)
        pd(:,n) = pd(:,n) * aion_inv(n)
     enddo

--- a/integration/VODE/vode_rhs_simplified_sdc.F90
+++ b/integration/VODE/vode_rhs_simplified_sdc.F90
@@ -8,7 +8,7 @@ module vode_rhs_module
 
 subroutine f_rhs(time, y, ydot, rpar)
 
-  use actual_network, only: aion, nspec_evolve
+  use actual_network, only: aion, nspec
   use amrex_fort_module, only: rt => amrex_real
   use burn_type_module, only: burn_t, net_ienuc, net_itemp, neqs
   use amrex_constants_module, only: ZERO, ONE
@@ -61,7 +61,7 @@ subroutine jac(time, y, ml, mu, pd, nrpd, rpar)
   ! use an analytic Jacobian.  Otherwise, VODE will use its internal
   ! Jacobian routines.
 
-  use network, only: aion, aion_inv, nspec_evolve
+  use network, only: aion, aion_inv, nspec
   use amrex_constants_module, only: ZERO
   use network_rhs_module, only: network_jac
   use burn_type_module, only: burn_t, net_ienuc, neqs

--- a/integration/VODE/vode_rpar.F90
+++ b/integration/VODE/vode_rpar.F90
@@ -10,9 +10,9 @@ module vode_rpar_indices
 #ifdef SIMPLIFIED_SDC
   use sdc_type_module, only: SVAR, SVAR_EVOLVE
 #elif TRUE_SDC
-  use actual_network, only: nspec, nspec_evolve
+  use actual_network, only: nspec
 #else
-  use actual_network, only: nspec, nspec_evolve
+  use actual_network, only: nspec
   use burn_type_module, only: neqs
 #endif
 
@@ -81,13 +81,13 @@ module vode_rpar_indices
 #endif
 
 #elif TRUE_SDC
-  ! f_source is function we are zeroing.  There are nspec_evolve + 2
+  ! f_source is function we are zeroing.  There are nspec + 2
   ! components (density and energy), since those are the unknowns for
   ! the nonlinear system
   integer, parameter :: irp_f_source = 1
 
   ! dt is the timestep (1 component)
-  integer, parameter :: irp_dt = irp_f_source + nspec_evolve + 2
+  integer, parameter :: irp_dt = irp_f_source + nspec + 2
 
   ! mom is the momentum (3 components)
   integer, parameter :: irp_mom = irp_dt + 1
@@ -98,19 +98,13 @@ module vode_rpar_indices
   ! the temperature -- used as a guess in the EOS
   integer, parameter :: irp_temp = irp_evar + 1
 
-  ! the unevolved species -- note: unevolved here means not reacting
-  integer, parameter :: irp_spec = irp_temp + 1  ! nspec - nspec_evolve components
-
-  integer, parameter :: n_rpar_comps = nspec_evolve + 8 + (nspec - nspec_evolve)
+  integer, parameter :: n_rpar_comps = irp_temp
 
 #else
-  integer, parameter :: n_not_evolved = nspec - nspec_evolve
-
   integer, parameter :: irp_dens = 1
   integer, parameter :: irp_cv = irp_dens + 1
   integer, parameter :: irp_cp = irp_cv + 1
-  integer, parameter :: irp_nspec = irp_cp + 1
-  integer, parameter :: irp_abar = irp_nspec + n_not_evolved
+  integer, parameter :: irp_abar = irp_cp + 1
   integer, parameter :: irp_zbar = irp_abar + 1
   integer, parameter :: irp_eta = irp_zbar + 1
   integer, parameter :: irp_ye = irp_eta + 1
@@ -123,7 +117,7 @@ module vode_rpar_indices
   integer, parameter :: irp_dcpdt = irp_dcvdt + 1
   integer, parameter :: irp_t0 = irp_dcpdt + 1
 
-  integer, parameter :: n_rpar_comps = irp_t0 + 1
+  integer, parameter :: n_rpar_comps = irp_t0
 #endif
 
 

--- a/integration/VODE/vode_type_simplified_sdc.F90
+++ b/integration/VODE/vode_type_simplified_sdc.F90
@@ -4,7 +4,7 @@ module vode_type_module
   use amrex_constants_module
   use cuvode_parameters_module, only : VODE_NEQS
 
-  use network, only : nspec, nspec_evolve, aion, aion_inv
+  use network, only : nspec, aion, aion_inv
 
   use vode_rpar_indices
   use sdc_type_module
@@ -236,8 +236,8 @@ contains
     ydot(:) = rpar(irp_ydot_a:irp_ydot_a-1+SVAR_EVOLVE)
 
     ! add in the reacting terms -- here we convert from dY/dt to dX/dt
-    ydot(SFS:SFS-1+nspec_evolve) = ydot(SFS:SFS-1+nspec_evolve) + &
-         rpar(irp_SRHO) * aion(1:nspec_evolve) * ydot_react(1:nspec_evolve)
+    ydot(SFS:SFS-1+nspec) = ydot(SFS:SFS-1+nspec) + &
+         rpar(irp_SRHO) * aion(1:nspec) * ydot_react(1:nspec)
 
 #if defined(SDC_EVOLVE_ENERGY)
 
@@ -271,24 +271,24 @@ contains
 
 #if defined(SDC_EVOLVE_ENERGY)
 
-    jac(SFS:SFS+nspec_evolve-1,SFS:SFS+nspec_evolve-1) = jac_react(1:nspec_evolve,1:nspec_evolve)
-    jac(SFS:SFS+nspec_evolve-1,SEDEN) = jac_react(1:nspec_evolve,net_ienuc)
-    jac(SFS:SFS+nspec_evolve-1,SEINT) = jac_react(1:nspec_evolve,net_ienuc)
+    jac(SFS:SFS+nspec-1,SFS:SFS+nspec-1) = jac_react(1:nspec,1:nspec)
+    jac(SFS:SFS+nspec-1,SEDEN) = jac_react(1:nspec,net_ienuc)
+    jac(SFS:SFS+nspec-1,SEINT) = jac_react(1:nspec,net_ienuc)
 
-    jac(SEDEN,SFS:SFS+nspec_evolve-1) = jac_react(net_ienuc,1:nspec_evolve)
+    jac(SEDEN,SFS:SFS+nspec-1) = jac_react(net_ienuc,1:nspec)
     jac(SEDEN,SEDEN) = jac_react(net_ienuc,net_ienuc)
     jac(SEDEN,SEINT) = jac_react(net_ienuc,net_ienuc)
 
-    jac(SEINT,SFS:SFS+nspec_evolve-1) = jac_react(net_ienuc,1:nspec_evolve)
+    jac(SEINT,SFS:SFS+nspec-1) = jac_react(net_ienuc,1:nspec)
     jac(SEINT,SEDEN) = jac_react(net_ienuc,net_ienuc)
     jac(SEINT,SEINT) = jac_react(net_ienuc,net_ienuc)
 
 #elif defined(SDC_EVOLVE_ENTHALPY)
 
-    jac(SFS:SFS+nspec_evolve-1,SFS:SFS+nspec_evolve-1) = jac_react(1:nspec_evolve,1:nspec_evolve)
-    jac(SFS:SFS+nspec_evolve-1,SENTH) = jac_react(1:nspec_evolve,net_ienuc)
+    jac(SFS:SFS+nspec-1,SFS:SFS+nspec-1) = jac_react(1:nspec,1:nspec)
+    jac(SFS:SFS+nspec-1,SENTH) = jac_react(1:nspec,net_ienuc)
 
-    jac(SENTH,SFS:SFS+nspec_evolve-1) = jac_react(net_ienuc,1:nspec_evolve)
+    jac(SENTH,SFS:SFS+nspec-1) = jac_react(net_ienuc,1:nspec)
     jac(SENTH,SENTH) = jac_react(net_ienuc,net_ienuc)
 
 #endif

--- a/integration/utils/nonaka_plot.f90
+++ b/integration/utils/nonaka_plot.f90
@@ -10,22 +10,22 @@ contains
   subroutine nonaka_init()
 
     use extern_probin_module, only: nonaka_file
-    use actual_network, only: nspec_evolve, short_spec_names
+    use actual_network, only: nspec, short_spec_names
 
     implicit none
 
     integer :: nonaka_file_unit, i
-    character(len=20*nspec_evolve+10) :: header_line
+    character(len=20*nspec+10) :: header_line
     character(len=20) :: scratch
 
     header_line = "time"
 
-    do i = 1, nspec_evolve
+    do i = 1, nspec
       scratch = "X("//trim(short_spec_names(i))//")"
       header_line = trim(header_line)//" "//trim(scratch)
     end do
 
-    do i = 1, nspec_evolve
+    do i = 1, nspec
       scratch = "dXdt("//trim(short_spec_names(i))//")"
       header_line = trim(header_line)//" "//trim(scratch)
     end do
@@ -51,7 +51,7 @@ contains
 
     use extern_probin_module, only: nonaka_i, nonaka_j, nonaka_k, nonaka_file
     use burn_type_module, only: burn_t, neqs
-    use actual_network, only: nspec_evolve, aion
+    use actual_network, only: nspec, aion
 
     implicit none
 
@@ -78,7 +78,7 @@ contains
         ! append current state to nonaka log
         ! at the current simulation time
 
-        write(vector_format, '("(", I0, "E30.16E5", ")")') nspec_evolve
+        write(vector_format, '("(", I0, "E30.16E5", ")")') nspec
         write(scalar_format, '("(", I0, "E30.16E5", ")")') 1
         
         open(newunit=nonaka_file_unit, file=nonaka_file, status="old", position="append", action="readwrite", &
@@ -89,29 +89,29 @@ contains
         if (present(trim_after_timestep)) then
             if (trim_after_timestep) then
                 ! determine last timestep in file
-                nextline = nextline - ( 30*(1 + 2*nspec_evolve) + 1 )
+                nextline = nextline - ( 30*(1 + 2*nspec) + 1 )
                 read(unit=nonaka_file_unit, pos=nextline, fmt=scalar_format) tprev
 
                 i = 0
                 ! remove last rows where VODE took a much too large timestep
                 do while (tprev >= simulation_time .and. i < 2)
-                    nextline = nextline - ( 30*(1 + 2*nspec_evolve) + 1 )
+                    nextline = nextline - ( 30*(1 + 2*nspec) + 1 )
                     read(unit=nonaka_file_unit, pos=nextline, fmt=scalar_format) tprev
                     i = i + 1
                 end do
 
                 ! store where to write new data
-                nextline = nextline + ( 30*(1 + 2*nspec_evolve) + 1 )
+                nextline = nextline + ( 30*(1 + 2*nspec) + 1 )
             end if
         end if
            
         write(unit=nonaka_file_unit, fmt=scalar_format, pos=nextline, advance="no") simulation_time
 
         ! Mass fractions X
-        write(unit=nonaka_file_unit, fmt=vector_format, advance="no") (state % xn(j), j = 1, nspec_evolve)
+        write(unit=nonaka_file_unit, fmt=vector_format, advance="no") (state % xn(j), j = 1, nspec)
 
         ! Convert molar fraction rhs to mass fraction rhs dX/dt
-        write(unit=nonaka_file_unit, fmt=vector_format) (ydot(j) * aion(j), j = 1, nspec_evolve)
+        write(unit=nonaka_file_unit, fmt=vector_format) (ydot(j) * aion(j), j = 1, nspec)
 
         close(unit=nonaka_file_unit)
 

--- a/integration/utils/numerical_jacobian.F90
+++ b/integration/utils/numerical_jacobian.F90
@@ -42,7 +42,7 @@ contains
        call copy_burn_t(state_delm, state)
 
        ! species derivatives
-       do n = 1, nspec_evolve
+       do n = 1, nspec
           ! perturb species
           state_delp % xn = state % xn
           state_delp % xn(n) = state % xn(n) * (ONE + eps)
@@ -51,14 +51,14 @@ contains
 
           ! We integrate X, so convert from the Y we got back from the RHS
 
-          ydotp(1:nspec_evolve) = ydotp(1:nspec_evolve) * aion(1:nspec_evolve)
+          ydotp(1:nspec) = ydotp(1:nspec) * aion(1:nspec)
 
           state_delm % xn = state % xn
           state_delm % xn(n) = state % xn(n) * (ONE - eps)
 
           call actual_rhs(state_delm, ydotm)
 
-          ydotm(1:nspec_evolve) = ydotm(1:nspec_evolve) * aion(1:nspec_evolve)
+          ydotm(1:nspec) = ydotm(1:nspec) * aion(1:nspec)
 
           do m = 1, neqs
              scratch = HALF*(ydotp(m) - ydotm(m)) / (eps * state % xn(n))
@@ -72,14 +72,14 @@ contains
 
        call actual_rhs(state_delp, ydotp)
 
-       ydotp(1:nspec_evolve) = ydotp(1:nspec_evolve) * aion(1:nspec_evolve)
+       ydotp(1:nspec) = ydotp(1:nspec) * aion(1:nspec)
 
        state_delm % xn = state % xn
        state_delm % T  = state % T * (ONE - eps)
 
        call actual_rhs(state_delm, ydotm)
 
-       ydotm(1:nspec_evolve) = ydotm(1:nspec_evolve) * aion(1:nspec_evolve)
+       ydotm(1:nspec) = ydotm(1:nspec) * aion(1:nspec)
 
        do m = 1, neqs
           scratch = HALF*(ydotp(m) - ydotm(m)) / (eps * state % T)
@@ -99,10 +99,10 @@ contains
        ! default
        call actual_rhs(state_delm, ydotm)
 
-       ydotm(1:nspec_evolve) = ydotm(1:nspec_evolve) * aion(1:nspec_evolve)
+       ydotm(1:nspec) = ydotm(1:nspec) * aion(1:nspec)
 
        ! species derivatives
-       do n = 1, nspec_evolve
+       do n = 1, nspec
           ! perturb species -- we send in X, but ydot is in terms of dY/dt, not dX/dt
           state_delp % xn = state % xn
 
@@ -117,7 +117,7 @@ contains
 
           ! We integrate X, so convert from the Y we got back from the RHS
 
-          ydotp(1:nspec_evolve) = ydotp(1:nspec_evolve) * aion(1:nspec_evolve)
+          ydotp(1:nspec) = ydotp(1:nspec) * aion(1:nspec)
 
           do m = 1, neqs
              scratch = (ydotp(m) - ydotm(m)) / h
@@ -137,7 +137,7 @@ contains
 
        call actual_rhs(state_delp, ydotp)
 
-       ydotp(1:nspec_evolve) = ydotp(1:nspec_evolve) * aion(1:nspec_evolve)
+       ydotp(1:nspec) = ydotp(1:nspec) * aion(1:nspec)
 
        do m = 1, neqs
           scratch = (ydotp(m) - ydotm(m)) / h
@@ -191,7 +191,7 @@ contains
     ! the analytic Jacobian is in terms of Y, since that's what the
     ! nets work with, so we convert it to derivatives with respect to
     ! X and of mass fraction creation rates
-    do n = 1, nspec_evolve
+    do n = 1, nspec
        do j = 1, neqs
           call scale_jac_entry(jac_analytic, n, j, aion(n))
           call scale_jac_entry(jac_analytic, j, n, aion_inv(n))
@@ -208,7 +208,7 @@ contains
     ! how'd we do?
     do j = 1, neqs
 
-       if (j <= nspec_evolve) then
+       if (j <= nspec) then
           namej = short_spec_names(j)
        else if (j == net_ienuc) then
           namej = "e"
@@ -220,7 +220,7 @@ contains
 
        do i = 1, neqs
 
-          if (i <= nspec_evolve) then
+          if (i <= nspec) then
              namei = short_spec_names(i)
           else if (i == net_ienuc) then
              namei = "e"

--- a/integration/utils/temperature_integration.F90
+++ b/integration/utils/temperature_integration.F90
@@ -149,7 +149,7 @@ contains
 
        ! d(itemp)/d(yi)
 
-       do k = 1, nspec_evolve
+       do k = 1, nspec
           call get_jac_entry(jac, net_ienuc, k, scratch)
           scratch = scratch * cspecInv
           call set_jac_entry(jac, net_itemp, k, scratch)

--- a/interfaces/burn_type.F90
+++ b/interfaces/burn_type.F90
@@ -1,9 +1,9 @@
 module burn_type_module
 
 #ifdef REACT_SPARSE_JACOBIAN
-  use actual_network, only: nspec, nspec_evolve, naux, NETWORK_SPARSE_JAC_NNZ
+  use actual_network, only: nspec, naux, NETWORK_SPARSE_JAC_NNZ
 #else
-  use actual_network, only: nspec, nspec_evolve, naux
+  use actual_network, only: nspec, naux
 #endif
 
   use amrex_fort_module, only : rt => amrex_real
@@ -16,7 +16,7 @@ module burn_type_module
   ! temperature, enuc + the number of species which participate
   ! in the evolution equations.
 
-  integer, parameter :: neqs = 2 + nspec_evolve
+  integer, parameter :: neqs = 2 + nspec
 
   ! for dimensioning the Jacobian
 
@@ -31,8 +31,8 @@ module burn_type_module
 
   ! Indices of the temperature and energy variables in the work arrays.
 
-  integer, parameter :: net_itemp = nspec_evolve + 1
-  integer, parameter :: net_ienuc = nspec_evolve + 2
+  integer, parameter :: net_itemp = nspec + 1
+  integer, parameter :: net_ienuc = nspec + 2
 
   type :: burn_t
 

--- a/networks/ECSN/actual_network.F90
+++ b/networks/ECSN/actual_network.F90
@@ -25,7 +25,6 @@ module actual_network
   integer, parameter :: num_rate_groups = 4
 
   ! Evolution and auxiliary
-  integer, parameter :: nspec_evolve = 11
   integer, parameter :: naux  = 0
 
   ! Number of nuclear species in the network
@@ -217,7 +216,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [ &
       1, &

--- a/networks/ECSN/actual_rhs.F90
+++ b/networks/ECSN/actual_rhs.F90
@@ -24,16 +24,6 @@ contains
   end subroutine actual_rhs_init
 
 
-  subroutine update_unevolved_species(state)
-    ! STUB FOR INTEGRATOR
-    type(burn_t)     :: state
-
-    !$gpu
-    
-    return
-  end subroutine update_unevolved_species
-
-
   subroutine zero_rate_eval(rate_eval)
 
     implicit none

--- a/networks/aprox13/actual_network.F90
+++ b/networks/aprox13/actual_network.F90
@@ -5,8 +5,6 @@ module actual_network
 
   implicit none
 
-  integer, parameter :: nspec_evolve = 13
-
   integer, parameter :: ihe4  = 1
   integer, parameter :: ic12  = 2
   integer, parameter :: io16  = 3
@@ -241,7 +239,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, &
                          1, 2, 3, 14, &

--- a/networks/aprox13/actual_rhs.F90
+++ b/networks/aprox13/actual_rhs.F90
@@ -2312,14 +2312,4 @@ contains
 
   end subroutine set_up_screening_factors
 
-  subroutine update_unevolved_species(state)
-
-    implicit none
-
-    type (burn_t)    :: state
-
-    !$gpu
-
-  end subroutine update_unevolved_species
-
 end module actual_rhs_module

--- a/networks/aprox19/actual_network.F90
+++ b/networks/aprox19/actual_network.F90
@@ -4,8 +4,6 @@ module actual_network
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
-  integer, parameter :: nspec_evolve = 19
-
   integer, parameter :: ih1   = 1
   integer, parameter :: ihe3  = 2
   integer, parameter :: ihe4  = 3

--- a/networks/aprox19/actual_rhs.F90
+++ b/networks/aprox19/actual_rhs.F90
@@ -2811,16 +2811,4 @@ contains
 
   end subroutine set_up_screening_factors
 
-  subroutine update_unevolved_species(state)
-
-    !$acc routine seq
-
-    implicit none
-
-    type (burn_t)    :: state
-
-    !$gpu
-
-  end subroutine update_unevolved_species
-
 end module actual_rhs_module

--- a/networks/aprox21/actual_network.F90
+++ b/networks/aprox21/actual_network.F90
@@ -5,8 +5,6 @@ module actual_network
 
   implicit none
 
-  integer, parameter :: nspec_evolve = 21
-  
   integer, parameter :: ih1   = 1
   integer, parameter :: ihe3  = 2
   integer, parameter :: ihe4  = 3

--- a/networks/aprox21/actual_rhs.F90
+++ b/networks/aprox21/actual_rhs.F90
@@ -3174,16 +3174,4 @@ contains
 
   end subroutine set_up_screening_factors
 
-  subroutine update_unevolved_species(state)
-
-    !$acc routine seq
-
-    implicit none
-
-    type (burn_t)    :: state
-
-    !$gpu
-
-  end subroutine update_unevolved_species
-
 end module actual_rhs_module

--- a/networks/breakout/actual_network.f90
+++ b/networks/breakout/actual_network.f90
@@ -14,7 +14,6 @@ module actual_network
 
   implicit none
 
-  integer, parameter :: nspec_evolve = 1
   integer, parameter :: nrates = 0
   integer, parameter :: num_rate_groups = 0
 

--- a/networks/breakout/actual_rhs.f90
+++ b/networks/breakout/actual_rhs.f90
@@ -45,12 +45,4 @@ contains
 
   end subroutine actual_jac
 
-  subroutine update_unevolved_species(state)
-
-    implicit none
-
-    type (burn_t)    :: state
-
-  end subroutine update_unevolved_species
-
 end module actual_rhs_module

--- a/networks/general_null/actual_rhs.F90
+++ b/networks/general_null/actual_rhs.F90
@@ -53,18 +53,4 @@ contains
 
   end subroutine actual_jac
 
-
-
-  subroutine update_unevolved_species(state)
-
-    use burn_type_module, only: burn_t
-
-    implicit none
-
-    !$gpu
-
-    type (burn_t)    :: state
-
-  end subroutine update_unevolved_species
-
 end module actual_rhs_module

--- a/networks/general_null/network.template
+++ b/networks/general_null/network.template
@@ -21,7 +21,6 @@ module actual_network
   implicit none
 
   integer, parameter :: nspec = @@NSPEC@@
-  integer, parameter :: nspec_evolve = @@NSPEC@@
   integer, parameter :: naux =  @@NAUX@@
 
   character (len=16), save :: spec_names(nspec) 

--- a/networks/ignition_chamulak/actual_network.F90
+++ b/networks/ignition_chamulak/actual_network.F90
@@ -10,9 +10,6 @@ module actual_network
   ! reaction
   real(rt)        , parameter :: M12_chamulak = 2.93e0_rt
 
-  ! we are only explicitly evolving C12
-  integer, parameter :: nspec_evolve = 1
-
   integer, parameter :: ic12  = 1
   integer, parameter :: io16  = 2
   integer, parameter :: iash  = 3

--- a/networks/ignition_chamulak/actual_rhs.F90
+++ b/networks/ignition_chamulak/actual_rhs.F90
@@ -81,7 +81,9 @@ contains
 
     temp = state % T
     dens = state % rho
-    y(:) = state % xn(:) * aion_inv(:)
+
+    ! convert mass fractions to molar fractions
+    y(1:nspec) = state % xn(1:nspec) * aion_inv(1:nspec)
 
     ! call the screening routine
     call screenz(temp, dens, 6.0e0_rt, 6.0e0_rt, 12.0e0_rt, 12.0e0_rt, &
@@ -138,9 +140,6 @@ contains
 
     ydot = ZERO
 
-    ! we enforce that O16 doesn't change and any C12 change goes to ash
-    call update_unevolved_species(state)
-
     call get_rates(state, rr)
 
     rate = rr % rates(1,1)
@@ -150,7 +149,9 @@ contains
 
     temp = state % T
     dens = state % rho
-    y(:) = state % xn(:) * aion_inv(:)
+
+    ! we come in with mass fractions -- convert to molar fractions
+    y(1:nspec) = state % xn(1:nspec) * aion_inv(1:nspec)
 
 
     ! The change in number density of C12 is
@@ -172,16 +173,18 @@ contains
     !
     ! The quantity [N_A <sigma v>] is what is tabulated in Caughlin and Fowler.
 
-    xc12tmp = max(y(ic12) * aion(ic12),0.e0_rt)
+    xc12tmp = max(y(ic12) * aion(ic12), 0.e0_rt)
     ydot(ic12) = -TWELFTH*HALF*M12_chamulak*dens*sc1212* rate * xc12tmp**2
+    ydot(io16) = 0.0_rt
+    ydot(iash) = -ydot(ic12)
 
     ! Convert back to molar form
 
-    ydot(1:nspec_evolve) = ydot(1:nspec_evolve) * aion_inv(1:nspec_evolve)
+    ydot(1:nspec) = ydot(1:nspec) * aion_inv(1:nspec)
 
     call get_ebin(dens, ebin)
 
-    call ener_gener_rate(ydot(1:nspec_evolve), ebin, ydot(net_ienuc))
+    call ener_gener_rate(ydot(1:nspec), ebin, ydot(net_ienuc))
 
     if (state % self_heat) then
 
@@ -233,6 +236,7 @@ contains
     ! carbon jacobian elements
 
     jac(ic12, ic12) = -TWO*TWELFTH*M12_chamulak*HALF*dens*scorr*rate*xc12tmp
+    jac(iash, ic12) = -jac(ic12, ic12)
 
     ! add the temperature derivatives: df(y_i) / dT
 
@@ -250,13 +254,13 @@ contains
 
     call get_ebin(dens, ebin)
 
-    do j = 1, nspec_evolve
-       call ener_gener_rate(jac(1:nspec_evolve,j), ebin, jac(net_ienuc,j))
+    do j = 1, nspec
+       call ener_gener_rate(jac(1:nspec,j), ebin, jac(net_ienuc,j))
     enddo
 
     ! Jacobian elements with respect to temperature
 
-    call ener_gener_rate(jac(1:nspec_evolve,net_itemp), ebin, jac(net_ienuc,net_itemp))
+    call ener_gener_rate(jac(1:nspec,net_itemp), ebin, jac(net_ienuc,net_itemp))
 
     call temperature_jac(state, jac)
 
@@ -270,26 +274,12 @@ contains
 
     implicit none
 
-    real(rt)         :: dydt(nspec_evolve), ebin(nspec), enuc
+    real(rt)         :: dydt(nspec), ebin(nspec), enuc
 
     !$gpu
 
     enuc = dydt(ic12) * aion(ic12) * ebin(ic12)
 
   end subroutine ener_gener_rate
-
-  subroutine update_unevolved_species(state)
-
-    !$acc routine seq
-
-    implicit none
-
-    type (burn_t)    :: state
-
-    !$gpu
-
-    state % xn(iash) = ONE - state % xn(ic12) - state % xn(io16)
-
-  end subroutine update_unevolved_species
 
 end module actual_rhs_module

--- a/networks/ignition_chamulak/actual_rhs.F90
+++ b/networks/ignition_chamulak/actual_rhs.F90
@@ -246,7 +246,7 @@ contains
 
     ! Convert back to molar form
 
-    do j = 1, nspec_evolve
+    do j = 1, nspec
        jac(j,:) = jac(j,:) * aion_inv(j)
     enddo
 

--- a/networks/ignition_chamulak/test/testburn.f90
+++ b/networks/ignition_chamulak/test/testburn.f90
@@ -26,7 +26,7 @@ program testburn
   dt = 0.06_rt
 
 
-  print *, 'calling the burner...', nspec, nspec_evolve, neqs
+  print *, 'calling the burner...', nspec, neqs
 
   state_in % rho = dens
   state_in % T = temp

--- a/networks/ignition_reaclib/C-burn-simple/actual_network.F90
+++ b/networks/ignition_reaclib/C-burn-simple/actual_network.F90
@@ -24,7 +24,6 @@ module actual_network
   integer, parameter :: nrates = 5
 
   ! Evolution and auxiliary
-  integer, parameter :: nspec_evolve = 8
   integer, parameter :: naux  = 0
 
   ! Number of nuclear species in the network
@@ -188,7 +187,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [ &
       1, &

--- a/networks/ignition_reaclib/C-burn-simple/actual_rhs.F90
+++ b/networks/ignition_reaclib/C-burn-simple/actual_rhs.F90
@@ -29,16 +29,6 @@ contains
   end subroutine actual_rhs_init
 
 
-  subroutine update_unevolved_species(state)
-    ! STUB FOR INTEGRATOR
-    type(burn_t)     :: state
-
-    !$gpu
-    
-    return
-  end subroutine update_unevolved_species
-
-
   subroutine zero_rate_eval(rate_eval)
 
     implicit none

--- a/networks/ignition_reaclib/C-test/actual_network.F90
+++ b/networks/ignition_reaclib/C-test/actual_network.F90
@@ -24,7 +24,6 @@ module actual_network
   integer, parameter :: nrates = 1
 
   ! Evolution and auxiliary
-  integer, parameter :: nspec_evolve = 3
   integer, parameter :: naux  = 0
 
   ! Number of nuclear species in the network
@@ -144,7 +143,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [ &
       1, &

--- a/networks/ignition_reaclib/C-test/actual_rhs.F90
+++ b/networks/ignition_reaclib/C-test/actual_rhs.F90
@@ -28,17 +28,6 @@ contains
     return
   end subroutine actual_rhs_init
 
-
-  subroutine update_unevolved_species(state)
-    ! STUB FOR INTEGRATOR
-    type(burn_t)     :: state
-
-    !$gpu
-    
-    return
-  end subroutine update_unevolved_species
-
-
   subroutine zero_rate_eval(rate_eval)
 
     implicit none

--- a/networks/ignition_reaclib/URCA-simple/actual_network.F90
+++ b/networks/ignition_reaclib/URCA-simple/actual_network.F90
@@ -24,7 +24,6 @@ module actual_network
   integer, parameter :: nrates = 7
 
   ! Evolution and auxiliary
-  integer, parameter :: nspec_evolve = 9
   integer, parameter :: naux  = 0
 
   ! Number of nuclear species in the network
@@ -198,7 +197,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [ &
       1, &

--- a/networks/ignition_reaclib/URCA-simple/actual_rhs.F90
+++ b/networks/ignition_reaclib/URCA-simple/actual_rhs.F90
@@ -29,16 +29,6 @@ contains
   end subroutine actual_rhs_init
 
 
-  subroutine update_unevolved_species(state)
-    ! STUB FOR INTEGRATOR
-    type(burn_t)     :: state
-
-    !$gpu
-    
-    return
-  end subroutine update_unevolved_species
-
-
   subroutine zero_rate_eval(rate_eval)
 
     implicit none

--- a/networks/ignition_simple/actual_network.F90
+++ b/networks/ignition_simple/actual_network.F90
@@ -17,8 +17,6 @@ module actual_network
   real(rt)        , parameter, private :: mp = 1.67262163783e-24_rt
   real(rt)        , parameter, private :: me = 9.1093821545e-28_rt
 
-  integer, parameter :: nspec_evolve = 1
-
   integer, parameter :: ic12  = 1
   integer, parameter :: io16  = 2
   integer, parameter :: img24 = 3
@@ -78,7 +76,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [1, 2, 1, 2, 1, 2, 3]
     csr_jac_row_count = [1, 3, 5, 8]

--- a/networks/iso7/actual_network.F90
+++ b/networks/iso7/actual_network.F90
@@ -5,8 +5,6 @@ module actual_network
 
   implicit none
 
-  integer, parameter :: nspec_evolve = 7
-  
   integer, parameter :: ihe4  = 1
   integer, parameter :: ic12  = 2
   integer, parameter :: io16  = 3

--- a/networks/iso7/actual_rhs.F90
+++ b/networks/iso7/actual_rhs.F90
@@ -1007,15 +1007,4 @@ contains
 
   end subroutine set_up_screening_factors
 
-
-  subroutine update_unevolved_species(state)
-
-    implicit none
-
-    type (burn_t) :: state
-
-    !$gpu
-
-  end subroutine update_unevolved_species
-
 end module actual_rhs_module

--- a/networks/nova/actual_network.F90
+++ b/networks/nova/actual_network.F90
@@ -24,7 +24,6 @@ module actual_network
   integer, parameter :: nrates = 19
 
   ! Evolution and auxiliary
-  integer, parameter :: nspec_evolve = 13
   integer, parameter :: naux  = 0
 
   ! Number of nuclear species in the network
@@ -242,7 +241,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [ &
       1, &

--- a/networks/nova/actual_rhs.F90
+++ b/networks/nova/actual_rhs.F90
@@ -28,17 +28,6 @@ contains
     return
   end subroutine actual_rhs_init
 
-
-  subroutine update_unevolved_species(state)
-    ! STUB FOR INTEGRATOR
-    type(burn_t)     :: state
-
-    !$gpu
-    
-    return
-  end subroutine update_unevolved_species
-
-
   subroutine zero_rate_eval(rate_eval)
 
     implicit none

--- a/networks/powerlaw/actual_network.f90
+++ b/networks/powerlaw/actual_network.f90
@@ -4,8 +4,6 @@ module actual_network
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
-  integer, parameter :: nspec_evolve = 2
-
   integer, parameter :: ifuel_  = 1
   integer, parameter :: iash_   = 2
   integer, parameter :: iinert_ = 3

--- a/networks/powerlaw/actual_rhs.f90
+++ b/networks/powerlaw/actual_rhs.f90
@@ -45,12 +45,13 @@ contains
 
     ydot(ifuel_)  = -rate
     ydot(iash_)   =  rate
+    ydot(iinert_) = 0.0_rt
 
     ! Convert back to molar form
 
-    ydot(1:nspec_evolve) = ydot(1:nspec_evolve) * aion_inv(1:nspec_evolve)
+    ydot(1:nspec) = ydot(1:nspec) * aion_inv(1:nspec)
 
-    call ener_gener_rate(ydot(1:nspec_evolve), ydot(net_ienuc))
+    call ener_gener_rate(ydot(1:nspec), ydot(net_ienuc))
 
     call temperature_rhs(state, ydot)
 
@@ -81,22 +82,12 @@ contains
 
     implicit none
 
-    real(rt)         :: dydt(nspec_evolve), enuc
+    real(rt)         :: dydt(nspec), enuc
 
     ! This is basically e = m c**2
 
-    enuc = sum(dydt(:) * aion(1:nspec_evolve) * ebin(1:nspec_evolve))
+    enuc = sum(dydt(:) * aion(1:nspec) * ebin(1:nspec))
 
   end subroutine ener_gener_rate
-
-  subroutine update_unevolved_species(state)
-
-    !$acc routine seq
-
-    implicit none
-
-    type (burn_t)    :: state
-
-  end subroutine update_unevolved_species
 
 end module actual_rhs_module

--- a/networks/rprox/actual_network.F90
+++ b/networks/rprox/actual_network.F90
@@ -8,8 +8,6 @@ module actual_network
   real(rt)        , parameter :: MeV2erg = 1.60217646e-6_rt
   real(rt)        , parameter :: N_A = 6.0221415e23_rt
 
-  integer, parameter :: nspec_evolve = 10
-
   integer, parameter :: ic12  = 1
   integer, parameter :: io14  = 2
   integer, parameter :: io15  = 3

--- a/networks/rprox/actual_rhs.F90
+++ b/networks/rprox/actual_rhs.F90
@@ -45,7 +45,7 @@ contains
     call make_ydots(y(1:nspec), T9, state, rr, ydot, .false.)
 
     ! Energy release
-    call ener_gener_rate(ydot(1:nspec_evolve), ydot(net_ienuc))
+    call ener_gener_rate(ydot(1:nspec), ydot(net_ienuc))
 
     ! Temperature ODE
     call temperature_rhs(state, ydot)
@@ -548,13 +548,13 @@ contains
 
     ! Energy generation rate Jacobian elements with respect to species
 
-    do j = 1, nspec_evolve
-       call ener_gener_rate(jac(1:nspec_evolve,j), jac(net_ienuc,j))
+    do j = 1, nspec
+       call ener_gener_rate(jac(1:nspec,j), jac(net_ienuc,j))
     enddo
 
     ! Jacobian elements with respect to temperature
 
-    call ener_gener_rate(jac(1:nspec_evolve,net_itemp), jac(net_ienuc,net_itemp))
+    call ener_gener_rate(jac(1:nspec,net_itemp), jac(net_ienuc,net_itemp))
 
     ! Temperature Jacobian elements
 
@@ -570,22 +570,12 @@ contains
 
     implicit none
 
-    real(rt)         :: dydt(nspec_evolve), enuc
+    real(rt)         :: dydt(nspec), enuc
 
     !$gpu
 
-    enuc = -sum(dydt(:) * aion(1:nspec_evolve) * ebin(1:nspec_evolve))
+    enuc = -sum(dydt(:) * aion(1:nspec) * ebin(1:nspec))
 
   end subroutine ener_gener_rate
-
-  subroutine update_unevolved_species(state)
-
-    implicit none
-
-    !$gpu
-
-    type (burn_t)    :: state
-
-  end subroutine update_unevolved_species
 
 end module actual_rhs_module

--- a/networks/sn160/actual_network.F90
+++ b/networks/sn160/actual_network.F90
@@ -24,7 +24,6 @@ module actual_network
   integer, parameter :: nrates = 1538
 
   ! Evolution and auxiliary
-  integer, parameter :: nspec_evolve = 160
   integer, parameter :: naux  = 0
 
   ! Number of nuclear species in the network
@@ -2937,7 +2936,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [ &
       1, &

--- a/networks/sn160/actual_rhs.F90
+++ b/networks/sn160/actual_rhs.F90
@@ -29,16 +29,6 @@ contains
   end subroutine actual_rhs_init
 
 
-  subroutine update_unevolved_species(state)
-    ! STUB FOR INTEGRATOR
-    type(burn_t)     :: state
-
-    !$gpu
-    
-    return
-  end subroutine update_unevolved_species
-
-
   subroutine zero_rate_eval(rate_eval)
 
     implicit none

--- a/networks/subch/actual_network.F90
+++ b/networks/subch/actual_network.F90
@@ -24,7 +24,6 @@ module actual_network
   integer, parameter :: nrates = 8
 
   ! Evolution and auxiliary
-  integer, parameter :: nspec_evolve = 11
   integer, parameter :: naux  = 0
 
   ! Number of nuclear species in the network
@@ -215,7 +214,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [ &
       1, &

--- a/networks/subch/actual_rhs.F90
+++ b/networks/subch/actual_rhs.F90
@@ -29,16 +29,6 @@ contains
   end subroutine actual_rhs_init
 
 
-  subroutine update_unevolved_species(state)
-    ! STUB FOR INTEGRATOR
-    type(burn_t)     :: state
-
-    !$gpu
-    
-    return
-  end subroutine update_unevolved_species
-
-
   subroutine zero_rate_eval(rate_eval)
 
     implicit none

--- a/networks/subch2/actual_network.F90
+++ b/networks/subch2/actual_network.F90
@@ -24,7 +24,6 @@ module actual_network
   integer, parameter :: nrates = 96
 
   ! Evolution and auxiliary
-  integer, parameter :: nspec_evolve = 28
   integer, parameter :: naux  = 0
 
   ! Number of nuclear species in the network
@@ -439,7 +438,7 @@ contains
 #ifdef REACT_SPARSE_JACOBIAN
     ! Set CSR format metadata for Jacobian
     allocate(csr_jac_col_index(NETWORK_SPARSE_JAC_NNZ))
-    allocate(csr_jac_row_count(nspec_evolve + 3)) ! neq + 1
+    allocate(csr_jac_row_count(nspec + 3)) ! neq + 1
 
     csr_jac_col_index = [ &
       1, &

--- a/networks/subch2/actual_rhs.F90
+++ b/networks/subch2/actual_rhs.F90
@@ -29,16 +29,6 @@ contains
   end subroutine actual_rhs_init
 
 
-  subroutine update_unevolved_species(state)
-    ! STUB FOR INTEGRATOR
-    type(burn_t)     :: state
-
-    !$gpu
-    
-    return
-  end subroutine update_unevolved_species
-
-
   subroutine zero_rate_eval(rate_eval)
 
     implicit none

--- a/networks/triple_alpha_plus_cago/actual_network.F90
+++ b/networks/triple_alpha_plus_cago/actual_network.F90
@@ -5,8 +5,6 @@ module actual_network
 
   implicit none
 
-  integer, parameter :: nspec_evolve = 3
-
   integer, parameter :: ihe4  = 1
   integer, parameter :: ic12  = 2
   integer, parameter :: io16  = 3

--- a/networks/triple_alpha_plus_cago/actual_rhs.F90
+++ b/networks/triple_alpha_plus_cago/actual_rhs.F90
@@ -82,11 +82,11 @@ contains
 
     rates(:)    = rr % rates(1,:)
 
-    call dydt(ymol, rates, ydot(1:nspec_evolve))
+    call dydt(ymol, rates, ydot(1:nspec))
 
     ! Energy generation rate
 
-    call ener_gener_rate(ydot(1:nspec_evolve), ydot(net_ienuc))
+    call ener_gener_rate(ydot(1:nspec), ydot(net_ienuc))
 
     call temperature_rhs(state, ydot)
 
@@ -148,17 +148,17 @@ contains
 
     ! Add the temperature derivatives: df(y_i) / dT
 
-    call dydt(ymol, dratesdt, jac(1:nspec_evolve,net_itemp))
+    call dydt(ymol, dratesdt, jac(1:nspec, net_itemp))
 
     ! Energy generation rate Jacobian elements with respect to species
 
-    do j = 1, nspec_evolve
-       call ener_gener_rate(jac(1:nspec_evolve,j), jac(net_ienuc,j))
+    do j = 1, nspec
+       call ener_gener_rate(jac(1:nspec,j), jac(net_ienuc,j))
     enddo
 
     ! Jacobian elements with respect to temperature
 
-    call ener_gener_rate(jac(1:nspec_evolve,net_itemp), jac(net_ienuc,net_itemp))
+    call ener_gener_rate(jac(1:nspec,net_itemp), jac(net_ienuc,net_itemp))
 
     call temperature_jac(state, jac)
 
@@ -175,26 +175,10 @@ contains
 
     !$gpu
 
-    real(rt)         :: dydt(nspec_evolve), enuc
+    real(rt)         :: dydt(nspec), enuc
 
-    enuc = -sum(dydt(:) * aion(1:nspec_evolve) * ebin(1:nspec_evolve))
+    enuc = -sum(dydt(:) * aion(1:nspec) * ebin(1:nspec))
 
   end subroutine ener_gener_rate
-
-  subroutine update_unevolved_species(state)
-
-    !$acc routine seq
-
-    implicit none
-
-    type (burn_t)    :: state
-
-    !$gpu
-
-    ! although we nspec_evolve < nspec, we never change the Fe56
-    ! abundance, so there is no algebraic relation we need to
-    ! enforce here.
-
-  end subroutine update_unevolved_species
 
 end module actual_rhs_module

--- a/networks/triple_alpha_plus_cago/dydt.F90
+++ b/networks/triple_alpha_plus_cago/dydt.F90
@@ -16,7 +16,7 @@ contains
     !$acc routine seq
 
     real(rt)        , intent(IN   ) :: ymol(nspec), rates(nrates)
-    real(rt)        , intent(  OUT) :: ydot(nspec_evolve)
+    real(rt)        , intent(  OUT) :: ydot(nspec)
 
     !$gpu
 

--- a/networks/xrb_simple/actual_network.f90
+++ b/networks/xrb_simple/actual_network.f90
@@ -5,7 +5,6 @@ module actual_network
 
   implicit none
 
-  integer, parameter :: nspec_evolve = 7
   integer, parameter :: nrates = 6  ! including constant weak rates
   integer, parameter :: num_rate_groups = 1
 

--- a/networks/xrb_simple/actual_rhs.f90
+++ b/networks/xrb_simple/actual_rhs.f90
@@ -221,12 +221,4 @@ contains
 
   end subroutine ener_gener_rate
 
-  subroutine update_unevolved_species(state)
-
-    implicit none
-
-    type (burn_t)    :: state
-
-  end subroutine update_unevolved_species
-
 end module actual_rhs_module

--- a/python_library/StarKiller/StarKiller/integration/sdc.py
+++ b/python_library/StarKiller/StarKiller/integration/sdc.py
@@ -11,14 +11,14 @@ class SDCOde(object):
     @staticmethod
     def burn_to_sdc(burn_state):
         y = np.zeros(BurnType.neqs)
-        y[:Network.nspec_evolve] = burn_state.state.xn[:Network.nspec_evolve]
+        y[:Network.nspec] = burn_state.state.xn[:Network.nspec]
         y[Network.net_ienuc] = burn_state.state.e
         y[Network.net_itemp] = burn_state.state.t
         return y
 
     @staticmethod
     def sdc_to_burn(y, burn_state):
-        burn_state.state.xn[:Network.nspec_evolve] = y[:Network.nspec_evolve]
+        burn_state.state.xn[:Network.nspec] = y[:Network.nspec]
         burn_state.state.e = y[Network.net_ienuc]
         burn_state.state.t = y[Network.net_itemp]
         return burn_state

--- a/python_library/StarKiller/StarKiller/network/network.py
+++ b/python_library/StarKiller/StarKiller/network/network.py
@@ -12,14 +12,13 @@ class Network(object):
         self.name = self.NetworkModule.get_network_name().decode("ASCII").strip().lower()
 
         self.nspec = self.ActualNetworkModule.nspec
-        self.nspec_evolve = self.ActualNetworkModule.nspec_evolve
 
         self.aion = self.ActualNetworkModule.aion
         self.aion_inv = self.NetworkModule.aion_inv
 
         # These are python zero based indexes
-        self.net_itemp = self.nspec_evolve
-        self.net_ienuc = self.nspec_evolve + 1
+        self.net_itemp = self.nspec
+        self.net_ienuc = self.nspec + 1
 
         self.short_species_names = [self.NetworkModule.get_network_short_species_name(i+1).decode("ASCII").strip().lower() for i in range(self.nspec)]
         self.species_names = [self.NetworkModule.get_network_species_name(i+1).decode("ASCII").strip().lower() for i in range(self.nspec)]

--- a/sphinx_docs/source/data_structures.rst
+++ b/sphinx_docs/source/data_structures.rst
@@ -114,7 +114,7 @@ to access the different components of the state:
 
 * ``neqs`` : the total number of variables we are integrating.
 
-   It is assumed that the first ``nspec_evolve`` are the species.
+   It is assumed that the first ``nspec`` are the species.
 
 * ``net_itemp`` : the index of the temperature in the solution vector
 

--- a/unit_test/test_cvode_react/react_utils.F90
+++ b/unit_test/test_cvode_react/react_utils.F90
@@ -82,15 +82,15 @@ contains
   end subroutine set_state
 
 
-  subroutine get_number_equations(neqs, nspec_not_evolved) bind(C, name="get_number_equations")
+  subroutine get_number_equations(neqs) bind(C, name="get_number_equations")
     use network, only: nspec, nspec_evolve
 
     implicit none
 
-    integer, intent(inout) :: neqs, nspec_not_evolved
+    integer, intent(inout) :: neqs
 
-    neqs = nspec_evolve + 2
-    nspec_not_evolved = nspec - nspec_evolve
+    neqs = nspec + 2
+
   end subroutine get_number_equations
 
 

--- a/unit_test/test_cvode_react/test_react_F.H
+++ b/unit_test/test_cvode_react/test_react_F.H
@@ -12,7 +12,7 @@ extern "C"
 
   void get_ncomp(int* ncomp);
 
-  void get_number_equations(int* neqs, int* nspec_not_evolved);
+  void get_number_equations(int* neqs);
 
   void get_species_index(int* index);
 
@@ -58,7 +58,6 @@ extern "C"
 
   void sk_get_num_rpar_comps(int* number_rpar_comps);
 
-  void sk_get_nspec_evolve(int* number_species_evolved);
 
 #ifdef AMREX_USE_CUDA
 __device__  void sk_initialize_cell_device(amrex::Real* y, amrex::Real* rpar);

--- a/util/eval_rhs/evaluate_rhs.f90
+++ b/util/eval_rhs/evaluate_rhs.f90
@@ -46,13 +46,12 @@ program evaluate_rhs
   ! Evaluate Jacobian
   call actual_jac(state)
 
-  write(*,'(A25I25)') 'nspec_evolve: ', nspec_evolve
   write(*,'(A25E30.16E5)') 'Density (g/cm^3): ', state%rho
   write(*,'(A25E30.16E5)') 'Temperature (K): ', state%T
   write(*,'(A25E30.16E5)') 'Ye: ', state%y_e
   write(*,*) 'RHS Evaluation'
   ! Print RHS
-  do i = 1, nspec_evolve
+  do i = 1, nspec
      write(*,'(A5A5A3E30.16E5)') 'ydot(', short_spec_names(i), '): ', state%ydot(i)
      write(*,'(A5A5A3E30.16E5)') 'xdot(', short_spec_names(i), '): ', state%ydot(i)*aion(i)
   end do
@@ -66,23 +65,23 @@ program evaluate_rhs
      write(*,FMT) ( state%jac(i, j), j = 1, net_ienuc )
   end do
   write(*,*) '--------------------'
-  write(*,*) 'd(dY(1:nspec_evolve)/dt)/dY(1:nspec_evolve)'
-  write(FMT, '("(", I0, "E30.16E5)")') nspec_evolve
-  do i = 1, nspec_evolve
-     write(*,FMT) ( state%jac(i, j), j = 1, nspec_evolve )
+  write(*,*) 'd(dY(1:nspec)/dt)/dY(1:nspec)'
+  write(FMT, '("(", I0, "E30.16E5)")') nspec
+  do i = 1, nspec
+     write(*,FMT) ( state%jac(i, j), j = 1, nspec )
   end do
   
-  write(*,*) 'd(dY(net_ienuc)/dt)/dY(1:nspec_evolve)'
-  write(*,FMT) ( state%jac(net_ienuc, j), j = 1, nspec_evolve )
+  write(*,*) 'd(dY(net_ienuc)/dt)/dY(1:nspec)'
+  write(*,FMT) ( state%jac(net_ienuc, j), j = 1, nspec)
   
-  write(*,*) 'd(dY(1:nspec_evolve)/dt)/dY(net_ienuc)'
-  write(*,FMT) ( state%jac(j, net_ienuc), j = 1, nspec_evolve )
+  write(*,*) 'd(dY(1:nspec)/dt)/dY(net_ienuc)'
+  write(*,FMT) ( state%jac(j, net_ienuc), j = 1, nspec)
   
-  write(*,*) 'd(dY(net_itemp)/dt)/dY(1:nspec_evolve)'
-  write(*,FMT) ( state%jac(net_itemp, j), j = 1, nspec_evolve )
+  write(*,*) 'd(dY(net_itemp)/dt)/dY(1:nspec)'
+  write(*,FMT) ( state%jac(net_itemp, j), j = 1, nspec)
   
-  write(*,*) 'd(dY(1:nspec_evolve)/dt)/dY(net_itemp)'
-  write(*,FMT) ( state%jac(j, net_itemp), j = 1, nspec_evolve )
+  write(*,*) 'd(dY(1:nspec)/dt)/dY(net_itemp)'
+  write(*,FMT) ( state%jac(j, net_itemp), j = 1, nspec)
   
   write(FMT, '("(", I0, "E30.16E5)")') 1
   


### PR DESCRIPTION
This addresses #277 -- we remove the ability to have nspec_evolve < nspec.  We only ever used it 
for the smallest nets, and it didn't work with simplified SDC.  

Note: for the nets that did have nspec_evolve < nspec, we expect tolerance-level changes to the answers because the ODE integrator is now working with a different system.

http://groot.astro.sunysb.edu/Microphysics/test-suite/gfortran/2020-03-12-002/index.html