### PR TITLE
add is_input_valid

### DIFF
--- a/EOS/breakout/actual_eos.F90
+++ b/EOS/breakout/actual_eos.F90
@@ -37,7 +37,25 @@ contains
   end subroutine actual_eos_init
 
 
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
 
+    !$gpu
+
+    valid = .true.
+
+    if (input == eos_input_rh .or. &
+        input == eos_input_tp .or. &
+        input == eos_input_ps .or. &
+        input == eos_input_ph .or. &
+        input == eos_input_th) then
+       valid = .false.
+    end if
+  end subroutine is_input_valid
+
+  
   subroutine actual_eos(input, state)
 
     use fundamental_constants_module, only: k_B, n_A

--- a/EOS/breakout/actual_eos.H
+++ b/EOS/breakout/actual_eos.H
@@ -21,7 +21,21 @@ void actual_eos_init ()
 
 }
 
+AMREX_GPU_HOST_DEVICE inline
+bool is_input_valid(eos_input_t input) {
 
+  bool valid = true;
+
+  if (input == eos_input_rh ||
+      input == eos_input_tp ||
+      input == eos_input_ps ||
+      input == eos_input_ph ||
+      input == eos_input_th) {
+    valid = false;
+  }
+
+  return valid;
+}
 
 AMREX_GPU_HOST_DEVICE inline
 void actual_eos (eos_input_t input, eos_t& state)

--- a/EOS/gamma_law/actual_eos.H
+++ b/EOS/gamma_law/actual_eos.H
@@ -37,6 +37,24 @@ void actual_eos_finalize ()
 {
 }
 
+
+AMREX_GPU_HOST_DEVICE inline
+bool is_input_valid(eos_input_t input) {
+
+  bool valid = true;
+
+  if (input == eos_input_rh ||
+      input == eos_input_tp ||
+      input == eos_input_ps ||
+      input == eos_input_ph ||
+      input == eos_input_th) {
+    valid = false;
+  }
+
+  return valid;
+}
+
+
 AMREX_GPU_HOST_DEVICE inline
 void actual_eos (eos_input_t input, eos_t& state)
 {

--- a/EOS/gamma_law/gamma_law.F90
+++ b/EOS/gamma_law/gamma_law.F90
@@ -54,6 +54,27 @@ contains
 
   end subroutine actual_eos_finalize
 
+
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
+
+    !$gpu
+
+    valid = .true.
+
+    if (input == eos_input_rh .or. &
+        input == eos_input_tp .or. &
+        input == eos_input_ps .or. &
+        input == eos_input_ph .or. &
+        input == eos_input_th) then
+       valid = .false.
+    end if
+
+  end subroutine is_input_valid
+
+
   subroutine actual_eos(input, state)
 
     !$acc routine seq

--- a/EOS/gamma_law_general/actual_eos.F90
+++ b/EOS/gamma_law_general/actual_eos.F90
@@ -53,6 +53,20 @@ contains
   end subroutine actual_eos_init
 
 
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
+
+    !$gpu
+
+    valid = .true.
+
+    if (input == eos_input_th) then
+       valid = .false.
+    end if
+  end subroutine is_input_valid
+
 
   subroutine actual_eos(input, state)
 

--- a/EOS/gamma_law_general/actual_eos.H
+++ b/EOS/gamma_law_general/actual_eos.H
@@ -26,6 +26,21 @@ void actual_eos_init() {
 
 }
 
+
+
+AMREX_GPU_HOST_DEVICE inline
+bool is_input_valid(eos_input_t input) {
+
+  bool valid = true;
+
+  if (input == eos_input_th) {
+    valid = false;
+  }
+
+  return valid;
+}
+
+
 AMREX_GPU_HOST_DEVICE inline
 void actual_eos(const eos_input_t input, eos_t& state) {
 

--- a/EOS/helmholtz/actual_eos.F90
+++ b/EOS/helmholtz/actual_eos.F90
@@ -1179,6 +1179,17 @@ contains
   end subroutine finalize_state
 
 
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
+
+    !$gpu
+
+    valid = .true.
+
+  end subroutine is_input_valid
+
 
   subroutine actual_eos_init
 

--- a/EOS/helmholtz/actual_eos.H
+++ b/EOS/helmholtz/actual_eos.H
@@ -1332,5 +1332,16 @@ void actual_eos_finalize ()
 {
 }
 
+
+
+AMREX_GPU_HOST_DEVICE inline
+bool is_input_valid(eos_input_t input) {
+
+  bool valid = true;
+
+  return valid;
+}
+
+
 #endif
 

--- a/EOS/multigamma/actual_eos.F90
+++ b/EOS/multigamma/actual_eos.F90
@@ -64,6 +64,22 @@ contains
 
 
 
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
+
+    !$gpu
+
+    valid = .true.
+
+    if (input == eos_input_ps .or. &
+        input == eos_input_th) then
+       valid = .false.
+    end if
+  end subroutine is_input_valid
+
+
   subroutine actual_eos(input, state)
 
     use fundamental_constants_module, only: k_B, n_A, hbar

--- a/EOS/multigamma/actual_eos.H
+++ b/EOS/multigamma/actual_eos.H
@@ -47,6 +47,19 @@ void actual_eos_init ()
 }
 
 
+AMREX_GPU_HOST_DEVICE inline
+bool is_input_valid(eos_input_t input) {
+
+  bool valid = true;
+
+  if (input == eos_input_ps ||
+      input == eos_input_th) {
+    valid = false;
+  }
+
+  return valid;
+}
+
 
 AMREX_GPU_HOST_DEVICE inline
 void actual_eos (eos_input_t input, eos_t& state)

--- a/EOS/polytrope/actual_eos.F90
+++ b/EOS/polytrope/actual_eos.F90
@@ -93,6 +93,18 @@ contains
   end subroutine actual_eos_init
 
 
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
+
+    !$gpu
+
+    valid = .true.
+
+  end subroutine is_input_valid
+
+
 
   !---------------------------------------------------------------------------
   ! Public interfaces 

--- a/EOS/polytrope/actual_eos.H
+++ b/EOS/polytrope/actual_eos.H
@@ -73,6 +73,14 @@ void actual_eos_init ()
 }
 
 
