### PR TITLE
Address various compiler warnings

### DIFF
--- a/EOS/breakout/actual_eos.H
+++ b/EOS/breakout/actual_eos.H
@@ -25,7 +25,7 @@ template <typename I>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 bool is_input_valid (I input)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   bool valid = true;
 
@@ -44,7 +44,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_eos (I input, T& state)
 {
-    static_assert(std::is_same<I, eos_input_t>::value);
+    static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
     const Real R = C::k_B * C::n_A;
 

--- a/EOS/gamma_law/actual_eos.H
+++ b/EOS/gamma_law/actual_eos.H
@@ -42,7 +42,7 @@ template <typename I>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 bool is_input_valid (I input)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   bool valid = true;
 
@@ -62,7 +62,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_eos (I input, T& state)
 {
-    static_assert(std::is_same<I, eos_input_t>::value);
+    static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
     const Real R = C::k_B * C::n_A;
 

--- a/EOS/gamma_law_general/actual_eos.H
+++ b/EOS/gamma_law_general/actual_eos.H
@@ -32,7 +32,7 @@ template <typename I>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 bool is_input_valid (I input)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   bool valid = true;
 
@@ -48,7 +48,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_eos (I input, T& state)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   // Get the mass of a nucleon from Avogadro's number.
   const Real m_nucleon = 1.0 / C::n_A;

--- a/EOS/helmholtz/actual_eos.H
+++ b/EOS/helmholtz/actual_eos.H
@@ -881,11 +881,13 @@ void prepare_for_iterations (I input, T& state,
         dvar = idens;
 
     }
+#ifndef AMREX_USE_GPU
     else {
 
-        static_assert("Unknown EOS input");
+        amrex::Error("Unknown EOS input");
 
     }
+#endif
 }
 
 
@@ -1134,11 +1136,13 @@ void finalize_state (I input, T& state,
            state.h = v_want;
 
        }
+#ifndef AMREX_USE_GPU
        else {
 
-           static_assert("Unknown EOS input");
+           amrex::Error("Unknown EOS input");
 
        }
+#endif
 
     }
 }
@@ -1149,7 +1153,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_eos (I input, T& state)
 {
-    static_assert(std::is_same<I, eos_input_t>::value);
+    static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
     using namespace helmholtz;
 
@@ -1345,7 +1349,7 @@ template <typename I>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 bool is_input_valid (I input)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   bool valid = true;
 

--- a/EOS/helmholtz/actual_eos.H
+++ b/EOS/helmholtz/actual_eos.H
@@ -1136,13 +1136,6 @@ void finalize_state (I input, T& state,
            state.h = v_want;
 
        }
-#ifndef AMREX_USE_GPU
-       else {
-
-           amrex::Error("Unknown EOS input");
-
-       }
-#endif
 
     }
 }

--- a/EOS/multigamma/actual_eos.H
+++ b/EOS/multigamma/actual_eos.H
@@ -51,7 +51,7 @@ template <typename I>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 bool is_input_valid (I input)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   bool valid = true;
 
