### PR TITLE
allow the EOS to be turned off by setting USE_FORT_EOS=FALSE

### DIFF
--- a/EOS/Make.package
+++ b/EOS/Make.package
@@ -1,4 +1,6 @@
-F90EXE_sources += composition.F90
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += composition.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += eos_composition.H
+  CEXE_headers += eos_composition.H
 endif

--- a/EOS/breakout/Make.package
+++ b/EOS/breakout/Make.package
@@ -1,7 +1,8 @@
-F90EXE_sources += actual_eos.F90
-
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += actual_eos.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += actual_eos_data.H
-CEXE_sources += actual_eos_data.cpp
-CEXE_headers += actual_eos.H
+  CEXE_headers += actual_eos_data.H
+  CEXE_sources += actual_eos_data.cpp
+  CEXE_headers += actual_eos.H
 endif

--- a/EOS/gamma_law/Make.package
+++ b/EOS/gamma_law/Make.package
@@ -1,7 +1,8 @@
-F90EXE_sources += gamma_law.F90
-
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += gamma_law.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += actual_eos_data.H
-CEXE_sources += actual_eos_data.cpp
-CEXE_headers += actual_eos.H
+  CEXE_headers += actual_eos_data.H
+  CEXE_sources += actual_eos_data.cpp
+  CEXE_headers += actual_eos.H
 endif

--- a/EOS/gamma_law_general/Make.package
+++ b/EOS/gamma_law_general/Make.package
@@ -1,5 +1,6 @@
-F90EXE_sources += actual_eos.F90
-
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += actual_eos.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += actual_eos.H
+  CEXE_headers += actual_eos.H
 endif

--- a/EOS/helmholtz/Make.package
+++ b/EOS/helmholtz/Make.package
@@ -1,7 +1,8 @@
-F90EXE_sources += actual_eos.F90
-
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += actual_eos.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += actual_eos_data.H
-CEXE_sources += actual_eos_data.cpp
-CEXE_headers += actual_eos.H
+  CEXE_headers += actual_eos_data.H
+  CEXE_sources += actual_eos_data.cpp
+  CEXE_headers += actual_eos.H
 endif

--- a/EOS/multigamma/Make.package
+++ b/EOS/multigamma/Make.package
@@ -1,7 +1,8 @@
-F90EXE_sources += actual_eos.F90
-
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += actual_eos.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += actual_eos_data.H
-CEXE_sources += actual_eos_data.cpp
-CEXE_headers += actual_eos.H
+  CEXE_headers += actual_eos_data.H
+  CEXE_sources += actual_eos_data.cpp
+  CEXE_headers += actual_eos.H
 endif

--- a/EOS/polytrope/Make.package
+++ b/EOS/polytrope/Make.package
@@ -1,7 +1,8 @@
-F90EXE_sources += actual_eos.F90
-
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += actual_eos.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += actual_eos_data.H
-CEXE_sources += actual_eos_data.cpp
-CEXE_headers += actual_eos.H
+  CEXE_headers += actual_eos_data.H
+  CEXE_sources += actual_eos_data.cpp
+  CEXE_headers += actual_eos.H
 endif

--- a/EOS/rad_power_law/Make.package
+++ b/EOS/rad_power_law/Make.package
@@ -1,5 +1,6 @@
-F90EXE_sources += rad_power_law.F90
-
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += rad_power_law.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += actual_eos.H
+  CEXE_headers += actual_eos.H
 endif

--- a/EOS/stellarcollapse/Make.package
+++ b/EOS/stellarcollapse/Make.package
@@ -1,2 +1,4 @@
-F90EXE_sources += actual_eos.F90
-f90EXE_sources += eos_aux_data.f90
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += actual_eos.F90
+  f90EXE_sources += eos_aux_data.f90
+endif

--- a/EOS/ztwd/Make.package
+++ b/EOS/ztwd/Make.package
@@ -1,5 +1,6 @@
-F90EXE_sources += actual_eos.F90
-
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += actual_eos.F90
+endif
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += actual_eos.H
+  CEXE_headers += actual_eos.H
 endif

--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -1,6 +1,17 @@
 # This is the main include makefile for applications that want to use Microphysics
 # You should set NETWORK_OUTPUT_PATH before including this file
 
+USE_FORT_EOS ?= TRUE
+ifeq ($(USE_FORT_EOS),TRUE)
+  DEFINES += -DMICROPHYSICS_FORT_EOS
+endif
+
+USE_CXX_REACTIONS ?= FALSE
+ifeq ($(USE_CXX_REACTIONS),TRUE)
+  DEFINES += -DCXX_REACTIONS
+endif
+
+
 EOS_PATH := $(MICROPHYSICS_HOME)/EOS/$(strip $(EOS_DIR))
 NETWORK_PATH := $(MICROPHYSICS_HOME)/networks/$(strip $(NETWORK_DIR))
 ifeq ($(USE_CONDUCTIVITY), TRUE)