+AMREX_GPU_HOST_DEVICE inline
+bool is_input_valid(eos_input_t input) {
+
+  bool valid = true;
+
+  return valid;
+}
+
 
 //---------------------------------------------------------------------------
 // Public interfaces 

--- a/EOS/rad_power_law/actual_eos.H
+++ b/EOS/rad_power_law/actual_eos.H
@@ -44,6 +44,24 @@ void actual_eos_finalize ()
 
 
 AMREX_GPU_HOST_DEVICE inline
+bool is_input_valid(eos_input_t input) {
+
+  bool valid = true;
+
+  if (input == eos_input_rh ||
+      input == eos_input_tp ||
+      input == eos_input_rp ||
+      input == eos_input_ps ||
+      input == eos_input_ph ||
+      input == eos_input_th) {
+    valid = false;
+  }
+
+  return valid;
+}
+
+
+AMREX_GPU_HOST_DEVICE inline
 void actual_eos (eos_input_t input, eos_t& state)
 {
 

--- a/EOS/rad_power_law/rad_power_law.F90
+++ b/EOS/rad_power_law/rad_power_law.F90
@@ -67,6 +67,26 @@ contains
 
 
 
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
+
+    !$gpu
+
+    valid = .true.
+
+    if (input == eos_input_rh .or. &
+        input == eos_input_tp .or. &
+        input == eos_input_rp .or. &
+        input == eos_input_ps .or. &
+        input == eos_input_ph .or. &
+        input == eos_input_th) then
+       valid = .false.
+    end if
+  end subroutine is_input_valid
+
+
   subroutine actual_eos(input, state)
 
 #ifndef AMREX_USE_GPU

--- a/EOS/stellarcollapse/actual_eos.F90
+++ b/EOS/stellarcollapse/actual_eos.F90
@@ -35,6 +35,22 @@ contains
   end subroutine actual_eos_init
 
 
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
+
+    !$gpu
+
+    valid = .true.
+
+    if (input == eos_input_ps .or. &
+        input == eos_input_ph .or. &
+        input == eos_input_th) then
+       valid = .false.
+    end if
+  end subroutine is_input_valid
+
 
   subroutine actual_eos(input, state)
 

--- a/EOS/ztwd/actual_eos.F90
+++ b/EOS/ztwd/actual_eos.F90
@@ -44,6 +44,17 @@ contains
   end subroutine actual_eos_init
 
 
+  subroutine is_input_valid(input, valid)
+    implicit none
+    integer, intent(in) :: input
+    logical, intent(out) :: valid
+
+    !$gpu
+
+    valid = .true.
+
+  end subroutine is_input_valid
+
 
   subroutine actual_eos(input, state)
 

--- a/EOS/ztwd/actual_eos.H
+++ b/EOS/ztwd/actual_eos.H
@@ -38,6 +38,15 @@ void actual_eos_init ()
 }
 
 
+AMREX_GPU_HOST_DEVICE inline
+bool is_input_valid(eos_input_t input) {
+
+  bool valid = true;
+
+  return valid;
+}
+
+
 
 AMREX_GPU_HOST_DEVICE inline
 Real pressure (Real x)

--- a/unit_test/test_eos_C/main.cpp
+++ b/unit_test/test_eos_C/main.cpp
@@ -234,7 +234,7 @@ void main_main ()
 
 
           // call EOS using T, p
-          if (eos_name == "gamma_law") {
+          if (! is_input_valid(eos_input_tp)) {
             sp(i, j, k, vars.ierr_rho_eos_tp) = 0.0;
           } else {
             // reset rho to give it some work to do
@@ -283,7 +283,7 @@ void main_main ()
 
           // some EOSes don't have physically valid treatments
           // of entropy throughout the entire rho-T plane
-          if (eos_name == "multigamma" || eos_state.s <= 0.0) {
+          if ( ! is_input_valid(eos_input_ps) || eos_state.s <= 0.0) {
             sp(i, j, k, vars.ierr_T_eos_ps) = 0.0;
             sp(i, j, k, vars.ierr_rho_eos_ps) = 0.0;
 
@@ -319,7 +319,7 @@ void main_main ()
 
           // call EOS using T, h
           // this doesn't work for all EOSes (where h doesn't depend on T)
-          if (eos_name == "gamma_law_general" || eos_name == "multigamma") {
+          if ( ! is_input_valid(eos_input_th)) {
             sp(i, j, k, vars.ierr_rho_eos_th) = 0.0;
 
           } else {


### PR DESCRIPTION
We can now query an EOS to see if it supports a given input mode