### PR TITLE
Allow other C++ integrators

### DIFF
--- a/integration/VODE/Make.package
+++ b/integration/VODE/Make.package
@@ -2,7 +2,7 @@ ifeq ($(USE_SIMPLIFIED_SDC), TRUE)
   F90EXE_sources += vode_integrator_simplified_sdc.F90
   F90EXE_sources += vode_rhs_simplified_sdc.F90
   F90EXE_sources += vode_type_simplified_sdc.F90
-  CEXE_headers += vode_integrator_simplified_sdc.H
+  CEXE_headers += actual_integrator_simplified_sdc.H
   CEXE_headers += vode_rhs_simplified_sdc.H
   CEXE_headers += vode_type_simplified_sdc.H
 else

--- a/integration/VODE/Make.package
+++ b/integration/VODE/Make.package
@@ -7,7 +7,7 @@ ifeq ($(USE_SIMPLIFIED_SDC), TRUE)
   CEXE_headers += vode_type_simplified_sdc.H
 else
   CEXE_headers += vode_rhs.H
-  CEXE_headers += vode_integrator.H
+  CEXE_headers += actual_integrator.H
   ifeq ($(USE_TRUE_SDC), TRUE)
     F90EXE_sources += vode_integrator_true_sdc.F90
     F90EXE_sources += vode_rhs_true_sdc.F90

--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -1,5 +1,5 @@
-#ifndef _vode_integrator_H_
-#define _vode_integrator_H_
+#ifndef actual_integrator_H
+#define actual_integrator_H
 
 // Common variables and routines for burners
 // that use VODE for their integration.
@@ -14,7 +14,7 @@
 #include <vode_dvode.H>
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void vode_integrator (burn_t& state, Real dt)
+void actual_integrator (burn_t& state, Real dt)
 {
 
     dvode_t vode_state;

--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -1,5 +1,5 @@
-#ifndef _vode_integrator_H_
-#define _vode_integrator_H_
+#ifndef actual_integrator_H
+#define actual_integrator_H
 
 // Common variables and routines for burners
 // that use VODE for their integration.
@@ -14,7 +14,7 @@
 #include <vode_dvode.H>
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void vode_integrator (burn_t& state, Real dt)
+void actual_integrator (burn_t& state, Real dt)
 {
 
     dvode_t vode_state;

--- a/integration/integrator.H
+++ b/integration/integrator.H
@@ -1,12 +1,12 @@
 #ifndef _integrator_H_
 #define _integrator_H_
 
-#include <vode_integrator.H>
+#include <actual_integrator.H>
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void integrator (burn_t& state, Real dt)
 {
-    vode_integrator(state, dt);
+    actual_integrator(state, dt);
 }
 
 #endif

--- a/integration/integrator_sdc.H
+++ b/integration/integrator_sdc.H
@@ -1,12 +1,12 @@
 #ifndef SDC_INTEGRATOR_H
 #define SDC_INTEGRATOR_H
 
-#include <vode_integrator_simplified_sdc.H>
+#include <actual_integrator_simplified_sdc.H>
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void integrator (burn_t& state, Real dt)
 {
-  vode_integrator(state, dt);
+    actual_integrator(state, dt);
 }
 
 #endif


### PR DESCRIPTION
This syncs up with the Fortran scheme where (at least for now) we'll have exactly one actual_integrator.H per build, which allows us to easily swap them out when we add others.