### PR TITLE
Include extern_parameters.H in actual_conductivity headers

### DIFF
--- a/conductivity/constant/actual_conductivity.H
+++ b/conductivity/constant/actual_conductivity.H
@@ -4,6 +4,7 @@
 #include <cmath>
 #include "eos_type.H"
 #include "network.H"
+#include <extern_parameters.H>
 
 const std::string cond_name = "constant";
 

--- a/conductivity/constant_opacity/actual_conductivity.H
+++ b/conductivity/constant_opacity/actual_conductivity.H
@@ -4,6 +4,7 @@
 #include <cmath>
 #include "eos_type.H"
 #include "network.H"
+#include <extern_parameters.H>
 
 const std::string cond_name = "constant_opacity";
 

--- a/conductivity/powerlaw/actual_conductivity.H
+++ b/conductivity/powerlaw/actual_conductivity.H
@@ -4,6 +4,7 @@
 #include <cmath>
 #include "eos_type.H"
 #include "network.H"
+#include <extern_parameters.H>
 
 const std::string cond_name = "powerlaw";
 


### PR DESCRIPTION
The `actual_conductivity.H` header files use variables defined in `extern_parameters.H`, so this file should be `#include`d so that successful compilation does not require the files to be `#include`d in a specific order.