### PR TITLE
Modify simplified SDC tolerances with SDC iteration number

### DIFF
--- a/integration/VODE/_parameters
+++ b/integration/VODE/_parameters
@@ -1,0 +1,3 @@
+# SDC iteration tolerance adjustment factor
+sdc_burn_tol_factor          real         1.d0
+

--- a/integration/VODE/vode_integrator_simplified_sdc.F90
+++ b/integration/VODE/vode_integrator_simplified_sdc.F90
@@ -78,7 +78,7 @@ contains
     ! to (a) decrease dT_crit, (b) increase the maximum number of
     ! steps allowed.
 
-    sdc_tol_fac = sdc_burn_tol_factor**(state_in % max_sdc_iter - state_in % sdc_iter - 1)
+    sdc_tol_fac = sdc_burn_tol_factor**(state_in % num_sdc_iter - state_in % sdc_iter - 1)
 
 #if defined(SDC_EVOLVE_ENERGY)
 

--- a/integration/VODE/vode_integrator_simplified_sdc.F90
+++ b/integration/VODE/vode_integrator_simplified_sdc.F90
@@ -32,7 +32,7 @@ contains
                                     burning_mode, retry_burn, &
                                     retry_burn_factor, retry_burn_max_change, &
                                     call_eos_in_rhs, dT_crit, use_jacobian_caching, &
-                                    ode_max_steps
+                                    ode_max_steps, sdc_burn_tol_factor
     use cuvode_parameters_module
     use integration_data, only: integration_status_t
 
@@ -78,23 +78,25 @@ contains
     ! to (a) decrease dT_crit, (b) increase the maximum number of
     ! steps allowed.
 
+    sdc_tol_fac = sdc_burn_tol_factor**(state_in % max_sdc_iter - state_in % sdc_iter - 1)
+
 #if defined(SDC_EVOLVE_ENERGY)
 
-    dvode_state % atol(SFS:SFS-1+nspec) = status % atol_spec
-    dvode_state % atol(SEDEN)           = status % atol_enuc
-    dvode_state % atol(SEINT)           = status % atol_enuc
+    dvode_state % atol(SFS:SFS-1+nspec) = status % atol_spec * sdc_tol_fac
+    dvode_state % atol(SEDEN)           = status % atol_enuc * sdc_tol_fac
+    dvode_state % atol(SEINT)           = status % atol_enuc * sdc_tol_fac
 
-    dvode_state % rtol(SFS:SFS-1+nspec) = status % rtol_spec
-    dvode_state % rtol(SEDEN)           = status % rtol_enuc
-    dvode_state % rtol(SEINT)           = status % rtol_enuc
+    dvode_state % rtol(SFS:SFS-1+nspec) = status % rtol_spec * sdc_tol_fac
+    dvode_state % rtol(SEDEN)           = status % rtol_enuc * sdc_tol_fac
+    dvode_state % rtol(SEINT)           = status % rtol_enuc * sdc_tol_fac
 
 #elif defined(SDC_EVOLVE_ENTHALPY)
 
-    dvode_state % atol(SFS:SFS-1+nspec) = status % atol_spec ! mass fractions
-    dvode_state % atol(SENTH)           = status % atol_enuc ! enthalpy
+    dvode_state % atol(SFS:SFS-1+nspec) = status % atol_spec * sdc_tol_fac ! mass fractions
+    dvode_state % atol(SENTH)           = status % atol_enuc * sdc_tol_fac ! enthalpy
 
-    dvode_state % rtol(SFS:SFS-1+nspec) = status % rtol_spec ! mass fractions
-    dvode_state % rtol(SENTH)           = status % rtol_enuc ! enthalpy
+    dvode_state % rtol(SFS:SFS-1+nspec) = status % rtol_spec * sdc_tol_fac ! mass fractions
+    dvode_state % rtol(SENTH)           = status % rtol_enuc * sdc_tol_fac ! enthalpy
 
 #endif
 

--- a/integration/VODE/vode_integrator_simplified_sdc.F90
+++ b/integration/VODE/vode_integrator_simplified_sdc.F90
@@ -78,7 +78,7 @@ contains
     ! to (a) decrease dT_crit, (b) increase the maximum number of
     ! steps allowed.
 
-    sdc_tol_fac = sdc_burn_tol_factor**(state_in % num_sdc_iter - state_in % sdc_iter - 1)
+    sdc_tol_fac = sdc_burn_tol_factor**(state_in % num_sdc_iters - state_in % sdc_iter - 1)
 
 #if defined(SDC_EVOLVE_ENERGY)
 

--- a/integration/VODE/vode_integrator_simplified_sdc.F90
+++ b/integration/VODE/vode_integrator_simplified_sdc.F90
@@ -61,6 +61,8 @@ contains
     logical :: integration_failed
     real(rt), parameter :: failure_tolerance = 1.e-2_rt
 
+    real(rt) :: sdc_tol_fac
+
     !$gpu
 
     dvode_state % jacobian = jacobian

--- a/interfaces/sdc_type.F90
+++ b/interfaces/sdc_type.F90
@@ -63,7 +63,7 @@ module sdc_type_module
      integer :: n_jac
 
      integer :: sdc_iter
-     integer :: max_sdc_iter
+     integer :: num_sdc_iter
 
      logical :: success
   end type sdc_t

--- a/interfaces/sdc_type.F90
+++ b/interfaces/sdc_type.F90
@@ -63,7 +63,7 @@ module sdc_type_module
      integer :: n_jac
 
      integer :: sdc_iter
-     integer :: num_sdc_iter
+     integer :: num_sdc_iters
 
      logical :: success
   end type sdc_t

--- a/interfaces/sdc_type.F90
+++ b/interfaces/sdc_type.F90
@@ -63,6 +63,7 @@ module sdc_type_module
      integer :: n_jac
 
      integer :: sdc_iter
+     integer :: max_sdc_iter
 
      logical :: success
   end type sdc_t


### PR DESCRIPTION
This PR adds the number of total SDC iterations to the `sdc_t` derived type for simplified SDC and adds an extern parameter `sdc_burn_tol_factor` for VODE (defaulted to 1.0 for no effect).

If the user wishes to adjust the ODE tolerances with the SDC iteration number, `sdc_burn_tol_factor` is accounted for in VODE for simplified SDC as follows:

```
sdc_tol_fac = sdc_burn_tol_factor**(state_in % num_sdc_iters - state_in % sdc_iter - 1)
```

Then the integrator absolute and relative tolerances are scaled by `sdc_tol_fac`.