### PR TITLE
get some of the scattered unit tests building again

### DIFF
--- a/Make.Microphysics
+++ b/Make.Microphysics
@@ -49,8 +49,8 @@ all: build_status $(executable) starkiller_library
 
 build_status:
 	$(AMREX_HOME)/Tools/C_scripts/describe_sources.py \
-          --git_names "Castro AMReX Microphysics" \
-          --git_dirs "$(TOP) $(AMREX_HOME) $(MICROPHYSICS_HOME)"
+          --git_names "Microphysics AMReX" \
+          --git_dirs "$(TOP) $(AMREX_HOME)"
 
 starkiller_library: $(executable)
 ifeq ($(USE_COMPILE_WITH_F2PY), TRUE)

--- a/networks/aprox13/test-cpp/GNUmakefile
+++ b/networks/aprox13/test-cpp/GNUmakefile
@@ -16,18 +16,14 @@ USE_REACT = TRUE
 # programs to be compiled
 ALL: testburn.ex table
 
-EOS_dir := helmholtz
+EOS_DIR := helmholtz
 
-Network_dir := aprox13
+NETWORK_DIR := aprox13
 
-INTEGRATOR_DIR := VBDF
+Bpack := ./Make.package
+Blocs := .
 
-f90EXE_sources += testburn.f90
-f90EXE_sources += testjacobian.f90
-
-BLOCS += .
-
-include $(CASTRO_DIR)/Exec/Make.Castro
+include $(MICROPHYSICS_HOME)/Make.Microphysics
 
 
 #my_objs = $(filter-out $(objEXETempDir)/main.o, $(objForExecs))

--- a/networks/aprox13/test-cpp/Make.package
+++ b/networks/aprox13/test-cpp/Make.package
@@ -1,0 +1,4 @@
+f90EXE_sources += testburn.f90
+f90EXE_sources += testjacobian.f90
+f90EXE_sources += do_initialization.f90
+CEXE_sources += main.cpp

--- a/networks/aprox13/test-cpp/do_initialization.f90
+++ b/networks/aprox13/test-cpp/do_initialization.f90
@@ -1,0 +1,20 @@
+subroutine do_initialization() bind(C)
+
+  use microphysics_module
+
+  implicit none
+
+  character (len=32) :: probin_file
+  integer :: probin_pass(32)
+  integer :: i
+
+  probin_file = "probin"
+  do i = 1, len(trim(probin_file))
+     probin_pass(i) = ichar(probin_file(i:i))
+  enddo
+
+  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
+
+  call microphysics_init()
+
+end subroutine do_initialization

--- a/networks/aprox13/test-cpp/main.cpp
+++ b/networks/aprox13/test-cpp/main.cpp
@@ -1,5 +1,3 @@
-#include <winstd.H>
-
 #include <new>
 #include <cstdio>
 #include <cstring>
@@ -10,33 +8,23 @@
 #include <unistd.h>
 #endif
 
-#include <CArena.H>
-#include <REAL.H>
-#include <Utility.H>
-#include <IntVect.H>
-#include <Box.H>
-#include <Amr.H>
-#include <ParmParse.H>
-#include <ParallelDescriptor.H>
-#include <AmrLevel.H>
+#include <AMReX_CArena.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Utility.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_Box.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_ParallelDescriptor.H>
 
 #include <time.h>
 
-#ifdef HAS_DUMPMODEL
-#include <DumpModel1d.H>
-#endif
-
-#ifdef HAS_XGRAPH
-#include <XGraph1d.H>
-#endif
-
-#include "Castro_io.H"
 
 
 extern "C"
 {
-   void do_burn();
    void test_jacobian();
+   void do_burn();
+   void do_initialization();
 }
 
 
@@ -50,7 +38,7 @@ main (int   argc,
     //
     // Make sure to catch new failures.
     //
-    BoxLib::Initialize(argc,argv);
+    amrex::Initialize(argc,argv);
 
     // save the inputs file name for later
     if (argc > 1) {
@@ -59,11 +47,13 @@ main (int   argc,
       }
     }
 
+    do_initialization();
+
     test_jacobian();
-    
+
     do_burn();
 
-    BoxLib::Finalize();
+    amrex::Finalize();
 
     return 0;
 }