--- a/interfaces/Make.package
+++ b/interfaces/Make.package
@@ -4,26 +4,29 @@ F90EXE_sources += microphysics.F90
 CEXE_headers += microphysics_F.H
 
 F90EXE_sources += network.F90
-F90EXE_sources += eos.F90
-F90EXE_sources += eos_override.F90
-F90EXE_sources += eos_type.F90
+
+ifeq ($(USE_FORT_EOS),TRUE)
+  F90EXE_sources += eos.F90
+  F90EXE_sources += eos_override.F90
+  F90EXE_sources += eos_type.F90
+endif
 
 ifeq ($(USE_CXX_EOS),TRUE)
-CEXE_headers += eos.H
-CEXE_headers += eos_data.H
-CEXE_headers += eos_type.H
-CEXE_headers += eos_override.H
+  CEXE_headers += eos.H
+  CEXE_headers += eos_data.H
+  CEXE_headers += eos_type.H
+  CEXE_headers += eos_override.H
 
-CEXE_sources += eos_data.cpp
+  CEXE_sources += eos_data.cpp
 endif
 
 CEXE_headers += network.H
 CEXE_headers += network_utilities.H
 ifeq ($(USE_CXX_REACTIONS),TRUE)
-CEXE_headers += rhs_utilities.H
-CEXE_sources += network_initialization.cpp
-CEXE_headers += fortran_to_cxx_actual_rhs.H
-F90EXE_sources += fortran_to_cxx_actual_rhs.F90
+  CEXE_headers += rhs_utilities.H
+  CEXE_sources += network_initialization.cpp
+  CEXE_headers += fortran_to_cxx_actual_rhs.H
+  F90EXE_sources += fortran_to_cxx_actual_rhs.F90
 endif
 
 ifeq ($(USE_CONDUCTIVITY), TRUE)

--- a/interfaces/microphysics.F90
+++ b/interfaces/microphysics.F90
@@ -1,7 +1,9 @@
 module microphysics_module
 
   use network
+#ifdef MICROPHYSICS_USE_FORT_EOS
   use eos_module, only : eos_init
+#endif
 #ifdef REACTIONS
   use actual_rhs_module, only : actual_rhs_init
 #ifndef SIMPLIFIED_SDC
@@ -34,6 +36,7 @@ contains
 
     call network_init()
 
+#ifdef MICROPHYSICS_USE_FORT_EOS
     if (present(small_temp) .and. present(small_dens)) then
        call eos_init(small_temp=small_temp, small_dens=small_dens)
     else if (present(small_temp)) then
@@ -43,6 +46,7 @@ contains
     else
        call eos_init()
     endif
+#endif
 
 #ifdef REACTIONS
     call actual_rhs_init()
@@ -59,12 +63,17 @@ contains
 
   subroutine microphysics_finalize() bind(C, name="microphysics_finalize")
 
+#ifdef MICROPHYSICS_USE_FORT_EOS
     use eos_module, only: eos_finalize
+#endif
 #ifdef USE_SCREENING
     use screening_module, only: screening_finalize
     call screening_finalize()
 #endif
+
+#ifdef MICROPHYSICS_USE_FORT_EOS
     call eos_finalize()
+#endif
     call network_finalize()
 
   end subroutine microphysics_finalize

--- a/interfaces/microphysics.F90
+++ b/interfaces/microphysics.F90
@@ -1,7 +1,7 @@
 module microphysics_module
 
   use network
-#ifdef MICROPHYSICS_USE_FORT_EOS
+#ifdef MICROPHYSICS_FORT_EOS
   use eos_module, only : eos_init
 #endif
 #ifdef REACTIONS
@@ -36,7 +36,7 @@ contains
 
     call network_init()
 
-#ifdef MICROPHYSICS_USE_FORT_EOS
+#ifdef MICROPHYSICS_FORT_EOS
     if (present(small_temp) .and. present(small_dens)) then
        call eos_init(small_temp=small_temp, small_dens=small_dens)
     else if (present(small_temp)) then
@@ -63,7 +63,7 @@ contains
 
   subroutine microphysics_finalize() bind(C, name="microphysics_finalize")
 
-#ifdef MICROPHYSICS_USE_FORT_EOS
+#ifdef MICROPHYSICS_FORT_EOS
     use eos_module, only: eos_finalize
 #endif
 #ifdef USE_SCREENING
@@ -71,7 +71,7 @@ contains
     call screening_finalize()
 #endif
 
