### PR TITLE
Fixes some minor issues in vode-cxx before merging to development

### DIFF
--- a/integration/VODE/vode_dvhin.H
+++ b/integration/VODE/vode_dvhin.H
@@ -64,7 +64,9 @@ void dvhin (burn_t& state, dvode_t& vstate, Real& H0, int& NITER, int& IER)
                 vstate.y(i) = vstate.yh(i,1) + H * vstate.yh(i,2);
             }
 
-            rhs(state, vstate, vstate.acor);
+            const Real t1 = vstate.t + H;
+
+            rhs(t1, state, vstate, vstate.acor);
 
             for (int i = 1; i <= VODE_NEQS; ++i) {
                 vstate.acor(i) = (vstate.acor(i) - vstate.yh(i,2)) / H;

--- a/integration/VODE/vode_dvjac.H
+++ b/integration/VODE/vode_dvjac.H
@@ -121,7 +121,7 @@ void dvjac (IArray1D& pivot, int& IERPJ, burn_t& state, dvode_t& vstate)
                 vstate.y(j) += R;
                 fac = 1.0_rt / R;
 
-                rhs(state, vstate, vstate.acor);
+                rhs(vstate.tn, state, vstate, vstate.acor);
                 for (int i = 1; i <= VODE_NEQS; ++i) {
                     vstate.jac(i,j) = (vstate.acor(i) - vstate.savf(i)) * fac;
                 }

--- a/integration/VODE/vode_dvnlsd.H
+++ b/integration/VODE/vode_dvnlsd.H
@@ -62,7 +62,7 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, burn_t& state, dvode_t& vstate)
             vstate.y(i) = vstate.yh(i,1);
         }
 
-        rhs(state, vstate, vstate.savf);
+        rhs(vstate.tn, state, vstate, vstate.savf);
         vstate.NFE += 1;
 
         if (vstate.IPUP == 1) {
@@ -156,7 +156,7 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, burn_t& state, dvode_t& vstate)
             }
 
             DELP = DEL;
-            rhs(state, vstate, vstate.savf);
+            rhs(vstate.tn, state, vstate, vstate.savf);
             vstate.NFE += 1;
 
         }

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -38,7 +38,7 @@ int dvode (burn_t& state, dvode_t& vstate)
 
     Array1D<Real, 1, VODE_NEQS> f_init;
 
