### PR TITLE
Add interface for C++ integrator to use Fortran RHS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
    * An interface has been added for C++ integrators to call the RHS
      from a network that only has a Fortran implementation. This allows
-     the use USE_CXX_REACTIONS = TRUE for any network (however, CUDA is
-     not currently supported for this case). (#419)
+     the use of USE_CXX_REACTIONS = TRUE for any network (however, CUDA
+     is not currently supported for this case). (#419)
 
 # 20.11
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 20.12
+
+   * An interface has been added for C++ integrators to call the RHS
+     from a network that only has a Fortran implementation. This allows
+     the use USE_CXX_REACTIONS = TRUE for any network (however, CUDA is
+     not currently supported for this case). (#419)
+
 # 20.11
 
    * The aprox19 + NSE network was ported to C++ (#362)

--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -2,8 +2,12 @@
 #define _vode_rhs_H_
 
 #include <network.H>
+#ifdef NETWORK_HAS_CXX_IMPLEMENTATION
 #include <actual_network.H>
 #include <actual_rhs.H>
+#else
+#include <fortran_to_cxx_actual_rhs.H>
+#endif
 #include <burn_type.H>
 #include <extern_parameters.H>
 #include <vode_type.H>

--- a/integration/VODE/vode_rhs_simplified_sdc.H
+++ b/integration/VODE/vode_rhs_simplified_sdc.H
@@ -2,12 +2,17 @@
 #define VODE_RHS_SIMPLIFIED_SDC_H
 
 #include <network.H>
-#include <actual_network.H>
-#include <actual_rhs.H>
 #include <burn_type.H>
 #include <extern_parameters.H>
 
 #include <vode_type_simplified_sdc.H>
+
+#ifdef NETWORK_HAS_CXX_IMPLEMENTATION
+#include <actual_network.H>
+#include <actual_rhs.H>
+#else
+#include <fortran_to_cxx_actual_rhs.H>
+#endif
 
 // The f_rhs routine provides the right-hand-side for the DVODE solver.
 // This is a generic interface that calls the specific RHS routine in the

--- a/integration/VODE/vode_type_simplified_sdc.H
+++ b/integration/VODE/vode_type_simplified_sdc.H
@@ -4,7 +4,11 @@
 #include <eos.H>
 #include <eos_composition.H>
 #include <burn_type.H>
+#ifdef NETWORK_HAS_CXX_IMPLEMENTATION
 #include <actual_rhs.H>
+#else
+#include <fortran_to_cxx_actual_rhs.H>
+#endif
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void fill_unevolved_variables(const Real time, burn_t& state, dvode_t& vode_state)

--- a/interfaces/Make.package
+++ b/interfaces/Make.package
@@ -21,6 +21,8 @@ endif
 CEXE_headers += network.H
 ifeq ($(USE_CXX_REACTIONS),TRUE)
 CEXE_sources += network_initialization.cpp
+CEXE_headers += fortran_to_cxx_actual_rhs.H
+F90EXE_sources += fortran_to_cxx_actual_rhs.F90
 endif
 
 ifeq ($(USE_CONDUCTIVITY), TRUE)

--- a/interfaces/fortran_to_cxx_actual_rhs.F90
+++ b/interfaces/fortran_to_cxx_actual_rhs.F90
@@ -1,0 +1,127 @@
+module fortran_to_cxx_actual_rhs_module
+
+  use amrex_fort_module, only: rt => amrex_real
+  use network, only: nspec, naux
+  use burn_type_module, only: burn_t, neqs
+
+  implicit none
+
+contains
+
+  subroutine fortran_to_cxx_actual_rhs(rho, T, e, xn, abar, zbar, y_e, eta, &
+#if NAUX_NET > 0
+                                       aux, &
+#endif
+#ifndef SIMPLIFIED_SDC
+                                       cv, cp, T_old, dcvdT, dcpdT, self_heat, &
+#endif
+                                       ydot) bind(C, name='fortran_to_cxx_actual_rhs')
+
+    use actual_rhs_module, only: actual_rhs
+
+    implicit none
+
+    real(rt), intent(in), value :: rho, T, e, abar, zbar, y_e, eta
+    real(rt), intent(in) :: xn(nspec)
+#if NAUX_NET > 0
+    real(rt), intent(in) :: aux(naux)
+#endif
+#ifndef SIMPLIFIED_SDC
+    real(rt), intent(in), value :: cv, cp, T_old, dcvdT, dcpdT
+    integer, intent(in), value :: self_heat
+#endif
+    real(rt), intent(inout) :: ydot(neqs)
+
+    type (burn_t) :: state
+
+    state % rho = rho
+    state % T = T
+    state % e = e
+    state % abar = abar
+    state % zbar = zbar
+    state % y_e = y_e
+    state % eta = eta
+    state % xn(:) = xn(:)
+#if NAUX_NET > 0
+    state % aux(:) = aux(:)
+#endif
+
+#ifndef SIMPLIFIED_SDC
+    state % cv = cv
+    state % cp = cp
+
+    if (self_heat == 1) then
+       state % self_heat = .true.
+    else
+       state % self_heat = .false.
+    end if
+
+    state % T_old = T_old
+    state % dcvdT = dcvdT
+    state % dcpdT = dcpdT
+#endif
+
+    call actual_rhs(state, ydot)
+
+  end subroutine fortran_to_cxx_actual_rhs
+
+
+
+  subroutine fortran_to_cxx_actual_jac(rho, T, e, xn, abar, zbar, y_e, eta, &
+#if NAUX_NET > 0
+                                       aux, &
+#endif
+#ifndef SIMPLIFIED_SDC
+                                       cv, cp, T_old, dcvdT, dcpdT, self_heat, &
+#endif
+                                       jac) bind(C, name='fortran_to_cxx_actual_jac')
+
+    use actual_rhs_module, only: actual_jac
+
+    implicit none
+
+    real(rt), intent(in), value :: rho, T, e, abar, zbar, y_e, eta
+    real(rt), intent(in) :: xn(nspec)
+#if NAUX_NET > 0
+    real(rt), intent(in) :: aux(naux)
+#endif
+#ifndef SIMPLIFIED_SDC
+    real(rt), intent(in), value :: cv, cp, T_old, dcvdT, dcpdT
+    integer, intent(in), value :: self_heat
+#endif
+    real(rt), intent(inout) :: jac(neqs, neqs)
+
+    type (burn_t) :: state
+
+    state % rho = rho
+    state % T = T
+    state % e = e
+    state % abar = abar
+    state % zbar = zbar
+    state % y_e = y_e
+    state % eta = eta
+    state % xn(:) = xn(:)
+#if NAUX_NET > 0
+    state % aux(:) = aux(:)
+#endif
+
+#ifndef SIMPLIFIED_SDC
+    state % cv = cv
+    state % cp = cp
+
+    if (self_heat == 1) then
+       state % self_heat = .true.
+    else
+       state % self_heat = .false.
+    end if
+
+    state % T_old = T_old
+    state % dcvdT = dcvdT
+    state % dcpdT = dcpdT
+#endif
+
+    call actual_jac(state, jac)
+
+  end subroutine fortran_to_cxx_actual_jac
+
+end module fortran_to_cxx_actual_rhs_module

--- a/interfaces/fortran_to_cxx_actual_rhs.H
+++ b/interfaces/fortran_to_cxx_actual_rhs.H
@@ -1,0 +1,76 @@
+#ifndef FORTRAN_TO_CXX_ACTUAL_RHS_H
+#define FORTRAN_TO_CXX_ACTUAL_RHS_H
+
+#ifndef NETWORK_HAS_CXX_IMPLEMENTATION
+
+#include <network.H>
+#include <burn_type.H>
+
+extern "C" void
+fortran_to_cxx_actual_rhs(Real rho, Real T, Real e, const Real* xn,
+                          Real abar, Real zbar, Real y_e, Real eta,
+#if NAUX_NET > 0
+                          const Real* aux,
+#endif
+#ifndef SIMPLIFIED_SDC
+                          Real cv, Real cp, int self_heat,
+                          Real T_old, Real dcvdT, Real dcpdT,
+#endif
+                          Real* const ydot);
+
+extern "C" void
+fortran_to_cxx_actual_jac(Real rho, Real T, Real e, const Real* xn,
+                          Real abar, Real zbar, Real y_e, Real eta,
+#if NAUX_NET > 0
+                          const Real* aux,
+#endif
+#ifndef SIMPLIFIED_SDC
+                          Real cv, Real cp, int self_heat,
+                          Real T_old, Real dcvdT, Real dcpdT,
+#endif
+                          Real* const jac);
+
+void
+AMREX_FORCE_INLINE
+actual_rhs(burn_t& state, Array1D<Real, 1, neqs>& ydot)
+{
+#ifndef SIMPLIFIED_SDC
+    int self_heat = state.self_heat ? 1 : 0;
+#endif
+
+    fortran_to_cxx_actual_rhs(state.rho, state.T, state.e, state.xn,
+                              state.abar, state.zbar, state.y_e, state.eta,
+#if NAUX_NET > 0
+                              state.aux,
+#endif
+#ifndef SIMPLIFIED_SDC
+                              state.cv, state.cp, self_heat,
+                              state.T_old, state.dcvdT, state.dcpdT,
+#endif
+                              &ydot(1));
+}
+
+template<class MatrixType>
+void
+AMREX_FORCE_INLINE
+actual_jac(burn_t& state, MatrixType& jac)
+{
+#ifndef SIMPLIFIED_SDC
+    int self_heat = state.self_heat ? 1 : 0;
+#endif
+
+    fortran_to_cxx_actual_jac(state.rho, state.T, state.e, state.xn,
+                              state.abar, state.zbar, state.y_e, state.eta,
+#if NAUX_NET > 0
+                              state.aux,
+#endif
+#ifndef SIMPLIFIED_SDC
+                              state.cv, state.cp, self_heat,
+                              state.T_old, state.dcvdT, state.dcpdT,
+#endif
+                              &jac(1,1));
+}
+
+#endif
+
+#endif

--- a/interfaces/network_initialization.cpp
+++ b/interfaces/network_initialization.cpp
@@ -1,12 +1,16 @@
 #ifdef REACTIONS
+#ifdef NETWORK_HAS_CXX_IMPLEMENTATION
 #include <actual_network.H>
 #include <actual_rhs.H>
+#endif
 #endif
 
 void network_init()
 {
 #ifdef REACTIONS
+#ifdef NETWORK_HAS_CXX_IMPLEMENTATION
     actual_network_init();
     actual_rhs_init();
+#endif
 #endif
 }

--- a/networks/aprox13/Make.package
+++ b/networks/aprox13/Make.package
@@ -2,12 +2,13 @@ F90EXE_sources += actual_network.F90
 F90EXE_sources += network_properties.F90
 CEXE_headers += network_properties.H
 
-
 ifeq ($(USE_REACT),TRUE)
 ifneq ($(USE_SIMPLIFIED_SDC), TRUE)
 F90EXE_sources += actual_burner.F90
 endif
 F90EXE_sources += actual_rhs.F90
+
+DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
 
 ifeq ($(USE_CXX_REACTIONS),TRUE)
 CEXE_sources += actual_network_data.cpp

--- a/networks/aprox19/Make.package
+++ b/networks/aprox19/Make.package
@@ -2,6 +2,7 @@ F90EXE_sources += actual_network.F90
 F90EXE_sources += network_properties.F90
 CEXE_headers += network_properties.H
 
+DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
 
 ifeq ($(USE_REACT),TRUE)
 

--- a/networks/ignition_simple/Make.package
+++ b/networks/ignition_simple/Make.package
@@ -2,6 +2,8 @@ F90EXE_sources += actual_network.F90
 F90EXE_sources += network_properties.F90
 CEXE_headers += network_properties.H
 
+DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
+
 ifeq ($(USE_REACT),TRUE)
 ifneq ($(USE_SIMPLIFIED_SDC), TRUE)
 F90EXE_sources += actual_burner.F90

--- a/networks/iso7/Make.package
+++ b/networks/iso7/Make.package
@@ -8,6 +8,8 @@ F90EXE_sources += actual_burner.F90
 endif
 F90EXE_sources += actual_rhs.F90
 
+DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
+
 ifeq ($(USE_CXX_REACTIONS),TRUE)
 CEXE_sources += actual_network_data.cpp
 CEXE_headers += actual_network.H

--- a/networks/powerlaw/Make.package
+++ b/networks/powerlaw/Make.package
@@ -1,6 +1,8 @@
 F90EXE_sources += actual_network.F90
 F90EXE_sources += network_properties.F90
 
+DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
+
 CEXE_headers += network_properties.H
 CEXE_headers += actual_network.H
 CEXE_sources += actual_network_data.cpp

--- a/networks/triple_alpha_plus_cago/Make.package
+++ b/networks/triple_alpha_plus_cago/Make.package
@@ -2,6 +2,8 @@ F90EXE_sources += actual_network.F90
 F90EXE_sources += network_properties.F90
 CEXE_headers += network_properties.H
 
+DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
+
 ifeq ($(USE_REACT),TRUE)
 ifneq ($(USE_SIMPLIFIED_SDC), TRUE)
 F90EXE_sources += actual_burner.F90

--- a/unit_test/test_rhs/rhs_zones.H
+++ b/unit_test/test_rhs/rhs_zones.H
@@ -14,6 +14,10 @@
 #include <actual_matrix.H>
 #endif
 
+#ifndef NETWORK_HAS_CXX_IMPLEMENTATION
+#include <fortran_to_cxx_actual_rhs.H>
+#endif
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 bool do_rhs (int i, int j, int k, Array4<Real> const& state)
 {


### PR DESCRIPTION
If a network has a C++ RHS implementation, it should set `DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION` in its Make.package, and the C++ integrator will continue to use it. Otherwise, we default to the Fortran RHS, and we add a wrapper script that translates between the C++ RHS/Jac and the Fortran RHS/Jac.

With this change, any downstream application can use `USE_CXX_REACTIONS = TRUE` everywhere and still use any network. The only catch is that there is no CUDA implementation right now in this PR, so the legacy Fortran networks won't run on GPUs. If we need to fix that later, it should be possible.