### PR TITLE
Warning fixes

### DIFF
--- a/interfaces/network.H
+++ b/interfaces/network.H
@@ -6,7 +6,9 @@
 
 void network_init();
 
-static int network_spec_index(const std::string name) {
+using namespace NucProperties;
+
+AMREX_INLINE int network_spec_index(const std::string name) {
   int idx = -1;
   for (int n = 0; n < NumSpec; n++) {
     if (name == spec_names_cxx[n]) {
@@ -18,7 +20,7 @@ static int network_spec_index(const std::string name) {
 }
 
 #if NAUX_NET > 0
-static int network_aux_index(const std::string name) {
+AMREX_INLINE int network_aux_index(const std::string name) {
   int idx = -1;
   for (int n = 0; n < NumAux; n++) {
     if (name == aux_names_cxx[n]) {

--- a/interfaces/network.H
+++ b/interfaces/network.H
@@ -6,8 +6,6 @@
 
 void network_init();
 
-using namespace NucProperties;
-
 AMREX_INLINE int network_spec_index(const std::string name) {
   int idx = -1;
   for (int n = 0; n < NumSpec; n++) {

--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -16,35 +16,38 @@ constexpr int NumAux = NAUX_NET;
 
 @@PROPERTIES@@
 
-static AMREX_GPU_MANAGED amrex::Real aion[NumSpec] = {
-   @@AION@@
-  };
+namespace NucProperties {
 
-static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpec] = {
-   @@AION_INV@@
-  };
+   const AMREX_GPU_MANAGED amrex::Real aion[NumSpec] = {
+      @@AION@@
+     };
 
-static AMREX_GPU_MANAGED amrex::Real zion[NumSpec] = {
-   @@ZION@@
-  };
+   static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpec] = {
+      @@AION_INV@@
+     };
 
-static const std::vector<std::string> short_spec_names_cxx = {
-   @@SHORT_SPEC_NAMES@@
-  };
+   static AMREX_GPU_MANAGED amrex::Real zion[NumSpec] = {
+      @@ZION@@
+     };
 
-static const std::vector<std::string> spec_names_cxx = {
-   @@SPEC_NAMES@@
-  };
+   static const std::vector<std::string> short_spec_names_cxx = {
+      @@SHORT_SPEC_NAMES@@
+     };
+
+   static const std::vector<std::string> spec_names_cxx = {
+      @@SPEC_NAMES@@
+     };
 
 #if NAUX_NET > 0
-static const std::vector<std::string> short_aux_names_cxx = {
-   @@SHORT_AUX_NAMES@@
-  };
+   static const std::vector<std::string> short_aux_names_cxx = {
+      @@SHORT_AUX_NAMES@@
+     };
 
-static const std::vector<std::string> aux_names_cxx = {
-   @@AUX_NAMES@@
-  };
+   static const std::vector<std::string> aux_names_cxx = {
+      @@AUX_NAMES@@
+     };
 #endif
+}
 
 namespace Species {
    enum NetworkSpecies {

--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -9,6 +9,12 @@
 #ifndef _network_properties_H_
 #define _network_properties_H_
 
+#if defined(__GNUC__)
+#define MICROPHYSICS_UNUSED [[gnu::unused]]
+#else
+#define MICROPHYSICS_UNUSED
+#endif
+
 constexpr int NumSpec = @@NSPEC@@;
 
 // filled via the preprocessor by including NAUX_NETWORK
@@ -16,38 +22,35 @@ constexpr int NumAux = NAUX_NET;
 
 @@PROPERTIES@@
 
-namespace NucProperties {
+static AMREX_GPU_MANAGED amrex::Real aion[NumSpec] MICROPHYSICS_UNUSED = {
+   @@AION@@
+  };
 
-   const AMREX_GPU_MANAGED amrex::Real aion[NumSpec] = {
-      @@AION@@
-     };
+static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpec] MICROPHYSICS_UNUSED = {
+   @@AION_INV@@
+  };
 
-   static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpec] = {
-      @@AION_INV@@
-     };
+static AMREX_GPU_MANAGED amrex::Real zion[NumSpec] MICROPHYSICS_UNUSED = {
+   @@ZION@@
+  };
 
-   static AMREX_GPU_MANAGED amrex::Real zion[NumSpec] = {
-      @@ZION@@
-     };
+static const std::vector<std::string> short_spec_names_cxx MICROPHYSICS_UNUSED = {
+   @@SHORT_SPEC_NAMES@@
+  };
 
-   static const std::vector<std::string> short_spec_names_cxx = {
-      @@SHORT_SPEC_NAMES@@
-     };
-
-   static const std::vector<std::string> spec_names_cxx = {
-      @@SPEC_NAMES@@
-     };
+static const std::vector<std::string> spec_names_cxx MICROPHYSICS_UNUSED = {
+   @@SPEC_NAMES@@
+  };
 
 #if NAUX_NET > 0
-   static const std::vector<std::string> short_aux_names_cxx = {
-      @@SHORT_AUX_NAMES@@
-     };
+static const std::vector<std::string> short_aux_names_cxx MICROPHYSICS_UNUSED = {
+   @@SHORT_AUX_NAMES@@
+  };
 
-   static const std::vector<std::string> aux_names_cxx = {
-      @@AUX_NAMES@@
-     };
+static const std::vector<std::string> aux_names_cxx MICROPHYSICS_UNUSED = {
+   @@AUX_NAMES@@
+  };
 #endif
-}
 
 namespace Species {
    enum NetworkSpecies {


### PR DESCRIPTION
The static variables in `network_properties.H` are warned as unused with GCC everywhere we include the header and don't use them all.  This uses the `[[gnu::unused]]` attribute to silence these warnings.