### PR TITLE
Add amrex namespace to stellar conductivity header

### DIFF
--- a/conductivity/stellar/actual_conductivity.H
+++ b/conductivity/stellar/actual_conductivity.H
@@ -8,6 +8,8 @@
 
 const std::string cond_name = "stellar";
 
+using namespace amrex;
+
 AMREX_FORCE_INLINE
 void
 actual_conductivity_init()


### PR DESCRIPTION
The stellar conductivity `actual_conductivity.H` header file needs a `using namespace amrex` statement so that the compiler can resolve the `Real` variable types. 