--- a/networks/aprox13/test-cpp/testburn.f90
+++ b/networks/aprox13/test-cpp/testburn.f90
@@ -3,6 +3,7 @@ subroutine do_burn() bind (C)
   use network
   use actual_rhs_module, only: actual_rhs_init
   use eos_module
+  use eos_type_module
   use burner_module
   use actual_burner_module
 
@@ -15,22 +16,9 @@ subroutine do_burn() bind (C)
 
   type (eos_t) :: eos_state
 
-  character (len=32) :: probin_file
-  integer :: probin_pass(32)
   integer :: i
   real(rt)         :: start, finish
 
-  probin_file = "probin"
-  do i = 1, len(trim(probin_file))
-     probin_pass(i) = ichar(probin_file(i:i))
-  enddo
-
-  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
-
-  call network_init()
-  call actual_rhs_init()
-  call burner_init()
-  call eos_init()
 
   state_in % rho       = 19134047.319619529e0_rt
   state_in % T         = 2091535024.9521415e0_rt

--- a/networks/aprox13/test-cpp/testjacobian.f90
+++ b/networks/aprox13/test-cpp/testjacobian.f90
@@ -18,21 +18,7 @@ subroutine test_jacobian() bind(C)
 
   type (eos_t) :: eos_state
 
-  character (len=32) :: probin_file
-  integer :: probin_pass(32)
   integer :: i, j
-
-  probin_file = "probin"
-  do i = 1, len(trim(probin_file))
-     probin_pass(i) = ichar(probin_file(i:i))
-  enddo
-
-  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
-
-  call network_init()
-  call actual_rhs_init()
-  call burner_init()
-  call eos_init()
 
   state_ana % rho   = 2.0e7_rt
   state_ana % T     = 8.0e9_rt

--- a/networks/aprox19/test-cpp/GNUmakefile
+++ b/networks/aprox19/test-cpp/GNUmakefile
@@ -16,16 +16,14 @@ USE_REACT = TRUE
 # programs to be compiled
 ALL: testburn.ex table
 
-EOS_dir := helmholtz
+EOS_DIR := helmholtz
 
-Network_dir := aprox19
+NETWORK_DIR := aprox19
 
-f90EXE_sources += testburn.f90
-f90EXE_sources += testjacobian.f90
+Bpack := ./Make.package
+Blocs := .
 
-BLOCS += .
-
-include $(CASTRO_DIR)/Exec/Make.Castro
+include $(MICROPHYSICS_HOME)/Make.Microphysics
 
 
 #my_objs = $(filter-out $(objEXETempDir)/main.o, $(objForExecs))

--- a/networks/aprox19/test-cpp/Make.package
+++ b/networks/aprox19/test-cpp/Make.package
@@ -1,0 +1,4 @@
+f90EXE_sources += testburn.f90
+f90EXE_sources += testjacobian.f90
+f90EXE_sources += do_initialization.f90
+CEXE_sources += main.cpp

--- a/networks/aprox19/test-cpp/do_initialization.f90
+++ b/networks/aprox19/test-cpp/do_initialization.f90
@@ -1,0 +1,20 @@
+subroutine do_initialization() bind(C)
+
+  use microphysics_module
+
+  implicit none
+
+  character (len=32) :: probin_file
+  integer :: probin_pass(32)
+  integer :: i
+
+  probin_file = "probin"
+  do i = 1, len(trim(probin_file))
+     probin_pass(i) = ichar(probin_file(i:i))
+  enddo
+
+  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
+
+  call microphysics_init()
+
+end subroutine do_initialization

--- a/networks/aprox19/test-cpp/main.cpp
+++ b/networks/aprox19/test-cpp/main.cpp
@@ -1,5 +1,3 @@
-#include <winstd.H>
-
 #include <new>
 #include <cstdio>
 #include <cstring>
@@ -10,33 +8,23 @@
 #include <unistd.h>
 #endif
 
-#include <CArena.H>
-#include <REAL.H>
-#include <Utility.H>
-#include <IntVect.H>
-#include <Box.H>
-#include <Amr.H>
-#include <ParmParse.H>
-#include <ParallelDescriptor.H>
-#include <AmrLevel.H>
+#include <AMReX_CArena.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Utility.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_Box.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_ParallelDescriptor.H>
 
 #include <time.h>
 
