### PR TITLE
remove the burn_to_vode in jac() -- it appears unnecessary

### DIFF
--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -136,8 +136,6 @@ void jac (burn_t& state, dvode_t& vode_state, MatrixType& pd)
         }
     }
 
-    burn_to_vode(state, vode_state);
-
 }
 
 #endif


### PR DESCRIPTION
closes #364 