### PR TITLE
Shorten iso7 integration time

### DIFF
--- a/unit_test/test_react/probin.iso7
+++ b/unit_test/test_react/probin.iso7
@@ -7,7 +7,7 @@
   temp_min   = 3.d7
   temp_max   = 5.d8
 
-  tmax = 1.d-5
+  tmax = 1.d-6
 
   primary_species_1 = "helium-4"
   primary_species_2 = "carbon-12"


### PR DESCRIPTION
In #457 we discovered that rearranging some iso7 Jacobian terms can unintentionally make the analytic Jacobian worse. Unfortunately there is not much we can do about that without some larger changes to our Jacobian strategy, such as perhaps attempting to capture the effects of screening. For now we do not really have a choice but to work around the problem by keeping the integration time relatively short so that it completes in a semi-reasonable amount of time.