-#ifdef HAS_DUMPMODEL
-#include <DumpModel1d.H>
-#endif
-
-#ifdef HAS_XGRAPH
-#include <XGraph1d.H>
-#endif
-
-#include "Castro_io.H"
 
 
 extern "C"
 {
    void test_jacobian();
    void do_burn();
+   void do_initialization();
 }
 
 
@@ -50,7 +38,7 @@ main (int   argc,
     //
     // Make sure to catch new failures.
     //
-    BoxLib::Initialize(argc,argv);
+    amrex::Initialize(argc,argv);
 
     // save the inputs file name for later
     if (argc > 1) {
@@ -59,11 +47,13 @@ main (int   argc,
       }
     }
 
+    do_initialization();
+
     test_jacobian();
 
     do_burn();
 
-    BoxLib::Finalize();
+    amrex::Finalize();
 
     return 0;
 }

--- a/networks/aprox19/test-cpp/testburn.f90
+++ b/networks/aprox19/test-cpp/testburn.f90
@@ -2,6 +2,7 @@ subroutine do_burn() bind (C)
 
   use network
   use eos_module
+  use eos_type_module
   use burner_module
   use actual_burner_module
 
@@ -13,21 +14,6 @@ subroutine do_burn() bind (C)
   real(rt)         :: time = 0.0_rt, dt = 1.0e-6_rt
 
   type (eos_t) :: eos_state
-
-  character (len=32) :: probin_file
-  integer :: probin_pass(32)
-  integer :: i
-
-  probin_file = "probin"
-  do i = 1, len(trim(probin_file))
-     probin_pass(i) = ichar(probin_file(i:i))
-  enddo
-
-  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
-
-  call network_init()
-  call burner_init()
-  call eos_init()
 
   state_in % rho    = 2.0e7_rt
   state_in % T      = 8.0e9_rt

--- a/networks/aprox21/test-cpp/GNUmakefile
+++ b/networks/aprox21/test-cpp/GNUmakefile
@@ -20,13 +20,10 @@ EOS_DIR := helmholtz
 
 NETWORK_DIR := aprox21
 
-f90EXE_sources += testburn.f90
-f90EXE_sources += testjacobian.f90
-f90EXE_sources += do_initialization.f90
+Bpack := ./Make.package
+Blocs := .
 
-BLOCS += .
-
-include $(CASTRO_HOME)/Exec/Make.Castro
+include $(MICROPHYSICS_HOME)/Make.Microphysics
 
 
 #my_objs = $(filter-out $(objEXETempDir)/main.o, $(objForExecs))

--- a/networks/aprox21/test-cpp/GNUmakefile
+++ b/networks/aprox21/test-cpp/GNUmakefile
@@ -16,16 +16,17 @@ USE_REACT = TRUE
 # programs to be compiled
 ALL: testburn.ex table
 
-EOS_dir := helmholtz
+EOS_DIR := helmholtz
 
-Network_dir := aprox21
+NETWORK_DIR := aprox21
 
 f90EXE_sources += testburn.f90
 f90EXE_sources += testjacobian.f90
+f90EXE_sources += do_initialization.f90
 
 BLOCS += .
 
-include $(CASTRO_DIR)/Exec/Make.Castro
+include $(CASTRO_HOME)/Exec/Make.Castro
 
 
 #my_objs = $(filter-out $(objEXETempDir)/main.o, $(objForExecs))

--- a/networks/aprox21/test-cpp/Make.package
+++ b/networks/aprox21/test-cpp/Make.package
@@ -1,0 +1,4 @@
+f90EXE_sources += testburn.f90
+f90EXE_sources += testjacobian.f90
+f90EXE_sources += do_initialization.f90
+CEXE_sources += main.cpp

--- a/networks/aprox21/test-cpp/do_initialization.f90
+++ b/networks/aprox21/test-cpp/do_initialization.f90
@@ -1,0 +1,20 @@
+subroutine do_initialization() bind(C)
+
+  use microphysics_module
+
+  implicit none
+
+  character (len=32) :: probin_file
+  integer :: probin_pass(32)
+  integer :: i
+
+  probin_file = "probin"
+  do i = 1, len(trim(probin_file))
+     probin_pass(i) = ichar(probin_file(i:i))
+  enddo
+
+  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
+
+  call microphysics_init()
+
+end subroutine do_initialization

