### PR TITLE
add inputs that can test the SDC code path with USE_NSE

### DIFF
--- a/unit_test/test_sdc/inputs_aprox19.no_nse
+++ b/unit_test/test_sdc/inputs_aprox19.no_nse
@@ -1,0 +1,9 @@
+n_cell = 16
+
+do_cxx = 1
+
+prefix = react_aprox19_sdc_
+
+amr.probin_file = probin.aprox19.no_nse
+
+

--- a/unit_test/test_sdc/probin.aprox19.no_nse
+++ b/unit_test/test_sdc/probin.aprox19.no_nse
@@ -1,0 +1,19 @@
+&extern
+
+  dens_min   = 1.d4
+  dens_max   = 1.d8
+  temp_min   = 5.d7
+  temp_max   = 5.d8
+
+  tmax = 1.d-7
+
+  primary_species_1 = "hydrogen-1"
+  primary_species_2 = "helium-4"
+  primary_species_3 = "oxygen-16"
+
+  rho_nse = 3.e10
+
+  jacobian = 1
+
+/
+


### PR DESCRIPTION
this disables calling the NSE table, but will do the thermodyanics via aux