### PR TITLE
move more stuff into the build scripts

### DIFF
--- a/util/build_scripts/runtime_parameters.py
+++ b/util/build_scripts/runtime_parameters.py
@@ -243,7 +243,7 @@ class Param:
                 tstr = f"{self.get_f90_decl()},  allocatable, save :: {self.name}\n"
         elif self.dtype == "string":
             if self.is_array():
-                print("error: cannot have a character array")
+                sys.exit("error: cannot have a character array")
             else:
                 tstr = f"character (len=256) :: {self.name}\n"
             print(f"warning: string parameter {self.name} will not be available on the GPU")


### PR DESCRIPTION
now the Fortran "get" routines are part of runtime_parameters.py.  This also adds array support.  This will help with porting the Castro problem parameters over.