### PR TITLE
Test iso7 RHS more comprehensively

### DIFF
--- a/unit_test/test_rhs/inputs_iso7
+++ b/unit_test/test_rhs/inputs_iso7
@@ -1,4 +1,4 @@
-n_cell = 16
+n_cell = 64
 
 prefix = react_iso7_
 

--- a/unit_test/test_rhs/probin.iso7
+++ b/unit_test/test_rhs/probin.iso7
@@ -3,28 +3,16 @@
   small_dens = 1.0d0
 
   dens_min   = 1.d6
-  dens_max   = 5.d8
-  temp_min   = 3.d7
-  temp_max   = 5.d8
-
-  tmax = 1.d-5
+  dens_max   = 1.d9
+  temp_min   = 1.d7
+  temp_max   = 1.d10
 
   primary_species_1 = "helium-4"
   primary_species_2 = "carbon-12"
-  primary_species_3 = "oxygen-16"
+  primary_species_3 = "silicon-28"
 
   do_constant_volume_burn = T
 
   call_eos_in_rhs = T
-
-  rtol_spec = 1.d-6
-  atol_spec = 1.d-6
-
-  rtol_temp = 1.d-6
-  atol_temp = 1.d-6
-
-  rtol_enuc = 1.d-6
-  atol_enuc = 1.d-6
-
 
 /


### PR DESCRIPTION
Since we're just evaluating the RHS we can afford to do it over more zones and still have the test complete within a few seconds. Also, since the critical piece of this network is the silicon burning, I made that one of the primary species.