### PR TITLE
Fix indexing that accidentally used a real as an int

### DIFF
--- a/integration/VODE/vode_type_simplified_sdc.F90
+++ b/integration/VODE/vode_type_simplified_sdc.F90
@@ -273,7 +273,7 @@ contains
     real(rt), intent(inout) :: jac_react(neqs, neqs)
     real(rt)    :: jac(SVAR_EVOLVE,SVAR_EVOLVE)
 
-    integer :: m, n
+    integer :: m, n, k
 #if defined(SDC_EVOLVE_ENERGY)
     integer, parameter :: iwrho = 1, iwfs=2, iwK = iwfs+nspec, iwT = iwK+1, iwvar = 3+nspec
 #else
@@ -290,7 +290,7 @@ contains
     type(burn_t) :: burn_state_pert
     type(eos_t) :: eos_state
     type(eos_xderivs_t) :: eos_xderivs
-    real(rt) :: K
+    real(rt) :: kineng
     real(rt), parameter :: eps = 1.e-8_rt
     real(rt) :: ydot(neqs), ydot_pert(neqs)
 
@@ -418,7 +418,7 @@ contains
     ! construct dwdU
 
     ! kinetic energy, K = 1/2 |U|^2
-    K = 0.5_rt * sum(vode_state % rpar(irp_SMX:irp_SMZ)**2)/vode_state % rpar(irp_SRHO)**2
+    kineng = 0.5_rt * sum(vode_state % rpar(irp_SMX:irp_SMZ)**2)/vode_state % rpar(irp_SRHO)**2
 
     ! density row (iwrho)
     dwdU(iwrho, SRHO_EXTRA) = 1.0_rt
@@ -430,7 +430,7 @@ contains
     end do
 
     ! K row
-    dwdU(iwK, SRHO_EXTRA) = -K / burn_state % rho
+    dwdU(iwK, SRHO_EXTRA) = -kineng / burn_state % rho
     dwdU(iwK, SEINT) = -1.0_rt / burn_state % rho
     dwdU(iwK, SEDEN) = 1.0_rt / burn_state % rho
 


### PR DESCRIPTION
The bit at the end of this routine that did the actual Jacobian conversion used `k` as a loop index and this was actually being treated as the `K` that was used to measure kinetic energy (since Fortran is case insensitive).