### PR TITLE
Restore approximate value of pi in ecapnuc

### DIFF
--- a/rates/aprox_rates.H
+++ b/rates/aprox_rates.H
@@ -152,8 +152,8 @@ void rate_c12ag_deboer17(tf_t tf, const Real den, Real& fr,
     const Real term_a5_nr = std::exp(a5_nr*tf.t953);
     const Real term_a6_nr = std::pow(tf.t9,a6_nr);
 
-    const Real term_nr = term_a0_nr * term_a1_nr * term_a2_nr * \
-              term_a3_nr * term_a4_nr * term_a5_nr * \
+    const Real term_nr = term_a0_nr * term_a1_nr * term_a2_nr *
+              term_a3_nr * term_a4_nr * term_a5_nr *
               term_a6_nr;
 
     const Real dterm_a2_nr = -a2_nr*tf.t9i43*term_a2_nr/3e0_rt;
@@ -162,10 +162,10 @@ void rate_c12ag_deboer17(tf_t tf, const Real den, Real& fr,
     const Real dterm_a5_nr = a5_nr*tf.t923*term_a5_nr*5.0_rt/3.0_rt;
     const Real dterm_a6_nr = tf.t9i*a6_nr*std::pow(tf.t9,a6_nr);
 
-    const Real dterm_nr = (term_a0_nr * term_a1_nr * dterm_a2_nr * term_a3_nr * term_a4_nr * term_a5_nr * term_a6_nr) + \
-               (term_a0_nr * term_a1_nr * term_a2_nr * dterm_a3_nr * term_a4_nr * term_a5_nr * term_a6_nr) + \
-               (term_a0_nr * term_a1_nr * term_a2_nr * term_a3_nr * dterm_a4_nr * term_a5_nr * term_a6_nr) + \
-               (term_a0_nr * term_a1_nr * term_a2_nr * term_a3_nr * term_a4_nr * dterm_a5_nr * term_a6_nr) + \
+    const Real dterm_nr = (term_a0_nr * term_a1_nr * dterm_a2_nr * term_a3_nr * term_a4_nr * term_a5_nr * term_a6_nr) +
+               (term_a0_nr * term_a1_nr * term_a2_nr * dterm_a3_nr * term_a4_nr * term_a5_nr * term_a6_nr) +
+               (term_a0_nr * term_a1_nr * term_a2_nr * term_a3_nr * dterm_a4_nr * term_a5_nr * term_a6_nr) +
+               (term_a0_nr * term_a1_nr * term_a2_nr * term_a3_nr * term_a4_nr * dterm_a5_nr * term_a6_nr) +
                (term_a0_nr * term_a1_nr * term_a2_nr * term_a3_nr * term_a4_nr * term_a5_nr * dterm_a6_nr);
 
     // resonant contributions to the reaction
@@ -185,14 +185,14 @@ void rate_c12ag_deboer17(tf_t tf, const Real den, Real& fr,
     const Real term_a5_r = std::exp(a5_r*tf.t953);
     const Real term_a6_r = std::pow(tf.t9,a6_r);
 
-    const Real term_r = term_a0_r * term_a1_r * term_a2_r * \
-              term_a3_r * term_a4_r * term_a5_r * \
+    const Real term_r = term_a0_r * term_a1_r * term_a2_r *
+              term_a3_r * term_a4_r * term_a5_r *
               term_a6_r;
 
     const Real dterm_a1_r = -a1_r*tf.t9i2*term_a1_r;
     const Real dterm_a6_r = tf.t9i*a6_r*std::pow(tf.t9,a6_r);
     
-    const Real dterm_r = (term_a0_r * dterm_a1_r * term_a6_r) + \
+    const Real dterm_r = (term_a0_r * dterm_a1_r * term_a6_r) +
               (term_a0_r * term_a1_r * dterm_a6_r);
 
     // full rate is the sum of resonant and non-resonant contributions
@@ -228,9 +228,9 @@ void rate_triplealf(tf_t tf, const Real den, Real& fr,
     const Real bb    = 4.164e9_rt * tf.t9i23 * std::exp(-13.49_rt*tf.t9i13 - tf.t92*q1);
     const Real dbb   = bb*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*13.49_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    const Real cc    = 1.0e0_rt + 0.031_rt*tf.t913 + 8.009_rt*tf.t923 + 1.732_rt*tf.t9 \
+    const Real cc    = 1.0e0_rt + 0.031_rt*tf.t913 + 8.009_rt*tf.t923 + 1.732_rt*tf.t9
           + 49.883_rt*tf.t943 + 27.426_rt*tf.t953;
-    const Real dcc   = 1.0_rt/3.0_rt*0.031_rt*tf.t9i23 + 2.0_rt/3.0_rt*8.009_rt*tf.t9i13 + 1.732_rt \
+    const Real dcc   = 1.0_rt/3.0_rt*0.031_rt*tf.t9i23 + 2.0_rt/3.0_rt*8.009_rt*tf.t9i13 + 1.732_rt
           + 4.0_rt/3.0_rt*49.883_rt*tf.t913 + 5.0_rt/3.0_rt*27.426_rt*tf.t923;
 
     const Real r2abe    = aa + bb * cc;
@@ -243,9 +243,9 @@ void rate_triplealf(tf_t tf, const Real den, Real& fr,
     const Real ee    = 2.510e7_rt * tf.t9i23 * std::exp(-23.57_rt*tf.t9i13 - tf.t92*q2);
     const Real dee   = ee*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*23.57_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q2);
 
-    const Real ff    = 1.0e0_rt + 0.018_rt*tf.t913 + 5.249_rt*tf.t923 + 0.650_rt*tf.t9 + \
+    const Real ff    = 1.0e0_rt + 0.018_rt*tf.t913 + 5.249_rt*tf.t923 + 0.650_rt*tf.t9 +
          19.176_rt*tf.t943 + 6.034_rt*tf.t953;
-    const Real dff   = 1.0_rt/3.0_rt*0.018_rt*tf.t9i23 + 2.0_rt/3.0_rt*5.249_rt*tf.t9i13 + 0.650_rt \
+    const Real dff   = 1.0_rt/3.0_rt*0.018_rt*tf.t9i23 + 2.0_rt/3.0_rt*5.249_rt*tf.t9i13 + 0.650_rt
           + 4.0_rt/3.0_rt*19.176_rt*tf.t913 + 5.0_rt/3.0_rt*6.034_rt*tf.t923;
 
     const Real rbeac    = dd + ee * ff;
@@ -259,8 +259,8 @@ void rate_triplealf(tf_t tf, const Real den, Real& fr,
     // high temperature rate
     if (tf.t9 > 0.08_rt) {
         term    = 2.90e-16_rt * r2abe * rbeac + xx;
-        dtermdt =   2.90e-16_rt * dr2abedt * rbeac \
-                    + 2.90e-16_rt * r2abe * drbeacdt \
+        dtermdt =   2.90e-16_rt * dr2abedt * rbeac
+                    + 2.90e-16_rt * r2abe * drbeacdt
                     + dxx;
 
     // low temperature rate
@@ -277,9 +277,9 @@ void rate_triplealf(tf_t tf, const Real den, Real& fr,
         //    ! fxt f1   = yy * aa;
         const Real df1  = (dyy - f1*dzz)*aa;
         term = 2.90e-16_rt * r2abe * rbeac * f1 +  xx;
-        dtermdt =   2.90e-16_rt * dr2abedt * rbeac * f1 \
-                    + 2.90e-16_rt * r2abe * drbeacdt * f1 \
-                    + 2.90e-16_rt * r2abe * rbeac * df1 \
+        dtermdt =   2.90e-16_rt * dr2abedt * rbeac * f1
+                    + 2.90e-16_rt * r2abe * drbeacdt * f1
+                    + 2.90e-16_rt * r2abe * rbeac * df1
                     + dxx;
     }
 
@@ -316,9 +316,9 @@ void rate_c12c12(tf_t tf, const Real den, Real& fr,
     const Real t9a56   = std::pow(t9a,5.0_rt/6.0_rt);
     const Real dt9a56  = 5.0_rt/6.0_rt*t9a56*zz;
 
-    const Real term    = 4.27e26_rt * t9a56 * tf.t9i32 * \
+    const Real term    = 4.27e26_rt * t9a56 * tf.t9i32 *
          std::exp(-84.165_rt/t9a13 - 2.12e-03_rt*tf.t93);
-    const Real dtermdt = term*(dt9a56/t9a56 - 1.5e0_rt*tf.t9i \
+    const Real dtermdt = term*(dt9a56/t9a56 - 1.5e0_rt*tf.t9i
             + 84.165_rt/(t9a13*t9a13)*dt9a13 - 6.36e-3_rt*tf.t92);
 
     // rates
@@ -387,11 +387,11 @@ void rate_o16o16(tf_t tf, const Real den, Real& fr,
                 Real& drrdt) 
 {
     // o16 + o16
-    const Real term  = 7.10e36_rt * tf.t9i23 * \
+    const Real term  = 7.10e36_rt * tf.t9i23 *
          std::exp(-135.93_rt * tf.t9i13 - 0.629_rt*tf.t923 
          - 0.445_rt*tf.t943 + 0.0103_rt*tf.t9*tf.t9);
 
-    const Real dtermdt = -2.0_rt/3.0_rt*term*tf.t9i \
+    const Real dtermdt = -2.0_rt/3.0_rt*term*tf.t9i
          + term * (1.0_rt/3.0_rt*135.93_rt*tf.t9i43 - 2.0_rt/3.0_rt*0.629_rt*tf.t9i13 
          - 4.0_rt/3.0_rt*0.445_rt*tf.t913 + 0.0206_rt*tf.t9);
 
@@ -452,9 +452,9 @@ void rate_ne20ag(tf_t tf, const Real den, Real& fr,
     Real aa   = 4.11e11_rt * tf.t9i23 * std::exp(-46.766_rt*tf.t9i13 - tf.t92*q1);
     Real daa  = aa*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*46.766_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    Real bb   = 1.0e0_rt + 0.009_rt*tf.t913 + 0.882_rt*tf.t923 + 0.055_rt*tf.t9 \
+    Real bb   = 1.0e0_rt + 0.009_rt*tf.t913 + 0.882_rt*tf.t923 + 0.055_rt*tf.t9
          + 0.749_rt*tf.t943 + 0.119_rt*tf.t953;
-    Real dbb  = 1.0_rt/3.0_rt*0.009_rt*tf.t9i23 + 2.0_rt/3.0_rt*0.882_rt*tf.t9i13 + 0.055_rt \
+    Real dbb  = 1.0_rt/3.0_rt*0.009_rt*tf.t9i23 + 2.0_rt/3.0_rt*0.882_rt*tf.t9i13 + 0.055_rt
          + 4.0_rt/3.0_rt*0.749_rt*tf.t913 + 5.0_rt/3.0_rt*0.119_rt*tf.t923;
 
     const Real term1  = aa * bb;
@@ -557,9 +557,9 @@ void rate_mg24ap(tf_t tf, const Real den, Real& fr,
     Real aa     = 1.10e8_rt * tf.t9i23 * std::exp(-23.261_rt*tf.t9i13 - tf.t92*q1);
     Real daa    = -2.0_rt/3.0_rt*aa*tf.t9i + aa*(23.261_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    Real bb     =  1.0e0_rt + 0.018_rt*tf.t913 + 12.85_rt*tf.t923 + 1.61_rt*tf.t9 \
+    Real bb     =  1.0e0_rt + 0.018_rt*tf.t913 + 12.85_rt*tf.t923 + 1.61_rt*tf.t9
          + 89.87_rt*tf.t943 + 28.66_rt*tf.t953;
-    Real dbb    = 1.0_rt/3.0_rt*0.018_rt*tf.t9i23 + 2.0_rt/3.0_rt*12.85_rt*tf.t9i13 + 1.61_rt \
+    Real dbb    = 1.0_rt/3.0_rt*0.018_rt*tf.t9i23 + 2.0_rt/3.0_rt*12.85_rt*tf.t9i13 + 1.61_rt
            + 4.0_rt/3.0_rt*89.87_rt*tf.t913 + 5.0_rt/3.0_rt*28.66_rt*tf.t923;
 
     const Real term1  = aa * bb;
@@ -658,9 +658,9 @@ void rate_al27pg_old(tf_t tf, const Real den, Real& fr,
     const Real aa  = 1.67e8_rt * tf.t9i23 * std::exp(-23.261_rt*tf.t9i13 - tf.t92*q1);
     const Real daa = aa*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*23.261_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    const Real bb  = 1.0e0_rt + 0.018_rt*tf.t913 + 5.81_rt*tf.t923 + 0.728_rt*tf.t9 \
+    const Real bb  = 1.0e0_rt + 0.018_rt*tf.t913 + 5.81_rt*tf.t923 + 0.728_rt*tf.t9
          + 27.31_rt*tf.t943 + 8.71_rt*tf.t953;
-    const Real dbb = 1.0_rt/3.0_rt*0.018_rt*tf.t9i23 + 2.0_rt/3.0_rt*5.81_rt*tf.t9i13 + 0.728_rt \
+    const Real dbb = 1.0_rt/3.0_rt*0.018_rt*tf.t9i23 + 2.0_rt/3.0_rt*5.81_rt*tf.t9i13 + 0.728_rt
          + 4.0_rt/3.0_rt*27.31_rt*tf.t913 + 5.0_rt/3.0_rt*8.71_rt*tf.t923;
 
     const Real cc  = aa*bb;
@@ -1387,12 +1387,12 @@ void rate_png(tf_t tf, const Real den, Real& fr,
     // p(n,g)d
     // smith,kawano,malany 1992
 
-    const Real aa      = 1.0e0_rt - 0.8504_rt*tf.t912 + 0.4895_rt*tf.t9 \
-         - 0.09623_rt*tf.t932 + 8.471e-3_rt*tf.t92 \
+    const Real aa      = 1.0e0_rt - 0.8504_rt*tf.t912 + 0.4895_rt*tf.t9
+         - 0.09623_rt*tf.t932 + 8.471e-3_rt*tf.t92
          - 2.80e-4_rt*tf.t952;
 
-    const Real daa     =  -0.5e0_rt*0.8504_rt*tf.t9i12 + 0.4895_rt \
-         - 1.5e0_rt*0.09623_rt*tf.t912 + 2.0e0_rt*8.471e-3_rt*tf.t9 \
+    const Real daa     =  -0.5e0_rt*0.8504_rt*tf.t9i12 + 0.4895_rt
+         - 1.5e0_rt*0.09623_rt*tf.t912 + 2.0e0_rt*8.471e-3_rt*tf.t9
          - 2.5e0_rt*2.80e-4_rt*tf.t932;
 
     const Real term    = 4.742e4_rt * aa;
@@ -1471,9 +1471,9 @@ void rate_he3he3(tf_t tf, const Real den, Real& fr,
     const Real aa   = 6.04e10_rt * tf.t9i23 * std::exp(-12.276_rt*tf.t9i13);
     const Real daa  = aa*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*12.276_rt*tf.t9i43);
 
-    const Real bb   = 1.0e0_rt + 0.034_rt*tf.t913 - 0.522_rt*tf.t923 - 0.124_rt*tf.t9 \
+    const Real bb   = 1.0e0_rt + 0.034_rt*tf.t913 - 0.522_rt*tf.t923 - 0.124_rt*tf.t9
          + 0.353_rt*tf.t943 + 0.213_rt*tf.t953;
-    const Real dbb  = 1.0_rt/3.0_rt*0.034_rt*tf.t9i23 - 2.0_rt/3.0_rt*0.522_rt*tf.t9i13 - 0.124_rt \
+    const Real dbb  = 1.0_rt/3.0_rt*0.034_rt*tf.t9i23 - 2.0_rt/3.0_rt*0.522_rt*tf.t9i13 - 0.124_rt
          + 4.0_rt/3.0_rt*0.353_rt*tf.t913 + 5.0_rt/3.0_rt*0.213_rt*tf.t923;
 
     const Real term    = aa * bb;
@@ -1511,7 +1511,7 @@ void rate_he3he4(tf_t tf, const Real den, Real& fr,
     const Real dt9a56  = 5.0_rt/6.0_rt*t9a56*zz;
 
     const Real term    = 5.61e6_rt * t9a56 * tf.t9i32 * std::exp(-12.826_rt/t9a13);
-    const Real dtermdt = term*(dt9a56/t9a56 - 1.5e0_rt*tf.t9i \
+    const Real dtermdt = term*(dt9a56/t9a56 - 1.5e0_rt*tf.t9i
          + 12.826_rt/(t9a13*t9a13) * dt9a13);
 
     // rates
@@ -1536,9 +1536,9 @@ void rate_c12pg(tf_t tf, const Real den, Real& fr,
     const Real aa   = 2.04e7_rt * tf.t9i23 * std::exp(-13.69_rt*tf.t9i13 - tf.t92*q1);
     const Real daa  = aa*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*13.69_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    const Real bb   = 1.0e0_rt + 0.03_rt*tf.t913 + 1.19_rt*tf.t923 + 0.254_rt*tf.t9 \
+    const Real bb   = 1.0e0_rt + 0.03_rt*tf.t913 + 1.19_rt*tf.t923 + 0.254_rt*tf.t9
          + 2.06_rt*tf.t943 + 1.12_rt*tf.t953;
-    const Real dbb  = 1.0_rt/3.0_rt*0.03_rt*tf.t9i23 + 2.0_rt/3.0_rt*1.19_rt*tf.t9i13 + 0.254_rt \
+    const Real dbb  = 1.0_rt/3.0_rt*0.03_rt*tf.t9i23 + 2.0_rt/3.0_rt*1.19_rt*tf.t9i13 + 0.254_rt
          + 4.0_rt/3.0_rt*2.06_rt*tf.t913 + 5.0_rt/3.0_rt*1.12_rt*tf.t923;
 
     const Real cc   = aa * bb;
@@ -1575,9 +1575,9 @@ void rate_n14pg(tf_t tf, const Real den, Real& fr,
     const Real aa  = 4.90e7_rt * tf.t9i23 * std::exp(-15.228_rt*tf.t9i13 - tf.t92*q1);
     const Real daa = aa*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*15.228_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    const Real bb   = 1.0e0_rt + 0.027_rt*tf.t913 - 0.778_rt*tf.t923 - 0.149_rt*tf.t9 \
+    const Real bb   = 1.0e0_rt + 0.027_rt*tf.t913 - 0.778_rt*tf.t923 - 0.149_rt*tf.t9
          + 0.261_rt*tf.t943 + 0.127_rt*tf.t953;
-    const Real dbb  = 1.0_rt/3.0_rt*0.027_rt*tf.t9i23 - 2.0_rt/3.0_rt*0.778_rt*tf.t9i13 - 0.149_rt \
+    const Real dbb  = 1.0_rt/3.0_rt*0.027_rt*tf.t9i23 - 2.0_rt/3.0_rt*0.778_rt*tf.t9i13 - 0.149_rt
          + 4.0_rt/3.0_rt*0.261_rt*tf.t913 + 5.0_rt/3.0_rt*0.127_rt*tf.t923;
 
     const Real cc   = aa * bb;
@@ -1614,9 +1614,9 @@ void rate_n15pg(tf_t tf, const Real den, Real& fr,
     const Real aa  = 9.78e8_rt * tf.t9i23 * std::exp(-15.251_rt*tf.t9i13 - tf.t92*q1);
     const Real daa = aa*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*15.251_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    const Real bb   = 1.0e0_rt  + 0.027_rt*tf.t913 + 0.219_rt*tf.t923 + 0.042_rt*tf.t9 \
+    const Real bb   = 1.0e0_rt  + 0.027_rt*tf.t913 + 0.219_rt*tf.t923 + 0.042_rt*tf.t9
          + 6.83_rt*tf.t943 + 3.32_rt*tf.t953;
-    const Real dbb  = 1.0_rt/3.0_rt*0.027_rt*tf.t9i23 + 2.0_rt/3.0_rt*0.219_rt*tf.t9i13 + 0.042_rt \
+    const Real dbb  = 1.0_rt/3.0_rt*0.027_rt*tf.t9i23 + 2.0_rt/3.0_rt*0.219_rt*tf.t9i13 + 0.042_rt
          + 4.0_rt/3.0_rt*6.83_rt*tf.t913 + 5.0_rt/3.0_rt*3.32_rt*tf.t923;
 
     const Real cc   = aa * bb;
@@ -1657,9 +1657,9 @@ void rate_n15pa(tf_t tf, const Real den, Real& fr,
     const Real aa  = 1.08e12_rt*tf.t9i23*std::exp(-15.251_rt*tf.t9i13 - tf.t92*q1);
     const Real daa = aa*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*15.251_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    const Real bb   = 1.0e0_rt + 0.027_rt*tf.t913 + 2.62_rt*tf.t923 + 0.501_rt*tf.t9 \
+    const Real bb   = 1.0e0_rt + 0.027_rt*tf.t913 + 2.62_rt*tf.t923 + 0.501_rt*tf.t9
          + 5.36_rt*tf.t943 + 2.60_rt*tf.t953;
-    const Real dbb  = 1.0_rt/3.0_rt*0.027_rt*tf.t9i23 + 2.0_rt/3.0_rt*2.62_rt*tf.t9i13 + 0.501_rt \
+    const Real dbb  = 1.0_rt/3.0_rt*0.027_rt*tf.t9i23 + 2.0_rt/3.0_rt*2.62_rt*tf.t9i13 + 0.501_rt
          + 4.0_rt/3.0_rt*5.36_rt*tf.t913 + 5.0_rt/3.0_rt*2.60_rt*tf.t923;
 
     const Real cc   = aa * bb;
@@ -1738,9 +1738,9 @@ void rate_n14ag(tf_t tf, const Real den, Real& fr,
     const Real aa  = 7.78e9_rt * tf.t9i23 * std::exp(-36.031_rt*tf.t9i13- tf.t92*q1);
     const Real daa = aa*(-2.0_rt/3.0_rt*tf.t9i + 1.0_rt/3.0_rt*36.031_rt*tf.t9i43 - 2.0e0_rt*tf.t9*q1);
 
-    const Real bb   = 1.0e0_rt + 0.012_rt*tf.t913 + 1.45_rt*tf.t923 + 0.117_rt*tf.t9 \
+    const Real bb   = 1.0e0_rt + 0.012_rt*tf.t913 + 1.45_rt*tf.t923 + 0.117_rt*tf.t9
          + 1.97_rt*tf.t943 + 0.406_rt*tf.t953;
-    const Real dbb  = 1.0_rt/3.0_rt*0.012_rt*tf.t9i23 + 2.0_rt/3.0_rt*1.45_rt*tf.t9i13 + 0.117_rt \
+    const Real dbb  = 1.0_rt/3.0_rt*0.012_rt*tf.t9i23 + 2.0_rt/3.0_rt*1.45_rt*tf.t9i13 + 0.117_rt
          + 4.0_rt/3.0_rt*1.97_rt*tf.t913 + 5.0_rt/3.0_rt*0.406_rt*tf.t923;
 
     const Real cc   = aa * bb;
@@ -1821,12 +1821,12 @@ void rate_fe54ng(tf_t tf, const Real den, Real& fr,
                 Real& drrdt) 
 {
     // fe54(n,g)fe55
-    const Real aa   =  2.307390e1_rt - 7.931795e-02_rt * tf.t9i + 7.535681e0_rt * tf.t9i13 \
-         - 1.595025e1_rt * tf.t913 + 1.377715e0_rt * tf.t9 - 1.291479e-01_rt * tf.t953 \
+    const Real aa   =  2.307390e1_rt - 7.931795e-02_rt * tf.t9i + 7.535681e0_rt * tf.t9i13
+         - 1.595025e1_rt * tf.t913 + 1.377715e0_rt * tf.t9 - 1.291479e-01_rt * tf.t953
          + 6.707473e0_rt * std::log(tf.t9);
 
-    const Real daa  =  7.931795e-02_rt * tf.t9i2 - 1.0_rt/3.0_rt * 7.535681e0_rt * tf.t9i43 \
-         - 1.0_rt/3.0_rt * 1.595025e1_rt *tf.t9i23 + 1.377715e0_rt - 5.0_rt/3.0_rt * 1.291479e-01_rt *tf.t923 \
+    const Real daa  =  7.931795e-02_rt * tf.t9i2 - 1.0_rt/3.0_rt * 7.535681e0_rt * tf.t9i43
+         - 1.0_rt/3.0_rt * 1.595025e1_rt *tf.t9i23 + 1.377715e0_rt - 5.0_rt/3.0_rt * 1.291479e-01_rt *tf.t923
          + 6.707473e0_rt * tf.t9i;
 
     Real term, dtermdt;
@@ -1887,12 +1887,12 @@ void rate_fe54ap(tf_t tf, const Real den, Real& fr,
                 Real& drrdt) 
 {
     // fe54(a,p)co57
-    const Real aa   =  3.97474900e1_rt - 6.06543100e0_rt * tf.t9i + 1.63239600e2_rt * tf.t9i13 \
-         - 2.20457700e2_rt * tf.t913 + 8.63980400e0_rt * tf.t9 - 3.45841300e-01_rt * tf.t953 \
+    const Real aa   =  3.97474900e1_rt - 6.06543100e0_rt * tf.t9i + 1.63239600e2_rt * tf.t9i13
+         - 2.20457700e2_rt * tf.t913 + 8.63980400e0_rt * tf.t9 - 3.45841300e-01_rt * tf.t953
          + 1.31464200e2_rt * std::log(tf.t9);
 
-    const Real daa  =  6.06543100e0_rt * tf.t9i2 - 1.0_rt/3.0_rt * 1.63239600e2_rt * tf.t9i43 \
-         - 1.0_rt/3.0_rt * 2.20457700e2_rt * tf.t9i23 + 8.63980400e0_rt - 5.0_rt/3.0_rt * 3.45841300e-01_rt * tf.t923 \
+    const Real daa  =  6.06543100e0_rt * tf.t9i2 - 1.0_rt/3.0_rt * 1.63239600e2_rt * tf.t9i43
+         - 1.0_rt/3.0_rt * 2.20457700e2_rt * tf.t9i23 + 8.63980400e0_rt - 5.0_rt/3.0_rt * 3.45841300e-01_rt * tf.t923
          + 1.31464200e2_rt  * tf.t9i;
 
     Real term, dtermdt;
@@ -1922,12 +1922,12 @@ void rate_fe55ng(tf_t tf, const Real den, Real& fr,
                 Real& drrdt) 
 {
     // fe55(n,g)fe56
-    const Real aa   =  1.954115e1_rt - 6.834029e-02_rt * tf.t9i + 5.379859e0_rt * tf.t9i13 \
-         - 8.758150e0_rt * tf.t913 + 5.285107e-01_rt * tf.t9 - 4.973739e-02_rt  * tf.t953 \
+    const Real aa   =  1.954115e1_rt - 6.834029e-02_rt * tf.t9i + 5.379859e0_rt * tf.t9i13
+         - 8.758150e0_rt * tf.t913 + 5.285107e-01_rt * tf.t9 - 4.973739e-02_rt  * tf.t953
          + 4.065564e0_rt  * std::log(tf.t9);
 
-    const Real daa  =  6.834029e-02_rt * tf.t9i2 - 1.0_rt/3.0_rt * 5.379859e0_rt * tf.t9i43 \
-         - 1.0_rt/3.0_rt * 8.758150e0_rt * tf.t9i23 + 5.285107e-01_rt - 5.0_rt/3.0_rt * 4.973739e-02_rt  *tf.t923 \
+    const Real daa  =  6.834029e-02_rt * tf.t9i2 - 1.0_rt/3.0_rt * 5.379859e0_rt * tf.t9i43
+         - 1.0_rt/3.0_rt * 8.758150e0_rt * tf.t9i23 + 5.285107e-01_rt - 5.0_rt/3.0_rt * 4.973739e-02_rt  *tf.t923
          + 4.065564e0_rt  * tf.t9i;
 
     Real term, dtermdt;
@@ -1958,12 +1958,12 @@ void rate_fe56pg(tf_t tf, const Real den, Real& fr,
 {
     // fe56(p,g)co57
 
-    const Real aa   =  1.755960e2_rt - 7.018872e0_rt * tf.t9i + 2.800131e2_rt * tf.t9i13 \
-         - 4.749343e2_rt * tf.t913 + 2.683860e1_rt * tf.t9 - 1.542324e0_rt  * tf.t953 \
+    const Real aa   =  1.755960e2_rt - 7.018872e0_rt * tf.t9i + 2.800131e2_rt * tf.t9i13
+         - 4.749343e2_rt * tf.t913 + 2.683860e1_rt * tf.t9 - 1.542324e0_rt  * tf.t953
          + 2.315911e2_rt  * std::log(tf.t9);
 
-    const Real daa  =  7.018872e0_rt * tf.t9i2 - 1.0_rt/3.0_rt * 2.800131e2_rt * tf.t9i43 \
-         - 1.0_rt/3.0_rt * 4.749343e2_rt * tf.t9i23 + 2.683860e1_rt - 5.0_rt/3.0_rt * 1.542324e0_rt  *tf.t923 \
+    const Real daa  =  7.018872e0_rt * tf.t9i2 - 1.0_rt/3.0_rt * 2.800131e2_rt * tf.t9i43
+         - 1.0_rt/3.0_rt * 4.749343e2_rt * tf.t9i23 + 2.683860e1_rt - 5.0_rt/3.0_rt * 1.542324e0_rt  *tf.t923
          + 2.315911e2_rt  * tf.t9i;
 
     Real term, dtermdt;
@@ -2070,6 +2070,8 @@ void ecapnuc(const Real etakep, const Real temp,
     const Real bk     = 1.38062e-16_rt;
     const Real qn2    = 2.0716446e-06_rt;
     const Real c2me   = 8.1872665e-07_rt;
+    const Real pi     = 3.1415927e0_rt;
+    const Real pi2    = pi * pi;
 
     // c2me is the constant used to convert the neutrino energy
     // loss rate from mec2/s (as in the paper) to ergs/particle/sec.
@@ -2128,11 +2130,11 @@ void ecapnuc(const Real etakep, const Real temp,
             const Real eta4   = eta3*eta;
             f1g = 0.5e0_rt*eta2 + 2.0e0_rt - exmeta;
             f2g = eta3*1.0_rt/3.0_rt + 4.0e0_rt*eta + 2.0e0_rt*exmeta;
-            f3g = 0.25e0_rt*eta4 + 0.5e0_rt*M_PI*M_PI*eta2 + 12.0e0_rt - 6.0e0_rt*exmeta;
-            f4g = 0.2e0_rt*eta4*eta + 2.0e0_rt*M_PI*M_PI*1.0_rt/3.0_rt*eta3 + 48.0e0_rt*eta \
+            f3g = 0.25e0_rt*eta4 + 0.5e0_rt*pi2*eta2 + 12.0e0_rt - 6.0e0_rt*exmeta;
+            f4g = 0.2e0_rt*eta4*eta + 2.0e0_rt*pi2*1.0_rt/3.0_rt*eta3 + 48.0e0_rt*eta
                     + 24.0e0_rt*exmeta;
-            f5g = eta4*eta2*1.0_rt/6.0_rt + 5.0e0_rt*1.0_rt/6.0_rt*M_PI*M_PI*eta4 \
-                    + 7.0e0_rt*1.0_rt/6.0_rt*M_PI*M_PI*eta2  + 240.0e0_rt -120.e0_rt*exmeta;
+            f5g = eta4*eta2*1.0_rt/6.0_rt + 5.0e0_rt*1.0_rt/6.0_rt*pi2*eta4
+                    + 7.0e0_rt*1.0_rt/6.0_rt*pi2*eta2  + 240.0e0_rt -120.e0_rt*exmeta;
         }
 
         // factors which are multiplied by the fermi integrals
@@ -2148,15 +2150,15 @@ void ecapnuc(const Real etakep, const Real temp,
         // neutrino emission rate for electron capture:
         const Real facv4 = 5.0e0_rt*etael + 3.0e0_rt*zetan;
         const Real facv3 = 10.0e0_rt*etael2 + 12.0e0_rt*etael*zetan + 3.0e0_rt*zetan2;
-        const Real facv2 = 10.0e0_rt*etael3 + 18.0e0_rt*etael2*zetan \
+        const Real facv2 = 10.0e0_rt*etael3 + 18.0e0_rt*etael2*zetan
             + 9.0e0_rt*etael*zetan2 + zetan2*zetan;
-        const Real facv1 = 5.0e0_rt*etael4 + 12.0e0_rt*etael3*zetan \
+        const Real facv1 = 5.0e0_rt*etael4 + 12.0e0_rt*etael3*zetan
             + 9.0e0_rt*etael2*zetan2 + 2.0e0_rt*etael*zetan2*zetan;
-        const Real facv0 = etael5 + 3.0e0_rt*etael4*zetan \
+        const Real facv0 = etael5 + 3.0e0_rt*etael4*zetan
             + 3.0e0_rt*etael3*zetan2 + etael2*zetan2*zetan;
-        rjv1  = f5l + facv4*f4l + facv3*f3l \
+        rjv1  = f5l + facv4*f4l + facv3*f3l
             + facv2*f2l + facv1*f1l + facv0*f0;
-        rjv2  = f5g + facv4*f4g + facv3*f3g \
+        rjv2  = f5g + facv4*f4g + facv3*f3g
             + facv2*f2g + facv1*f1g + facv0*f0;
 
         // for electrons capture onto protons


### PR DESCRIPTION
Although in the long term it would be good to sync up mathematical and physical constants with more accurate values, our immediate concern is making the C++ port match the Fortran code, and restoring the approximate value of pi hardcoded in the Fortran is necessary to do that (otherwise we get differences at the 1e-9 level for the rates depending on the output of ecapnuc, such as jac(He3, H1)).