### PR TITLE
Remove attributes(device) from cuVODE

### DIFF
--- a/integration/VODE/cuVODE/source/cuvode.F90
+++ b/integration/VODE/cuVODE/source/cuvode.F90
@@ -5,9 +5,6 @@ module cuvode_module
   use vode_rpar_indices
   use amrex_fort_module, only: rt => amrex_real
   use linpack_module
-#ifdef AMREX_USE_CUDA
-  use cudafor
-#endif
   use cuvode_dvhin_module
   use cuvode_dvstep_module
   
@@ -17,9 +14,6 @@ module cuvode_module
   
 contains
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine dvode(vstate)
 
     !$acc routine seq

--- a/integration/VODE/cuVODE/source/cuvode_dvhin.F90
+++ b/integration/VODE/cuVODE/source/cuvode_dvhin.F90
@@ -8,9 +8,6 @@ module cuvode_dvhin_module
 
 contains
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine dvhin(vstate, H0, NITER, IER)
   
     !$acc routine seq

--- a/integration/VODE/cuVODE/source/cuvode_dvjac.F90
+++ b/integration/VODE/cuVODE/source/cuvode_dvjac.F90
@@ -10,9 +10,6 @@ module cuvode_dvjac_module
 
 contains
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine dvjac(pivot, IERPJ, vstate)
 
     !$acc routine seq

--- a/integration/VODE/cuVODE/source/cuvode_dvjust.F90
+++ b/integration/VODE/cuVODE/source/cuvode_dvjust.F90
@@ -8,9 +8,6 @@ module cuvode_dvjust_module
 
 contains
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine dvjust(IORD, vstate)
 
     !$acc routine seq

--- a/integration/VODE/cuVODE/source/cuvode_dvnlsd.F90
+++ b/integration/VODE/cuVODE/source/cuvode_dvnlsd.F90
@@ -10,9 +10,6 @@ module cuvode_dvnlsd_module
 
 contains
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine dvnlsd(pivot, NFLAG, vstate)
 
     !$acc routine seq

--- a/integration/VODE/cuVODE/source/cuvode_dvset.F90
+++ b/integration/VODE/cuVODE/source/cuvode_dvset.F90
@@ -7,9 +7,6 @@ module cuvode_dvset_module
 
 contains
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine dvset(vstate)
 
     !$acc routine seq

--- a/integration/VODE/cuVODE/source/cuvode_dvstep.F90
+++ b/integration/VODE/cuVODE/source/cuvode_dvstep.F90
@@ -11,9 +11,6 @@ module cuvode_dvstep_module
 
 contains
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine advance_nordsieck(vstate)
 
     ! Effectively multiplies the Nordsieck history
@@ -40,9 +37,6 @@ contains
   end subroutine advance_nordsieck
 
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine retract_nordsieck(vstate)
 
     ! Undoes the Pascal triangle matrix multiplication
@@ -69,9 +63,6 @@ contains
   end subroutine retract_nordsieck
 
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine dvstep(pivot, vstate)
 
     !$acc routine seq

--- a/integration/VODE/cuVODE/source/linpack_module.F90
+++ b/integration/VODE/cuVODE/source/linpack_module.F90
@@ -7,9 +7,6 @@ module linpack_module
 
 contains
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif  
   subroutine dgesl(a, ipvt, b)
 
     implicit none
@@ -49,9 +46,6 @@ contains
 
   end subroutine dgesl
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   subroutine dgefa (a, ipvt, info)
 
     real(rt), intent(inout) :: a(VODE_NEQS, VODE_NEQS)
@@ -121,9 +115,6 @@ contains
 
   end subroutine dgefa
 
-#if defined(AMREX_USE_CUDA) && !defined(AMREX_USE_GPU_PRAGMA)
-  attributes(device) &
-#endif
   function idamax(N, x) result(index)
 
     implicit none


### PR DESCRIPTION
This was added to support Nyx which was not using USE_GPU_PRAGMA, but Nyx no longer needs it, so we can remove it.