### PR TITLE
Guard against pulling in actual_network

### DIFF
--- a/interfaces/network_initialization.cpp
+++ b/interfaces/network_initialization.cpp
@@ -1,12 +1,12 @@
-#include <actual_network.H>
 #ifdef REACTIONS
+#include <actual_network.H>
 #include <actual_rhs.H>
 #endif
 
 void network_init()
 {
-    actual_network_init();
 #ifdef REACTIONS
+    actual_network_init();
     actual_rhs_init();
 #endif
 }


### PR DESCRIPTION
We pull in this file if USE_CXX_REACTIONS = TRUE, but if that is set without USE_REACT = TRUE, we will attempt to pull in actual_network.H, which only exists for some networks.