--- a/networks/aprox21/test-cpp/main.cpp
+++ b/networks/aprox21/test-cpp/main.cpp
@@ -13,10 +13,8 @@
 #include <AMReX_Utility.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_Box.H>
-#include <AMReX_Amr.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_ParallelDescriptor.H>
-#include <AMReX_AmrLevel.H>
 
 #include <time.h>
 

--- a/networks/aprox21/test-cpp/main.cpp
+++ b/networks/aprox21/test-cpp/main.cpp
@@ -1,5 +1,3 @@
-#include <winstd.H>
-
 #include <new>
 #include <cstdio>
 #include <cstring>
@@ -10,33 +8,25 @@
 #include <unistd.h>
 #endif
 
-#include <CArena.H>
-#include <REAL.H>
-#include <Utility.H>
-#include <IntVect.H>
-#include <Box.H>
-#include <Amr.H>
-#include <ParmParse.H>
-#include <ParallelDescriptor.H>
-#include <AmrLevel.H>
+#include <AMReX_CArena.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Utility.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_Box.H>
+#include <AMReX_Amr.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_AmrLevel.H>
 
 #include <time.h>
 
-#ifdef HAS_DUMPMODEL
-#include <DumpModel1d.H>
-#endif
-
-#ifdef HAS_XGRAPH
-#include <XGraph1d.H>
-#endif
-
-#include "Castro_io.H"
 
 
 extern "C"
 {
    void test_jacobian();
    void do_burn();
+   void do_initialization();
 }
 
 
@@ -50,7 +40,7 @@ main (int   argc,
     //
     // Make sure to catch new failures.
     //
-    BoxLib::Initialize(argc,argv);
+    amrex::Initialize(argc,argv);
 
     // save the inputs file name for later
     if (argc > 1) {
@@ -59,11 +49,13 @@ main (int   argc,
       }
     }
 
+    do_initialization();
+
     test_jacobian();
 
     do_burn();
 
-    BoxLib::Finalize();
+    amrex::Finalize();
 
     return 0;
 }

--- a/networks/aprox21/test-cpp/testburn.f90
+++ b/networks/aprox21/test-cpp/testburn.f90
@@ -2,6 +2,7 @@ subroutine do_burn() bind (C)
 
   use network
   use eos_module
+  use eos_type_module
   use burner_module
   use burn_type_module
   use actual_burner_module
@@ -15,20 +16,8 @@ subroutine do_burn() bind (C)
 
   type (eos_t) :: eos_state
 
-  character (len=32) :: probin_file
-  integer :: probin_pass(32)
   integer :: i
 
-  probin_file = "probin"
-  do i = 1, len(trim(probin_file))
-     probin_pass(i) = ichar(probin_file(i:i))
-  enddo
-
-  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
-
-  call network_init()
-  call burner_init()
-  call eos_init()
 
   state_in % rho       = 1.4311401611205835e7_rt
   state_in % T         = 4.6993994016410122e9_rt

--- a/networks/iso7/Make.package
+++ b/networks/iso7/Make.package
@@ -2,18 +2,20 @@ F90EXE_sources += actual_network.F90
 F90EXE_sources += network_properties.F90
 CEXE_headers += network_properties.H
 
-CEXE_sources += actual_network_data.cpp
-CEXE_headers += actual_network.H
-
 ifeq ($(USE_REACT),TRUE)
 ifneq ($(USE_SIMPLIFIED_SDC), TRUE)
 F90EXE_sources += actual_burner.F90
 endif
 F90EXE_sources += actual_rhs.F90
 
+ifeq ($(USE_CXX_REACTIONS),TRUE)
+CEXE_sources += actual_network_data.cpp
+CEXE_headers += actual_network.H
+
 CEXE_sources += actual_rhs_data.cpp
 CEXE_headers += actual_rhs.H
 CEXE_headers += actual_linear_solver.H
+endif
 
 USE_RATES       = TRUE
 USE_SCREENING   = TRUE

--- a/networks/iso7/test-cpp/GNUmakefile
+++ b/networks/iso7/test-cpp/GNUmakefile
@@ -16,16 +16,14 @@ USE_REACT = TRUE
 # programs to be compiled
 ALL: testburn.ex table
 
-EOS_dir := helmholtz
+EOS_DIR := helmholtz
 
-Network_dir := iso7
+NETWORK_DIR := iso7
 
