### PR TITLE
Fix to compile with MAESTROeX SDC

### DIFF
--- a/integration/VODE/vode_type_simplified_sdc.F90
+++ b/integration/VODE/vode_type_simplified_sdc.F90
@@ -544,8 +544,8 @@ contains
 
     eos_state % rho = vode_state % rpar(irp_SRHO)
     eos_state % T = 1.e4   ! initial guess
-    eos_state % xn(:) = y(SFS:SFS-1+nspec)/vode_state % rpar(irp_SRHO)
-    eos_state % h = y(SENTH)/vode_state % rpar(irp_SRHO)
+    eos_state % xn(:) = vode_state % y(SFS:SFS-1+nspec)/vode_state % rpar(irp_SRHO)
+    eos_state % h = vode_state % y(SENTH)/vode_state % rpar(irp_SRHO)
 
     call eos(eos_input_rh, eos_state)
 

--- a/interfaces/burn_type.F90
+++ b/interfaces/burn_type.F90
@@ -44,6 +44,11 @@ module burn_type_module
     real(rt) :: aux(naux)
 #endif
 
+#if SDC_EVOLVE_ENTHALPY
+    ! make pressure available to RHS
+    real(rt) :: p0
+#endif
+    
     real(rt) :: cv
     real(rt) :: cp
     real(rt) :: y_e


### PR DESCRIPTION
This PR fixes some compilation errors when using SDC_EVOLVE_ENTHALPY, which is used by MAESTROeX.
