### PR TITLE
add a species name enum to network_properties.H

### DIFF
--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -42,4 +42,9 @@ static const std::vector<std::string> aux_names_cxx = {
    @@AUX_NAMES@@
   };
 
+namespace Species {
+   enum NetworkSpecies {
+     @@SPECIES_ENUM@@
+   };
+};
 #endif

--- a/networks/general_null/write_network.py
+++ b/networks/general_null/write_network.py
@@ -282,6 +282,15 @@ def write_network(network_template, header_template,
                             print(p)
                             fout.write("{}constexpr int {} = {};\n".format(indent, p, properties[p]))
 
+                elif keyword == "SPECIES_ENUM":
+                    if lang == "C++":
+                        for n, spec in enumerate(species):
+                            if n == 0:
+                                fout.write("{}{}=1,\n".format(indent, spec.short_name.capitalize()))
+                            else:
+                                fout.write("{}{},\n".format(indent, spec.short_name.capitalize()))
+                        fout.write("{}NumberSpecies={}\n".format(indent, species[-1].short_name.capitalize()))
+
             else:
                 fout.write(line)
 


### PR DESCRIPTION
This adds an enum like
```
namespace Species {
   enum NetworkSpecies {
     He4=1,
     C12,
     O16,
     Ne20,
     Mg24,
     Si28,
     S32,
     Ar36,
     Ca40,
     Ti44,
     Cr48,
     Fe52,
     Ni56,
     NumberSpecies=Ni56
   };
};
```
to the `network_properties.H` file.

To test this, in `test_react` (or any unit test), do:
```
make net_prop_debug
```
and then look in `tmp_build_dir` for the `network_properties.H`