### PR TITLE
Fix create_release action

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-env name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Set release text
         id: release_txt


### PR DESCRIPTION
`set_env` is no longer supported in GitHub actions, so this fixes the `create_release` action so that it no longer includes that command.