-#ifdef MICROPHYSICS_USE_FORT_EOS
+#ifdef MICROPHYSICS_FORT_EOS
     call eos_finalize()
 #endif
     call network_finalize()

--- a/unit_test/test_eos/Make.package
+++ b/unit_test/test_eos/Make.package
@@ -1,12 +1,16 @@
 CEXE_sources += main.cpp
 CEXE_sources += eos_util.cpp
-F90EXE_sources += eos_util_F.F90
+
+ifeq ($(USE_FORT_EOS), TRUE)
+  F90EXE_sources += eos_util_F.F90
+endif
 
 FEXE_headers += test_eos_F.H
+f90EXE_sources += unit_test.f90
+
 CEXE_headers += test_eos.H
 
 CEXE_sources += variables.cpp
 CEXE_headers += variables.H
 F90EXE_sources += variables_F.F90
 
-f90EXE_sources += unit_test.f90

--- a/unit_test/test_eos/main.cpp
+++ b/unit_test/test_eos/main.cpp
@@ -104,7 +104,11 @@ void main_main ()
     for (int i = 0; i < probin_file_length; i++)
       probin_file_name[i] = probin_file[i];
 
-    init_unit_test(probin_file_name.dataPtr(), &probin_file_length);
+    init_runtime_parameters(probin_file_name.dataPtr(), &probin_file_length);
+
+#ifdef MICROPHYSICS_FORT_EOS
+    init_fortran_microphysics();
+#endif
 
     init_extern_parameters();
 
@@ -113,18 +117,16 @@ void main_main ()
     // for C++
     plot_t vars;
 
-    // for F90
-    Vector<std::string> varnames;
-
-    // C++ test
     vars = init_variables();
 
     amrex::Vector<std::string> names;
     get_varnames(vars, names);
 
+#ifdef MICROPHYSICS_FORT_EOS
     // Fortran test
 
     init_variables_F();
+#endif
 
     // time = starting time in the simulation
     Real time = 0.0;
@@ -163,11 +165,13 @@ void main_main ()
         if (do_cxx == 1) {
           eos_test_C(bx, dlogrho, dlogT, dmetal, vars, sp);
 
+#ifdef MICROPHYSICS_FOR_EOS
         } else {
 #pragma gpu
         do_eos(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                dlogrho, dlogT, dmetal,
                BL_TO_FORTRAN_ANYD(state[mfi]));
+#endif
         }
 
     }

--- a/unit_test/test_eos/main.cpp
+++ b/unit_test/test_eos/main.cpp
@@ -165,7 +165,7 @@ void main_main ()
         if (do_cxx == 1) {
           eos_test_C(bx, dlogrho, dlogT, dmetal, vars, sp);
 
-#ifdef MICROPHYSICS_FOR_EOS
+#ifdef MICROPHYSICS_FORT_EOS
         } else {
 #pragma gpu
         do_eos(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),

--- a/unit_test/test_eos/test_eos_F.H
+++ b/unit_test/test_eos/test_eos_F.H
@@ -10,7 +10,11 @@ extern "C"
 #endif
   void init_variables_F();
 
-  void init_unit_test(const int* name, const int* namlen); 
+  void init_runtime_parameters(const int* name, const int* namlen); 
+
+#ifdef MICROPHYSICS_FORT_EOS
+  void init_fortran_microphysics();
+#endif
 
   void do_eos(const int* lo, const int* hi,
               amrex::Real dlogrho, amrex::Real dlogT, amrex::Real dmetal,

--- a/unit_test/test_eos/unit_test.f90
+++ b/unit_test/test_eos/unit_test.f90
@@ -1,8 +1,7 @@
-subroutine init_unit_test(name, namlen) bind(C, name="init_unit_test")
+subroutine init_runtime_parameters(name, namlen) bind(C, name="init_runtime_parameters")
 
   use amrex_fort_module, only: rt => amrex_real
   use extern_probin_module
-  use microphysics_module
 
   implicit none
 
@@ -11,6 +10,16 @@ subroutine init_unit_test(name, namlen) bind(C, name="init_unit_test")
 
   call runtime_init(name, namlen)
 
+end subroutine init_runtime_parameters
+
+subroutine init_fortran_microphysics() bind(C, name="init_fortran_microphysics")
+
+  use amrex_fort_module, only: rt => amrex_real
+  use microphysics_module
+  use extern_probin_module, only : small_temp, small_dens
+
+  implicit none
+
   call microphysics_init(small_temp, small_dens)
 
-end subroutine init_unit_test
+end subroutine init_fortran_microphysics


### PR DESCRIPTION
By default, we set `USE_FORT_EOS ?= TRUE` in the `Make.Microphysics_extern`, so no codes will need to be changed.
This addresses part of #453 