### PR TITLE
For simplified SDC, scale the absolute tolerances by density

### DIFF
--- a/integration/VODE/vode_integrator_simplified_sdc.F90
+++ b/integration/VODE/vode_integrator_simplified_sdc.F90
@@ -61,7 +61,7 @@ contains
     logical :: integration_failed
     real(rt), parameter :: failure_tolerance = 1.e-2_rt
 
-    real(rt) :: sdc_tol_fac
+    real(rt) :: sdc_tol_fac, sdc_min_density
 
     !$gpu
 
@@ -72,35 +72,6 @@ contains
     else
        dvode_state % JSV = -1
     endif
-
-    ! Set the tolerances.  We will be more relaxed on the temperature
-    ! since it is only used in evaluating the rates.
-    !
-    ! **NOTE** if you reduce these tolerances, you probably will need
-    ! to (a) decrease dT_crit, (b) increase the maximum number of
-    ! steps allowed.
-
-    sdc_tol_fac = sdc_burn_tol_factor**(state_in % num_sdc_iters - state_in % sdc_iter - 1)
-
-#if defined(SDC_EVOLVE_ENERGY)
-
-    dvode_state % atol(SFS:SFS-1+nspec) = status % atol_spec * sdc_tol_fac
-    dvode_state % atol(SEDEN)           = status % atol_enuc * sdc_tol_fac
-    dvode_state % atol(SEINT)           = status % atol_enuc * sdc_tol_fac
-
-    dvode_state % rtol(SFS:SFS-1+nspec) = status % rtol_spec * sdc_tol_fac
-    dvode_state % rtol(SEDEN)           = status % rtol_enuc * sdc_tol_fac
-    dvode_state % rtol(SEINT)           = status % rtol_enuc * sdc_tol_fac
-
-#elif defined(SDC_EVOLVE_ENTHALPY)
-
-    dvode_state % atol(SFS:SFS-1+nspec) = status % atol_spec * sdc_tol_fac ! mass fractions
-    dvode_state % atol(SENTH)           = status % atol_enuc * sdc_tol_fac ! enthalpy
-
-    dvode_state % rtol(SFS:SFS-1+nspec) = status % rtol_spec * sdc_tol_fac ! mass fractions
-    dvode_state % rtol(SENTH)           = status % rtol_enuc * sdc_tol_fac ! enthalpy
-
-#endif
 
     ! We want VODE to re-initialize each time we call it.
 
@@ -124,6 +95,38 @@ contains
 
     call sdc_to_vode(state_in, dvode_state)
 
+    ! Set the tolerances.  We will be more relaxed on the temperature
+    ! since it is only used in evaluating the rates.
+    !
+    ! **NOTE** if you reduce these tolerances, you probably will need
+    ! to (a) decrease dT_crit, (b) increase the maximum number of
+    ! steps allowed.
+
+    sdc_tol_fac = sdc_burn_tol_factor**(state_in % num_sdc_iters - state_in % sdc_iter - 1)
+
+#if defined(SDC_EVOLVE_ENERGY)
+
+    sdc_min_density = min(dvode_state % rpar(irp_SRHO), dvode_state % rpar(irp_SRHO) + dvode_state % rpar(irp_ydot_a-1+SRHO) * dt)
+
+    dvode_state % atol(SFS:SFS-1+nspec) = sdc_min_density * status % atol_spec * sdc_tol_fac
+    dvode_state % atol(SEDEN)           = sdc_min_density * status % atol_enuc * sdc_tol_fac
+    dvode_state % atol(SEINT)           = sdc_min_density * status % atol_enuc * sdc_tol_fac
+
+    dvode_state % rtol(SFS:SFS-1+nspec) = status % rtol_spec * sdc_tol_fac
+    dvode_state % rtol(SEDEN)           = status % rtol_enuc * sdc_tol_fac
+    dvode_state % rtol(SEINT)           = status % rtol_enuc * sdc_tol_fac
+
+#elif defined(SDC_EVOLVE_ENTHALPY)
+
+    sdc_min_density = min(dvode_state % rpar(irp_SRHO), dvode_state % rpar(irp_SRHO) + sum(dvode_state % rpar(irp_ydot_a-1+SFS:irp_ydot_a-1+SFS+nspec-1)) * dt)
+
+    dvode_state % atol(SFS:SFS-1+nspec) = sdc_min_density * status % atol_spec * sdc_tol_fac ! mass fractions
+    dvode_state % atol(SENTH)           = sdc_min_density * status % atol_enuc * sdc_tol_fac ! enthalpy
+
+    dvode_state % rtol(SFS:SFS-1+nspec) = status % rtol_spec * sdc_tol_fac ! mass fractions
+    dvode_state % rtol(SENTH)           = status % rtol_enuc * sdc_tol_fac ! enthalpy
+
+#endif
 
     ! this is not used but we set it to prevent accessing uninitialzed
     ! data in common routines with the non-SDC integrator


### PR DESCRIPTION
This PR implements the changes described in #310 for `SDC_EVOLVE_ENERGY` and `SDC_EVOLVE_ENTHALPY` for the simplified SDC burning mode.

Absolute tolerances for `rho*X`, `rho*E`, or `rho*h` are set to the absolute tolerances in the inputs file for species and enuc, respectively, scaled by density `rho_min`.

The density scale `rho_min` is:

`rho_min = min(rho(0), rho(0) + rho_advective_source * dt)`

For `SDC_EVOLVE_ENERGY`, `rho_advective_source` is the density advective source in the `sdc_t` passed to the integrator.

For `SDC_EVOLVE_ENTHALPY`, `rho_advective_source` is the sum of the advective sources for the partial densities `rho * Xi` for the species.