-f90EXE_sources += testburn.f90
-f90EXE_sources += testjacobian.f90
+Bpack := ./Make.package
+Blocs := .
 
-BLOCS += .
-
-include $(CASTRO_DIR)/Exec/Make.Castro
+include $(MICROPHYSICS_HOME)/Make.Microphysics
 
 
 #my_objs = $(filter-out $(objEXETempDir)/main.o, $(objForExecs))

--- a/networks/iso7/test-cpp/Make.package
+++ b/networks/iso7/test-cpp/Make.package
@@ -1,0 +1,4 @@
+f90EXE_sources += testburn.f90
+f90EXE_sources += testjacobian.f90
+f90EXE_sources += do_initialization.f90
+CEXE_sources += main.cpp

--- a/networks/iso7/test-cpp/do_initialization.f90
+++ b/networks/iso7/test-cpp/do_initialization.f90
@@ -1,0 +1,20 @@
+subroutine do_initialization() bind(C)
+
+  use microphysics_module
+
+  implicit none
+
+  character (len=32) :: probin_file
+  integer :: probin_pass(32)
+  integer :: i
+
+  probin_file = "probin"
+  do i = 1, len(trim(probin_file))
+     probin_pass(i) = ichar(probin_file(i:i))
+  enddo
+
+  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
+
+  call microphysics_init()
+
+end subroutine do_initialization

--- a/networks/iso7/test-cpp/main.cpp
+++ b/networks/iso7/test-cpp/main.cpp
@@ -1,5 +1,3 @@
-#include <winstd.H>
-
 #include <new>
 #include <cstdio>
 #include <cstring>
@@ -10,33 +8,23 @@
 #include <unistd.h>
 #endif
 
-#include <CArena.H>
-#include <REAL.H>
-#include <Utility.H>
-#include <IntVect.H>
-#include <Box.H>
-#include <Amr.H>
-#include <ParmParse.H>
-#include <ParallelDescriptor.H>
-#include <AmrLevel.H>
+#include <AMReX_CArena.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Utility.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_Box.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_ParallelDescriptor.H>
 
 #include <time.h>
 
-#ifdef HAS_DUMPMODEL
-#include <DumpModel1d.H>
-#endif
-
-#ifdef HAS_XGRAPH
-#include <XGraph1d.H>
-#endif
-
-#include "Castro_io.H"
 
 
 extern "C"
 {
    void test_jacobian();
    void do_burn();
+   void do_initialization();
 }
 
 
@@ -50,7 +38,7 @@ main (int   argc,
     //
     // Make sure to catch new failures.
     //
-    BoxLib::Initialize(argc,argv);
+    amrex::Initialize(argc,argv);
 
     // save the inputs file name for later
     if (argc > 1) {
@@ -59,11 +47,13 @@ main (int   argc,
       }
     }
 
+    do_initialization();
+
     test_jacobian();
 
     do_burn();
 
-    BoxLib::Finalize();
+    amrex::Finalize();
 
     return 0;
 }

--- a/networks/iso7/test-cpp/testburn.f90
+++ b/networks/iso7/test-cpp/testburn.f90
@@ -2,6 +2,7 @@ subroutine do_burn() bind (C)
 
   use network
   use eos_module
+  use eos_type_module
   use burner_module
   use burn_type_module
   use actual_burner_module
@@ -15,20 +16,7 @@ subroutine do_burn() bind (C)
 
   type (eos_t) :: eos_state
 
-  character (len=32) :: probin_file
-  integer :: probin_pass(32)
   integer :: i
-
-  probin_file = "probin"
-  do i = 1, len(trim(probin_file))
-     probin_pass(i) = ichar(probin_file(i:i))
-  enddo
-
-  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
-
-  call network_init()
-  call burner_init()
-  call eos_init()
 
   state_in % rho       = 1.4311401611205835e7_rt
   state_in % T         = 4.6993994016410122e9_rt

--- a/networks/iso7/test-cpp/testjacobian.f90
+++ b/networks/iso7/test-cpp/testjacobian.f90
@@ -9,127 +9,22 @@ subroutine test_jacobian() bind(C)
   use actual_burner_module
   use actual_rhs_module
   use burn_type_module
+  use numerical_jac_module
   
   use amrex_fort_module, only : rt => amrex_real
   implicit none
 
