### PR TITLE
Pass small_temp and small_dens into eos_init

### DIFF
--- a/interfaces/eos.H
+++ b/interfaces/eos.H
@@ -15,7 +15,7 @@ using namespace amrex;
 // call any specific initialization used by the EOS.
 
 inline
-void eos_init() {
+void eos_init(Real& small_temp, Real& small_dens) {
 
   // Allocate and set default values
 
@@ -48,6 +48,15 @@ void eos_init() {
 
   EOSData::initialized = true;
 
+}
+
+// Overload of the above for cases where we didn't pass in small_temp and small_dens
+
+inline
+void eos_init() {
+    Real small_temp = -1.e200;
+    Real small_dens = -1.e200;
+    eos_init(small_temp, small_dens);
 }
 
 inline

--- a/unit_test/burn_cell/main.cpp
+++ b/unit_test/burn_cell/main.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
 #ifdef CXX_REACTIONS
 
   // C++ EOS initialization (must be done after Fortran eos_init and init_extern_parameters)
-  eos_init();
+  eos_init(small_temp, small_dens);
 
   // C++ Network, RHS, screening, rates initialization
   network_init();

--- a/unit_test/eos_cell/main.cpp
+++ b/unit_test/eos_cell/main.cpp
@@ -38,7 +38,7 @@ int main(int argc, char *argv[]) {
   init_extern_parameters();
 
   // C++ EOS initialization (must be done after Fortran eos_init and init_extern_parameters)
-  eos_init();
+  eos_init(small_temp, small_dens);
 
   // C++ Network, RHS, screening, rates initialization
   network_init();

--- a/unit_test/test_aprox_rates/main.cpp
+++ b/unit_test/test_aprox_rates/main.cpp
@@ -112,7 +112,7 @@ void main_main ()
 
     init_extern_parameters();
 
-    eos_init();
+    eos_init(small_temp, small_dens);
 
     rates_init();
 

--- a/unit_test/test_conductivity/main.cpp
+++ b/unit_test/test_conductivity/main.cpp
@@ -112,7 +112,7 @@ void main_main ()
 
     init_extern_parameters();
 
-    eos_init();
+    eos_init(small_temp, small_dens);
     conductivity_init();
 
     // for C++

--- a/unit_test/test_eos/main.cpp
+++ b/unit_test/test_eos/main.cpp
@@ -112,7 +112,7 @@ void main_main ()
 
     init_extern_parameters();
 
-    eos_init();
+    eos_init(small_temp, small_dens);
 
     // for C++
     plot_t vars;

--- a/unit_test/test_react/main.cpp
+++ b/unit_test/test_react/main.cpp
@@ -125,7 +125,7 @@ void main_main ()
     init_extern_parameters();
 
     // C++ EOS initialization (must be done after Fortran eos_init and init_extern_parameters)
-    eos_init();
+    eos_init(small_temp, small_dens);
 
 #ifdef CXX_REACTIONS
     // C++ Network, RHS, screening, rates initialization

--- a/unit_test/test_rhs/main.cpp
+++ b/unit_test/test_rhs/main.cpp
@@ -128,7 +128,7 @@ void main_main ()
     init_extern_parameters();
 
     // C++ EOS initialization (must be done after Fortran eos_init and init_extern_parameters)
-    eos_init();
+    eos_init(small_temp, small_dens);
 
 #ifdef CXX_REACTIONS
     // C++ Network, RHS, screening, rates initialization

--- a/unit_test/test_screening/main.cpp
+++ b/unit_test/test_screening/main.cpp
@@ -113,7 +113,7 @@ void main_main ()
 
     init_extern_parameters();
 
-    eos_init();
+    eos_init(small_temp, small_dens);
 
     screening_init();
 

--- a/unit_test/test_sdc/main.cpp
+++ b/unit_test/test_sdc/main.cpp
@@ -125,7 +125,7 @@ void main_main ()
     init_extern_parameters();
 
     // C++ EOS initialization (must be done after Fortran eos_init and init_extern_parameters)
-    eos_init();
+    eos_init(small_temp, small_dens);
 
 #ifdef CXX_REACTIONS
     // C++ Network, RHS, screening, rates initialization


### PR DESCRIPTION
This is needed because the downstream codes do not make these variables available as globals without a namespace.