### PR TITLE
create a routine to call any of the EOSes with a single thermodynamics state

### DIFF
--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -72,9 +72,11 @@ std::ostream& operator<< (std::ostream& o, burn_t const& burn_state)
   }
   o << std::endl;
 #if NAUX_NET > 0
+  o << "aux = ";
   for (int n = 0; n < NumAux; ++n) {
-    burn_state.aux[n] << " " << std::endl;
+    o << burn_state.aux[n] << " ";
   }
+  o << std::endl;
 #endif
   return o;
 }

--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -53,6 +53,67 @@ struct eos_t {
 
 };
 
+inline
+std::ostream& operator<< (std::ostream& o, eos_t const& eos_state)
+{
+  o << "rho = " << eos_state.rho << std::endl;
+  o << "T =   " << eos_state.T << std::endl;
+  o << "xn = ";
+  for (int n = 0; n < NumSpec; ++n) {
+    o << eos_state.xn[n] << " ";
+  }
+  o << std::endl;
+#if NAUX_NET > 0
+  o << "aux = ";
+  for (int n = 0; n < NumAux; ++n) {
+    o << eos_state.aux[n] << " ";
+  }
+  o << std::endl;
+#endif
+  o << "p = " << eos_state.p << std::endl;
+  o << "e = " << eos_state.e << std::endl;
+  o << "h = " << eos_state.h << std::endl;
+  o << "s = " << eos_state.s << std::endl;
+
+  o << "dpdT = " << eos_state.dpdT << std::endl;
+  o << "dpdr = " << eos_state.dpdr << std::endl;
+  o << "dedT = " << eos_state.dedT << std::endl;
+  o << "dedr = " << eos_state.dedr << std::endl;
+  o << "dhdT = " << eos_state.dhdT << std::endl;
+  o << "dhdr = " << eos_state.dhdr << std::endl;
+  o << "dsdT = " << eos_state.dsdT << std::endl;
+  o << "dsdr = " << eos_state.dsdr << std::endl;
+  o << "dpde = " << eos_state.dpde << std::endl;
+  o << "dpdr_e = " << eos_state.dpdr_e  << std::endl;
+
+  o << "cv = " << eos_state.cv << std::endl;
+  o << "cp = " << eos_state.cp << std::endl;
+  o << "xne = " << eos_state.xne << std::endl;
+  o << "xnp = " << eos_state.xnp << std::endl;
+  o << "eta = " << eos_state.eta << std::endl;
+  o << "pele = " << eos_state.pele << std::endl;
+  o << "ppos = " << eos_state.ppos << std::endl;
+  o << "mu = " << eos_state.mu << std::endl;
+  o << "mu_e = " << eos_state.mu_e << std::endl;
+  o << "y_e = " << eos_state.y_e << std::endl;
+  o << "gam1 = " << eos_state.gam1 << std::endl;
+  o << "cs = " << eos_state.cs << std::endl;
+
+  o << "abar = " << eos_state.abar << std::endl;
+  o << "zbar = " << eos_state.zbar << std::endl;
+
+#ifdef EXTRA_THERMO
+  o << "dpdA = " << eos_state.dpdA << std::endl;
+  o << "dpdZ = " << eos_state.dpdZ << std::endl;
+  o << "dedA = " << eos_state.dedA << std::endl;
+  o << "dedZ = " << eos_state.dedZ << std::endl;
+#endif
+
+  o << "conductivity = " << eos_state.conductivity << std::endl;
+
+  return o;
+}
+
 enum eos_input_t {eos_input_rt = 0,
                   eos_input_rh,
                   eos_input_tp,

--- a/unit_test/eos_cell/GNUmakefile
+++ b/unit_test/eos_cell/GNUmakefile
@@ -1,0 +1,50 @@
+PRECISION  = DOUBLE
+PROFILE    = FALSE
+
+DEBUG      = FALSE
+
+DIM        = 3
+
+COMP	   = gnu
+
+USE_MPI    = FALSE
+USE_OMP    = FALSE
+
+USE_REACT = TRUE
+
+EBASE = main
+
+USE_CXX_EOS = TRUE
+
+USE_CXX_REACTIONS ?= TRUE
+
+ifeq ($(USE_CXX_REACTIONS),TRUE)
+  DEFINES += -DCXX_REACTIONS
+endif
+
+# define the location of the CASTRO top directory
+MICROPHYSICS_HOME  := ../..
+
+# This sets the EOS directory in Castro/EOS -- note: gamma_law will not work,
+# you'll need to use gamma_law_general
+EOS_DIR     := helmholtz
+
+# This sets the network directory in Castro/Networks
+NETWORK_DIR := aprox13
+
+CONDUCTIVITY_DIR := stellar
+
+INTEGRATOR_DIR =  VODE
+
+ifeq ($(USE_CUDA), TRUE)
+  INTEGRATOR_DIR := VODE
+endif
+
+EXTERN_SEARCH += .
+
+Bpack   := ./Make.package
+Blocs   := .
+
+include $(MICROPHYSICS_HOME)/Make.Microphysics
+
+

--- a/unit_test/eos_cell/Make.package
+++ b/unit_test/eos_cell/Make.package
@@ -1,0 +1,4 @@
+CEXE_sources += main.cpp
+CEXE_headers += eos_cell.H
+F90EXE_sources += unit_test.F90
+F90EXE_headers += eos_cell_F.H

--- a/unit_test/eos_cell/_parameters
+++ b/unit_test/eos_cell/_parameters
@@ -1,0 +1,30 @@
+small_temp    real       1.e5
+small_dens    real       1.e5
+
+density       real       1.d7
+temperature   real       3.d9
+
+X1            real       1.0d0
+X2            real       0.0d0
+X3            real       0.0d0
+X4            real       0.0d0
+X5            real       0.0d0
+X6            real       0.0d0
+X7            real       0.0d0
+X8            real       0.0d0
+X9            real       0.0d0
+X10           real       0.0d0
+X11           real       0.0d0
+X12           real       0.0d0
+X13           real       0.0d0
+X14           real       0.0d0
+X15           real       0.0d0
+X16           real       0.0d0
+X17           real       0.0d0
+X18           real       0.0d0
+X19           real       0.0d0
+X20           real       0.0d0
+X21           real       0.0d0
+
+
+

--- a/unit_test/eos_cell/eos_cell.H
+++ b/unit_test/eos_cell/eos_cell.H
@@ -1,0 +1,116 @@
+
+#include <extern_parameters.H>
+#include <eos.H>
+#include <network.H>
+#include <fstream>
+#include <iostream>
+
+void eos_cell_c()
+{
+
+    eos_t state;
+
+    // Set mass fractions to sanitize inputs for them
+    Real massfractions[NumSpec];
+    for (int n = 0; n < NumSpec; ++n) {
+        massfractions[n] = -1.0e0_rt;
+    }
+
+    // Make sure user set all the mass fractions to values in the interval [0, 1]
+    for (int n = 1; n <= NumSpec; ++n) {
+        switch (n) {
+
+        case 1:
+            massfractions[n-1] = X1;
+            break;
+        case 2:
+            massfractions[n-1] = X2;
+            break;
+        case 3:
+            massfractions[n-1] = X3;
+            break;
+        case 4:
+            massfractions[n-1] = X4;
+            break;
+        case 5:
+            massfractions[n-1] = X5;
+            break;
+        case 6:
+            massfractions[n-1] = X6;
+            break;
+        case 7:
+            massfractions[n-1] = X7;
+            break;
+        case 8:
+            massfractions[n-1] = X8;
+            break;
+        case 9:
+            massfractions[n-1] = X9;
+            break;
+        case 10:
+            massfractions[n-1] = X10;
+            break;
+        case 11:
+            massfractions[n-1] = X11;
+            break;
+        case 12:
+            massfractions[n-1] = X12;
+            break;
+        case 13:
+            massfractions[n-1] = X13;
+            break;
+        case 14:
+            massfractions[n-1] = X14;
+            break;
+        case 15:
+            massfractions[n-1] = X15;
+            break;
+        case 16:
+            massfractions[n-1] = X16;
+            break;
+        case 17:
+            massfractions[n-1] = X17;
+            break;
+        case 18:
+            massfractions[n-1] = X18;
+            break;
+        case 19:
+            massfractions[n-1] = X19;
+            break;
+        case 20:
+            massfractions[n-1] = X20;
+            break;
+        case 21:
+            massfractions[n-1] = X21;
+            break;
+
+        }
+
+        if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
+            amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");
+        }
+
+    }
+
+    std::cout << "State Density (g/cm^3): " << density << std::endl;
+    std::cout << "State Temperature (K): " << temperature << std::endl;
+    for (int n = 0; n < NumSpec; ++n) {
+        std::cout << "Mass Fraction (" << short_spec_names_cxx[n] << "): " << massfractions[n] << std::endl;
+    }
+
+    state.T   = temperature;
+    state.rho = density;
+    for (int n = 0; n < NumSpec; ++n) {
+        state.xn[n] = massfractions[n];
+    }
+
+    // Initialize initial energy to zero
+    state.e = 0.0_rt;
+    Real energy = 0.0_rt;
+
+    Real time = 0.0_rt;
+
+    // call the EOS to set initial e
+    eos(eos_input_rt, state);
+
+}