-  type (burn_t) :: state, statep, statem
+  type (burn_t) :: state_ana, state_num
 
   type (eos_t) :: eos_state
 
-  character (len=32) :: probin_file
-  integer :: probin_pass(32)
   integer :: i, j
 
-  real(rt)        , parameter :: delta = 1.e-6_rt
-  real(rt)        , parameter :: SMALL = 1.e-12_rt
-  real(rt)         :: num_jac
-
-  character(len=16) :: namei,namej  
+  state_ana % rho   = 2.0e7_rt
+  state_ana % T     = 8.0e9_rt
   
-  probin_file = "probin"
-  do i = 1, len(trim(probin_file))
-     probin_pass(i) = ichar(probin_file(i:i))
-  enddo
+  state_ana % xn(:) = ONE / nspec
 
-  call runtime_init(probin_pass(1:len(trim(probin_file))), len(trim(probin_file)))
-
-  call network_init()
-  call burner_init()
-  call eos_init()
-
-  ! Set up state
-
-  state % rho   = 2.0e7_rt
-  state % T     = 8.0e9_rt
-
-  state % xn(:) = ONE / nspec
-
-  call burn_to_eos(state, eos_state)
-  call normalize_abundances(eos_state)
-  call eos(eos_input_rt, eos_state)
-  call eos_to_burn(eos_state, state)
-
-  state % self_heat = .true.
-  
-  ! Evaluate the analytical Jacobian. Note that we
-  ! need to call f_rhs first because that will fill
-  ! the state with the rates that the Jacobian needs.
-
-  call actual_rhs(state)
-  call actual_jac(state)  
-  
-888 format(a,"-derivatives that don't match:")
-999 format(5x, "df(",a,")/dy(",a,")", g18.10, g18.10, g18.10)
-
-  ! Now evaluate a numerical estimate of the Jacobian
-  ! using the RHS.
-  
-  do j = 1, neqs
-
-     statep = state
-     statem = state
-
-     if (j <= nspec) then
-        statep % xn(j) = (ONE + delta) * state % xn(j)
-     else if (j == net_itemp) then
-        statep % T     = (ONE + delta) * state % T
-     else if (j == net_ienuc) then
-        statep % e     = (ONE + delta) * state % e
-     endif
-
-     call actual_rhs(statep)
-     
-     if (j <= nspec) then
-        statem % xn(j) = (ONE - delta) * state % xn(j)
-     else if (j == net_itemp) then
-        statem % T     = (ONE - delta) * state % T
-     else if (j == net_ienuc) then
-        statem % e     = (ONE - delta) * state % e
-     endif
-
-     call actual_rhs(statem)
-
-     if (j <= nspec) then
-        namej = short_spec_names(j)
-     else if (j==net_ienuc) then
-        namej = "e"
-     else if (j==net_itemp) then
-        namej = "T"
-     endif
-
-     write(*,888) trim(namej)
-
-     do i = 2, neqs
-
-        if (j <= nspec) then
-           num_jac = (statep % ydot(i) - statem % ydot(i))/(statep % xn(j) - statem % xn(j) + SMALL)
-        else if (j == net_itemp) then
-           num_jac = (statep % ydot(i) - statem % ydot(i))/(statep % T - statem % T + SMALL)
-        else if (j == net_ienuc) then
-           num_jac = (statep % ydot(i) - statem % ydot(i))/(statep % e - statem % e + SMALL)
-        endif
-
-        if (i <= nspec) then
-           namei = short_spec_names(i)
-        else if (i==net_ienuc) then
-           namei = "e"
-        else if (i==net_itemp) then
-           namei = "T"
-        endif
-
-        ! only dump the ones that don't match
-        if (num_jac /= state % jac(i,j)) then
-           if (num_jac /= ZERO) then
-              write (*,999) trim(namei), &
-                   trim(namej), num_jac, state % jac(i,j), (num_jac-state % jac(i,j))/num_jac
-           else
-              write (*,999) trim(namei), &
-                   trim(namej), num_jac, state % jac(i,j)
-           endif
-        endif
-
-     enddo
-  enddo  
+  call test_numerical_jac(state_ana)
   
 end subroutine test_jacobian


### PR DESCRIPTION
A lot of networks have a test-cpp/ subdirectory that just exercises the RHS for that network.  This gets some of these building again, and removes all the dependencies on Castro.