### PR TITLE
Add types to determine if an EOS type has given members

### DIFF
--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -53,6 +53,62 @@ struct eos_t {
 
 };
 
+template <typename T, typename Enable = void>
+struct has_energy
+    : std::false_type {};
+
+template <typename T>
+struct has_energy<T, typename std::enable_if<(sizeof((T*){}->e) > 0)>::type>
+    : std::true_type {};
+
+template <typename T, typename Enable = void>
+struct has_enthalpy
+    : std::false_type {};
+
+template <typename T>
+struct has_enthalpy<T, typename std::enable_if<(sizeof((T*){}->h) > 0)>::type>
+    : std::true_type {};
+
+template <typename T, typename Enable = void>
+struct has_entropy
+    : std::false_type {};
+
+template <typename T>
+struct has_entropy<T, typename std::enable_if<(sizeof((T*){}->s) > 0)>::type>
+    : std::true_type {};
+
+template <typename T, typename Enable = void>
+struct has_pressure
+    : std::false_type {};
+
+template <typename T>
+struct has_pressure<T, typename std::enable_if<(sizeof((T*){}->p) > 0)>::type>
+    : std::true_type {};
+
+template <typename T, typename Enable = void>
+struct has_pele_ppos
+    : std::false_type {};
+
+template <typename T>
+struct has_pele_ppos<T, typename std::enable_if<(sizeof((T*){}->pele) > 0)>::type>
+    : std::true_type {};
+
+template <typename T, typename Enable = void>
+struct has_xne_xnp
+    : std::false_type {};
+
+template <typename T>
+struct has_xne_xnp<T, typename std::enable_if<(sizeof((T*){}->xne) > 0)>::type>
+    : std::true_type {};
+
+template <typename T, typename Enable = void>
+struct has_eta
+    : std::false_type {};
+
+template <typename T>
+struct has_eta<T, typename std::enable_if<(sizeof((T*){}->eta) > 0)>::type>
+    : std::true_type {};
+
 inline
 std::ostream& operator<< (std::ostream& o, eos_t const& eos_state)
 {


### PR DESCRIPTION
To do #470 we will need to be able to determine at compile time if a given template type has certain member data. This adds a few structs for that purpose. The idea is that they can be used like

```
    if constexpr (has_xne_xnp<T>::value) {
        state.xne = xnefer;
        state.xnp = 0.0e0_rt;
    }
```

The intended usage above requires C++17, but this PR does not yet require that.