--- a/unit_test/eos_cell/eos_cell.H
+++ b/unit_test/eos_cell/eos_cell.H
@@ -92,25 +92,14 @@ void eos_cell_c()
 
     }
 
-    std::cout << "State Density (g/cm^3): " << density << std::endl;
-    std::cout << "State Temperature (K): " << temperature << std::endl;
-    for (int n = 0; n < NumSpec; ++n) {
-        std::cout << "Mass Fraction (" << short_spec_names_cxx[n] << "): " << massfractions[n] << std::endl;
-    }
-
     state.T   = temperature;
     state.rho = density;
     for (int n = 0; n < NumSpec; ++n) {
         state.xn[n] = massfractions[n];
     }
 
-    // Initialize initial energy to zero
-    state.e = 0.0_rt;
-    Real energy = 0.0_rt;
-
-    Real time = 0.0_rt;
-
-    // call the EOS to set initial e
     eos(eos_input_rt, state);
+
+    std::cout << state;
 
 }

--- a/unit_test/eos_cell/eos_cell_F.H
+++ b/unit_test/eos_cell/eos_cell_F.H
@@ -1,0 +1,18 @@
+#ifndef EOS_CELL_F_H_
+#define EOS_CELL_F_H
+
+#include <AMReX_BLFort.H>
+
+#ifdef __cplusplus
+#include <AMReX.H>
+extern "C"
+{
+#endif
+
+void init_unit_test(const int* name, const int* namlen);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/unit_test/eos_cell/inputs_eos
+++ b/unit_test/eos_cell/inputs_eos
@@ -1,0 +1,2 @@
+
+amr.probin_file = probin_triple

--- a/unit_test/eos_cell/inputs_eos
+++ b/unit_test/eos_cell/inputs_eos
@@ -1,2 +1,2 @@
 
-amr.probin_file = probin_triple
+amr.probin_file = probin

--- a/unit_test/eos_cell/main.cpp
+++ b/unit_test/eos_cell/main.cpp
@@ -1,0 +1,49 @@
+#include <iostream>
+#include <cstring>
+#include <vector>
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFab.H>
+using namespace amrex;
+
+#include <extern_parameters.H>
+#include <eos.H>
+#include <network.H>
+#include "eos_cell.H"
+#include "eos_cell_F.H"
+
+int main(int argc, char *argv[]) {
+
+  amrex::Initialize(argc, argv);
+
+  std::cout << "calling the EOS on a single zone state..." << std::endl;
+
+  ParmParse ppa("amr");
+
+  std::string probin_file = "probin";
+
+  ppa.query("probin_file", probin_file);
+
+  std::cout << "probin = " << probin_file << std::endl;
+
+  const int probin_file_length = probin_file.length();
+  Vector<int> probin_file_name(probin_file_length);
+
+  for (int i = 0; i < probin_file_length; i++)
+    probin_file_name[i] = probin_file[i];
+
+  init_unit_test(probin_file_name.dataPtr(), &probin_file_length);
+
+  // Copy extern parameters from Fortran to C++
+  init_extern_parameters();
+
+  // C++ EOS initialization (must be done after Fortran eos_init and init_extern_parameters)
+  eos_init();
+
+  // C++ Network, RHS, screening, rates initialization
+  network_init();
+
+  eos_cell_c();
+
+  amrex::Finalize();
+}

--- a/unit_test/eos_cell/probin
+++ b/unit_test/eos_cell/probin
@@ -1,0 +1,34 @@
+&extern
+  
+  run_prefix = "react_triple_"
+
+  small_temp = 1d5
+  small_dens = 1d5
+
+  burner_verbose = .false.
+
+  ! Set which jacobian to use
+  ! 1 = analytic jacobian 
+  ! 2 = numerical jacobian
+  jacobian   = 2
+
+  renormalize_abundances = F
+
+  rtol_spec = 1.0d-6
+  rtol_enuc = 1.0d-6
+  rtol_temp = 1.0d-6
+  atol_spec = 1.0d-6
+  atol_enuc = 1.0d-6
+  atol_temp = 1.0d-6
+
+  tmax    = 1.0d-6
+
+  density      = 1.d6
+  temperature  = 1.d9
+
+  X1 = 1.0d0
+  X2 = 0.0d0
+  X3 = 0.0d0
+  x4 = 0.0d0
+
+/

--- a/unit_test/eos_cell/probin
+++ b/unit_test/eos_cell/probin
@@ -1,27 +1,6 @@
 &extern
-  
-  run_prefix = "react_triple_"
-
   small_temp = 1d5
   small_dens = 1d5
-
-  burner_verbose = .false.
-
-  ! Set which jacobian to use
-  ! 1 = analytic jacobian 
-  ! 2 = numerical jacobian
-  jacobian   = 2
-
-  renormalize_abundances = F
-
-  rtol_spec = 1.0d-6
-  rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
-  atol_spec = 1.0d-6
-  atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
-
-  tmax    = 1.0d-6
 
   density      = 1.d6
   temperature  = 1.d9

--- a/unit_test/eos_cell/unit_test.F90
+++ b/unit_test/eos_cell/unit_test.F90
@@ -1,0 +1,16 @@
+subroutine init_unit_test(name, namlen) bind(C, name="init_unit_test")
+
+  use amrex_fort_module, only: rt => amrex_real
+  use extern_probin_module
+  use microphysics_module
+
+  implicit none
+
+  integer, intent(in) :: namlen
+  integer, intent(in) :: name(namlen)
+
+  call runtime_init(name, namlen)
+
+  call microphysics_init(small_temp, small_dens)
+
+end subroutine init_unit_test


### PR DESCRIPTION
This adds the eos_cell unit test which simply calls the (C++) EOS on a single zone and outputs the information.  To do the output, this creates a << operator for an eos_t.  We also fix a bug in the burn_t << for aux data.

closes #174 