-    rhs(state, vstate, f_init);
+    rhs(vstate.t, state, vstate, f_init);
 
     for (int i = 1; i <= VODE_NEQS; ++i) {
         vstate.yh(i,2) = f_init(i);

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -344,7 +344,7 @@ int dvstep (burn_t& state, dvode_t& vstate)
         vstate.H *= vstate.ETA;
         vstate.HSCAL = vstate.H;
         vstate.tau(1) = vstate.H;
-        rhs(state, vstate, vstate.savf);
+        rhs(vstate.tn, state, vstate, vstate.savf);
         vstate.NFE += 1;
         for (int i = 1; i <= VODE_NEQS; ++i) {
             vstate.yh(i,2) = vstate.H * vstate.savf(i);

--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -87,8 +87,8 @@ void jac (burn_t& state, dvode_t& vode_state, RArray2D& pd)
 
     // apply fudge factor:
     if (react_boost > 0.0_rt) {
-        for (int j = 1; j <= NumSpec; ++j) {
-            for (int i = 1; i <= NumSpec; ++i) {
+        for (int j = 1; j <= VODE_NEQS; ++j) {
+            for (int i = 1; i <= VODE_NEQS; ++i) {
                 pd(i,j) *= react_boost;
             }
         }
@@ -96,13 +96,13 @@ void jac (burn_t& state, dvode_t& vode_state, RArray2D& pd)
 
     // Allow temperature and energy integration to be disabled.
     if (!integrate_temperature) {
-        for (int j = 1; j <= NumSpec; ++j) {
+        for (int j = 1; j <= VODE_NEQS; ++j) {
             pd(net_itemp,j) = 0.0_rt;
         }
     }
 
     if (!integrate_energy) {
-        for (int j = 1; j <= NumSpec; ++j) {
+        for (int j = 1; j <= VODE_NEQS; ++j) {
             pd(net_ienuc,j) = 0.0_rt;
         }
     }

--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -67,6 +67,9 @@ void rhs (const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot)
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void jac (burn_t& state, dvode_t& vode_state, RArray2D& pd)
 {
+    // NOTE: the time at which to evaluate the Jacobian is not
+    // explicitly passed. VODE always evaluates the analytic
+    // Jacobian at vode_state.tn, and we pass vode_state.
 
     // Call the specific network routine to get the Jacobian.
 

--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -51,7 +51,7 @@ void rhs (const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot)
 
     // apply fudge factor:
     if (react_boost > 0.0_rt) {
-        for (int n = 1; n <= NumSpec; ++n) {
+        for (int n = 1; n <= VODE_NEQS; ++n) {
             ydot(n) *= react_boost;
         }
     }

--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -12,7 +12,7 @@
 // network you're actually using.
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void rhs (burn_t& state, dvode_t& vode_state, RArray1D& ydot)
+void rhs (const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot)
 {
 
     // We are integrating a system of

--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -79,7 +79,7 @@ void jac (burn_t& state, dvode_t& vode_state, RArray2D& pd)
 
     // We integrate X, not Y
     for (int j = 1; j <= NumSpec; ++j) {
-        for (int i = 1; i <= NumSpec; ++i) {
+        for (int i = 1; i <= VODE_NEQS; ++i) {
             pd(j,i) *= aion[j-1];
             pd(i,j) *= aion_inv[j-1];
         }

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -79,13 +79,6 @@ void print_state(dvode_t& dvode_state)
     std::cout << "el(4) = " << dvode_state.el(4) << std::endl;
     std::cout << "el(5) = " << dvode_state.el(5) << std::endl;
     std::cout << "el(6) = " << dvode_state.el(6) << std::endl;
-    std::cout << "el(7) = " << dvode_state.el(7) << std::endl;
-    std::cout << "el(8) = " << dvode_state.el(8) << std::endl;
-    std::cout << "el(9) = " << dvode_state.el(9) << std::endl;
-    std::cout << "el(10) = " << dvode_state.el(10) << std::endl;
-    std::cout << "el(11) = " << dvode_state.el(11) << std::endl;
-    std::cout << "el(12) = " << dvode_state.el(12) << std::endl;
-    std::cout << "el(13) = " << dvode_state.el(13) << std::endl;
     std::cout << "ETA = " << dvode_state.ETA << std::endl;
     std::cout << "ETAMAX = " << dvode_state.ETAMAX << std::endl;
     std::cout << "H = " << dvode_state.H << std::endl;

--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -96,7 +96,7 @@ void burn_to_eos (const burn_t& burn_state, eos_t& eos_state)
         eos_state.xn[n] = burn_state.xn[n];
     }
 #if NumAux > 0
-    for (int n = 0; n < NumSpec; ++n) {
+    for (int n = 0; n < NumAux; ++n) {
         eos_state.aux[n] = burn_state.aux[n];
     }
 #endif

--- a/networks/powerlaw/actual_network.H
+++ b/networks/powerlaw/actual_network.H
@@ -5,7 +5,7 @@
 #include <extern_parameters.H>
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void actual_rhs (burn_t& state, Array1D<Real, 1, VODE_NEQS>& ydot)
+void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
 {
 
     for (int n = 1; n <= NumSpec; ++n) {
@@ -47,7 +47,7 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, VODE_NEQS>& ydot)
 // At present the analytical Jacobian is not implemented.
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void actual_jac (burn_t& state, Array2D<Real, 1, VODE_NEQS, 1, VODE_NEQS>& jac)
+void actual_jac (burn_t& state, Array2D<Real, 1, neqs, 1, neqs>& jac)
 {
 
     for (int j = 1; j <= NumSpec; ++j) {


### PR DESCRIPTION
This fixes some minor issues with loop bounds as well as some small cosmetic changes.

The main structural change was to put back the time argument passed to VODE's rhs function.

Although our networks are not explicitly time dependent, this is essential for generality to time dependent rhs in more general applications. So I thought it would be best to preserve what time arguments are passed in what parts of VODE in the C++ version.