@@ -68,7 +68,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_eos (I input, T& state)
 {
-    static_assert(std::is_same<I, eos_input_t>::value);
+    static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
     // Get the mass of a nucleon from Avogadro's number.
     const Real m_nucleon = 1.0_rt / C::n_A;

--- a/EOS/polytrope/actual_eos.H
+++ b/EOS/polytrope/actual_eos.H
@@ -77,7 +77,7 @@ template <typename I>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 bool is_input_valid (I input)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   bool valid = true;
 
@@ -120,7 +120,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_eos (I input, T& state)
 {
-    static_assert(std::is_same<I, eos_input_t>::value);
+    static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
     Real dens = state.rho;
     Real temp = state.T;

--- a/EOS/rad_power_law/actual_eos.H
+++ b/EOS/rad_power_law/actual_eos.H
@@ -47,7 +47,7 @@ template <typename I>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 bool is_input_valid (I input)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   bool valid = true;
 
@@ -68,7 +68,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_eos (I input, T& state)
 {
-    static_assert(std::is_same<I, eos_input_t>::value);
+    static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
     switch (input) {
 

--- a/EOS/ztwd/actual_eos.H
+++ b/EOS/ztwd/actual_eos.H
@@ -42,7 +42,7 @@ template <typename I>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 bool is_input_valid (I input)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   bool valid = true;
 
@@ -129,7 +129,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_eos (I input, T& state)
 {
-    static_assert(std::is_same<I, eos_input_t>::value);
+    static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
     Real dens = state.rho;
     Real temp = state.T;

--- a/integration/VODE/cuVODE/test/main.cpp
+++ b/integration/VODE/cuVODE/test/main.cpp
@@ -130,7 +130,6 @@ void main_main ()
     {
         const Box& bx = mfi.tilebox();
 
-#pragma gpu
         do_react(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                  BL_TO_FORTRAN_ANYD(state[mfi]), Ncomp, dt);
 

--- a/interfaces/eos.H
+++ b/interfaces/eos.H
@@ -15,7 +15,7 @@ using namespace amrex;
 // call any specific initialization used by the EOS.
 
 AMREX_INLINE
-void eos_init (Real& small_temp, Real& small_dens)
+void eos_init (Real& small_temp_in, Real& small_dens_in)
 {
   // Allocate and set default values
 
@@ -40,11 +40,11 @@ void eos_init (Real& small_temp, Real& small_dens)
   actual_eos_init();
 
   // Set EOSData::min{temp,dens} and small_{temp,dens} to the maximum of the two
-  EOSData::mintemp = amrex::max(EOSData::mintemp, small_temp);
-  small_temp = amrex::max(small_temp, EOSData::mintemp);
+  EOSData::mintemp = amrex::max(EOSData::mintemp, small_temp_in);
+  small_temp = amrex::max(small_temp_in, EOSData::mintemp);
 
-  EOSData::mindens = amrex::max(EOSData::mindens, small_dens);
-  small_dens = amrex::max(small_dens, EOSData::mindens);
+  EOSData::mindens = amrex::max(EOSData::mindens, small_dens_in);
+  small_dens = amrex::max(small_dens_in, EOSData::mindens);
 
   EOSData::initialized = true;
 }
@@ -54,9 +54,9 @@ void eos_init (Real& small_temp, Real& small_dens)
 AMREX_INLINE
 void eos_init ()
 {
-    Real small_temp = -1.e200;
-    Real small_dens = -1.e200;
-    eos_init(small_temp, small_dens);
+    Real small_temp_tmp = -1.e200;
+    Real small_dens_tmp = -1.e200;
+    eos_init(small_temp_tmp, small_dens_tmp);
 }
 
 AMREX_INLINE
@@ -381,7 +381,7 @@ template <typename I, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void eos (const I input, T& state, bool use_raw_inputs = false)
 {
-  static_assert(std::is_same<I, eos_input_t>::value);
+  static_assert(std::is_same<I, eos_input_t>::value, "input must be an eos_input_t");
 
   // Input arguments
 

--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -58,7 +58,7 @@ struct has_energy
     : std::false_type {};
 
 template <typename T>
-struct has_energy<T, typename std::enable_if<(sizeof((T*){}->e) > 0)>::type>
+struct has_energy<T, typename std::enable_if<(sizeof(((T*)0)->e) > 0)>::type>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -66,7 +66,7 @@ struct has_enthalpy
     : std::false_type {};
 
 template <typename T>
-struct has_enthalpy<T, typename std::enable_if<(sizeof((T*){}->h) > 0)>::type>
+struct has_enthalpy<T, typename std::enable_if<(sizeof(((T*)0)->h) > 0)>::type>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -74,7 +74,7 @@ struct has_entropy
     : std::false_type {};
 
 template <typename T>
-struct has_entropy<T, typename std::enable_if<(sizeof((T*){}->s) > 0)>::type>
+struct has_entropy<T, typename std::enable_if<(sizeof(((T*)0)->s) > 0)>::type>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -82,7 +82,7 @@ struct has_pressure
     : std::false_type {};
 
 template <typename T>
-struct has_pressure<T, typename std::enable_if<(sizeof((T*){}->p) > 0)>::type>
+struct has_pressure<T, typename std::enable_if<(sizeof(((T*)0)->p) > 0)>::type>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -90,7 +90,7 @@ struct has_pele_ppos
     : std::false_type {};
 
 template <typename T>
-struct has_pele_ppos<T, typename std::enable_if<(sizeof((T*){}->pele) > 0)>::type>
+struct has_pele_ppos<T, typename std::enable_if<(sizeof(((T*)0)->pele) > 0)>::type>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -98,7 +98,7 @@ struct has_xne_xnp
     : std::false_type {};
 
 template <typename T>
-struct has_xne_xnp<T, typename std::enable_if<(sizeof((T*){}->xne) > 0)>::type>
+struct has_xne_xnp<T, typename std::enable_if<(sizeof(((T*)0)->xne) > 0)>::type>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -106,7 +106,7 @@ struct has_eta
     : std::false_type {};
 
 template <typename T>
-struct has_eta<T, typename std::enable_if<(sizeof((T*){}->eta) > 0)>::type>
+struct has_eta<T, typename std::enable_if<(sizeof(((T*)0)->eta) > 0)>::type>
     : std::true_type {};
 
 inline

--- a/unit_test/test_aprox_rates/main.cpp
+++ b/unit_test/test_aprox_rates/main.cpp
@@ -170,7 +170,6 @@ void main_main ()
           aprox_rates_test_C(bx, dlogrho, dlogT, dNi, vars, sp);
 
         } else {
-#pragma gpu
           do_rates(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                    dlogrho, dlogT, dNi,
                    BL_TO_FORTRAN_ANYD(state[mfi]));

--- a/unit_test/test_conductivity/main.cpp
+++ b/unit_test/test_conductivity/main.cpp
@@ -168,7 +168,6 @@ void main_main ()
         cond_test_C(bx, dlogrho, dlogT, dmetal, vars, sp);
 
       } else {
-#pragma gpu
         do_conductivity(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                         dlogrho, dlogT, dmetal,
                         BL_TO_FORTRAN_ANYD(state[mfi]));

--- a/unit_test/test_eos/main.cpp
+++ b/unit_test/test_eos/main.cpp
@@ -167,10 +167,9 @@ void main_main ()
 
 #ifdef MICROPHYSICS_FORT_EOS
         } else {
-#pragma gpu
-        do_eos(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
-               dlogrho, dlogT, dmetal,
-               BL_TO_FORTRAN_ANYD(state[mfi]));
+            do_eos(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
+                   dlogrho, dlogT, dmetal,
+                   BL_TO_FORTRAN_ANYD(state[mfi]));
 #endif
         }
 

--- a/unit_test/test_react/main.cpp
+++ b/unit_test/test_react/main.cpp
@@ -238,7 +238,6 @@ void main_main ()
         else {
 #endif
 
-#pragma gpu
             do_react(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                      BL_TO_FORTRAN_ANYD(state[mfi]),
                      BL_TO_FORTRAN_ANYD(integrator_n_rhs[mfi]));

--- a/unit_test/test_rhs/main.cpp
+++ b/unit_test/test_rhs/main.cpp
@@ -212,7 +212,6 @@ void main_main ()
         else {
 #endif
 
-#pragma gpu
             do_rhs(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                    BL_TO_FORTRAN_ANYD(state[mfi]));
 

--- a/unit_test/test_screening/main.cpp
+++ b/unit_test/test_screening/main.cpp
@@ -168,7 +168,6 @@ void main_main ()
         screen_test_C(bx, dlogrho, dlogT, dmetal, vars, sp);
 
       } else {
-#pragma gpu
         do_screening(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                      dlogrho, dlogT, dmetal,
                      BL_TO_FORTRAN_ANYD(state[mfi]));

--- a/unit_test/test_sdc/main.cpp
+++ b/unit_test/test_sdc/main.cpp
@@ -238,7 +238,6 @@ void main_main ()
         else {
 #endif
 
-#pragma gpu
           do_react_F(AMREX_INT_ANYD(bx.loVect()), AMREX_INT_ANYD(bx.hiVect()),
                      BL_TO_FORTRAN_ANYD(state[mfi]),
                      BL_TO_FORTRAN_ANYD(integrator_n_rhs[mfi]));

--- a/util/build_scripts/write_probin.py
+++ b/util/build_scripts/write_probin.py
@@ -429,12 +429,12 @@ def write_probin(probin_template, param_files,
 
         fout.write("\n")
         fout.write("  void init_{}_parameters() {{\n".format(os.path.basename(cxx_prefix)))
-        fout.write("    int slen = 0;\n\n")
 
         for p in params:
             if p.dtype == "character":
-                fout.write("    get_f90_{}_len(slen);\n".format(p.var))
-                fout.write("    char _{}[slen+1];\n".format(p.var))
+                fout.write("    int slen_{} = 0;\n".format(p.var))
+                fout.write("    get_f90_{}_len(slen_{});\n".format(p.var, p.var))
+                fout.write("    char _{}[slen_{}+1];\n".format(p.var, p.var))
                 fout.write("    get_f90_{}(_{});\n".format(p.var, p.var))
                 fout.write("    {} = std::string(_{});\n\n".format(p.var, p.var))
             else:


### PR DESCRIPTION
- Use of single argument static_assert without a message is C++17-only
- One usage of static_assert in helmeos was prematurely implemented at compile time instead of runtime
- Shadowing of small_dens and small_temp in eos.H
- Unknown compiler pragmas (pragma gpu)
- Invalid use of compound literals in eos_type.H (C99 only)
- slen is unused in extern_parameters.cpp if there are no string parameters