### PR TITLE
VODE steps fail if the state is not valid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+# 20.08
+
+   * VODE can now reject an internal timestep that has any abundance
+     change by more than a factor of 2, or an abundance < 0 or > 1,
+     as well as timesteps where the temperature ends up negative. (#350)
+
 # 20.07
 
    * The "master" branch has been renamed "main" (#333)

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -147,6 +147,15 @@ int dvstep (burn_t& state, dvode_t& vstate)
         vstate.RC *= (vstate.RL1 / vstate.PRL1);
         vstate.PRL1 = vstate.RL1;
 
+        // Save the value of y before calling the solver.
+        // We will use this saved value to determine if any
+        // constraints were violated in the update.
+
+        Array1D<Real, 1, VODE_NEQS> y_save;
+        for (int i = 1; i <= VODE_NEQS; ++i) {
+            y_save(i) = vstate.y(i);
+        }
+
         // Call the nonlinear system solver.
 
         Real ACNRM = dvnlsd(pivot, NFLAG, state, vstate);
@@ -195,11 +204,43 @@ int dvstep (burn_t& state, dvode_t& vstate)
             continue;
         }
 
+        // We add to VODE some constraints. If these constraints are violated,
+        // we treat it the same way we will treat an error test failure (below).
+
+        bool valid_update = true;
+
+        if (vstate.y(net_itemp) < 0.0_rt) {
+            valid_update = false;
+        }
+
+        for (int i = 1; i <= NumSpec; ++i) {
+            // Constrain abundances such that they don't change by more than a certain
+            // factor in a given step (as long as their initial abundance was large enough
+            // for us to worry about).
+
+            if (std::abs(y_save(i)) >= vode_change_factor_X_threshold &&
+                (std::abs(vstate.y(i)) > vode_increase_change_factor * std::abs(y_save(i)) ||
+                 std::abs(vstate.y(i)) < vode_decrease_change_factor * std::abs(y_save(i)))) {
+                valid_update = false;
+            }
+
+            // Constrain abundances such that they are not negative (within a tolerance)
+            // or greater than one (within a tolerance).
+
+            if (vstate.y(i) < -vode_failure_tolerance) {
+                valid_update = false;
+            }
+
+            if (vstate.y(i) > 1.0_rt + vode_failure_tolerance) {
+                valid_update = false;
+            }
+        }
+
         // The corrector has converged (NFLAG = 0). The local error test is
         // made and control passes to statement 500 if it fails.
 
         DSM = ACNRM / vstate.tq(2);
-        if (DSM <= 1.0_rt) {
+        if (DSM <= 1.0_rt && valid_update) {
 
             // After a successful step, update the yh and TAU arrays and decrement
             // NQWAIT. If NQWAIT is then 1 and NQ .lt. MAXORD, then ACOR is saved
@@ -254,7 +295,8 @@ int dvstep (burn_t& state, dvode_t& vstate)
 
         }
 
-        // The error test failed. kflag keeps track of multiple failures.
+        // The error test failed (or our constraints on the species failed).
+        // kflag keeps track of multiple failures.
         // Restore tn and the yh array to their previous values, and prepare
         // to try the step again. Compute the optimum step size for the
         // same order. After repeated failures, H is forced to decrease

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -218,7 +218,7 @@ int dvstep (burn_t& state, dvode_t& vstate)
             // factor in a given step (as long as their initial abundance was large enough
             // for us to worry about).
 
-            if (std::abs(y_save(i)) >= vode_change_factor_X_threshold &&
+            if (std::abs(y_save(i)) >= atol_spec &&
                 (std::abs(vstate.y(i)) > vode_increase_change_factor * std::abs(y_save(i)) ||
                  std::abs(vstate.y(i)) < vode_decrease_change_factor * std::abs(y_save(i)))) {
                 valid_update = false;

--- a/integration/VODE/vode_integrator.H
+++ b/integration/VODE/vode_integrator.H
@@ -19,8 +19,6 @@ void vode_integrator (burn_t& state, Real dt)
 
     dvode_t vode_state;
 
-    const Real failure_tolerance = 1.e-2_rt;
-
     // Set the tolerances.  We will be more relaxed on the temperature
     // since it is only used in evaluating the rates.
     //
@@ -133,11 +131,11 @@ void vode_integrator (burn_t& state, Real dt)
     }
 
     for (int n = 1; n <= NumSpec; ++n) {
-        if (vode_state.y(n) < -failure_tolerance) {
+        if (vode_state.y(n) < -vode_failure_tolerance) {
             state.success = false;
         }
 
-        if (vode_state.y(n) > 1.e0_rt + failure_tolerance) {
+        if (vode_state.y(n) > 1.0_rt + vode_failure_tolerance) {
             state.success = false;
         }
     }

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -22,6 +22,18 @@ const amrex::Real CCMXJ = 0.2e0_rt;
 const amrex::Real HMIN = 0.0_rt;
 const amrex::Real HMXI = 0.0_rt;
 
+// We will use this parameter to determine if a given species abundance
+// is unreasonably small or large (each X must satisfy
+// -failure_tolerance <= X <= 1.0 + failure_tolerance).
+const Real vode_failure_tolerance = 1.e-2_rt;
+
+// For each species whose abundance is above a certain threshold, we do
+// not allow its mass fraction to change by more than a certain amount
+// in any integration step.
+const Real vode_increase_change_factor = 2.0_rt;
+const Real vode_decrease_change_factor = 0.5_rt;
+const Real vode_change_factor_X_threshold = 1.0e-6_rt;
+
 // For the backward differentiation formula (BDF) integration
 // the maximum order should be no greater than 5.
 const int VODE_MAXORD = 5;

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -32,7 +32,6 @@ const Real vode_failure_tolerance = 1.e-2_rt;
 // in any integration step.
 const Real vode_increase_change_factor = 2.0_rt;
 const Real vode_decrease_change_factor = 0.5_rt;
-const Real vode_change_factor_X_threshold = 1.0e-6_rt;
 
 // For the backward differentiation formula (BDF) integration
 // the maximum order should be no greater than 5.


### PR DESCRIPTION
Commit 9d3ddb13b8abf8953756ef6dc036ed569d27664b added intentional failure modes to the VODE integrator to prevent VODE from giving us a state where the integrator believed it was successful but the state was not physically valid. Specifically, we checked on T < 0 and X < -0.01 or X > 1.01. Although this gave us the opportunity to then retry the burn, retries are expensive and we'd like to avoid them if possible (#106). One way we can significantly mitigate this is by preventing these failure modes from occurring at the end of each step rather than only at the end of the burn. We can then rely on the integrator's built-in step retry mechanism (which decreases dt or changes the integration order).

I chose to use the same failure modes as the one at the end of the burn. Additionally, I added a failure mode if any X changes by more than a factor of 2. The abundance never changes that much in a single step in a typical burn, but I have witnessed some extreme cases where the abundance floors in a single integration step and VODE doesn't reject the update. (I am not sure why.)