### PR TITLE
Start moving towards zero-based indexing with linpack

### DIFF
--- a/util/linpack.H
+++ b/util/linpack.H
@@ -8,35 +8,38 @@
 
 template <int num_eqs>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void dgesl (RArray2D& a, IArray1D& pivot, RArray1D& b)
+void dgesl (RArray2D& a1, IArray1D& pivot1, RArray1D& b1)
 {
+    auto const& a = reinterpret_cast<Array2D<Real, 0, num_eqs-1, 0, num_eqs-1>&>(a1);
+    auto const& pivot = reinterpret_cast<Array1D<int, 0, num_eqs-1>&>(pivot1);
+    auto& b = reinterpret_cast<Array1D<Real, 0, num_eqs-1>&>(b1);
 
     int nm1 = num_eqs - 1;
 
     // solve a * x = b
     // first solve l * y = b
     if (nm1 >= 1) {
-        for (int k = 1; k <= nm1; ++k) {
-            int l = pivot(k);
+        for (int k = 0; k < nm1; ++k) {
+            int l = pivot(k) - 1;
             Real t = b(l);
             if (l != k) {
                 b(l) = b(k);
                 b(k) = t;
             }
 
-            for (int j = k+1; j <= num_eqs; ++j) {
+            for (int j = k+1; j < num_eqs; ++j) {
                 b(j) += t * a(j,k);
             }
         }
     }
 
     // now solve u * x = y
-    for (int kb = 1; kb <= num_eqs; ++kb) {
+    for (int kb = 0; kb < num_eqs; ++kb) {
 
-        int k = num_eqs + 1 - kb;
+        int k = num_eqs - kb - 1;
         b(k) = b(k) / a(k,k);
         Real t = -b(k);
-        for (int j = 1; j <= k-1; ++j) {
+        for (int j = 0; j < k; ++j) {
             b(j) += t * a(j,k);
         }
     }
@@ -47,8 +50,10 @@ void dgesl (RArray2D& a, IArray1D& pivot, RArray1D& b)
 
 template <int num_eqs>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void dgefa (RArray2D& a, IArray1D& pivot, int& info)
+void dgefa (RArray2D& a1, IArray1D& pivot1, int& info)
 {
+    auto& a = reinterpret_cast<Array2D<Real, 0, num_eqs-1, 0, num_eqs-1>&>(a1);
+    auto& pivot = reinterpret_cast<Array1D<int, 0, num_eqs-1>&>(pivot1);
 
     // dgefa factors a matrix by gaussian elimination.
     // a is returned in the form a = l * u where
@@ -64,19 +69,19 @@ void dgefa (RArray2D& a, IArray1D& pivot, int& info)
 
     if (nm1 >= 1) {
 
-        for (int k = 1; k <= nm1; ++k) {
+        for (int k = 0; k < nm1; ++k) {
 
             // find l = pivot index
             int l = k;
             Real dmax = std::abs(a(k,k));
-            for (int i = k+1; i <= num_eqs; ++i) {
+            for (int i = k+1; i < num_eqs; ++i) {
                 if (std::abs(a(i,k)) > dmax) {
                     l = i;
                     dmax = std::abs(a(i,k));
                 }
             }
 
-            pivot(k) = l;
+            pivot(k) = l + 1;
 
             // zero pivot implies this column already triangularized
             if (a(l,k) != 0.0e0_rt) {
@@ -90,25 +95,25 @@ void dgefa (RArray2D& a, IArray1D& pivot, int& info)
 
                 // compute multipliers
                 t = -1.0e0_rt / a(k,k);
-                for (int j = k+1; j <= num_eqs; ++j) {
+                for (int j = k+1; j < num_eqs; ++j) {
                     a(j,k) *= t;
                 }
 
                 // row elimination with column indexing
-                for (int j = k+1; j <= num_eqs; ++j) {
+                for (int j = k+1; j < num_eqs; ++j) {
                     t = a(l,j);
                     if (l != k) {
                         a(l,j) = a(k,j);
                         a(k,j) = t;
                     }
-                    for (int i = k+1; i <= num_eqs; ++i) {
+                    for (int i = k+1; i < num_eqs; ++i) {
                         a(i,j) += t * a(i,k);
                     }
                 }
             }
             else {
 
-                info = k;
+                info = k+1;
 
             }
 
@@ -116,9 +121,9 @@ void dgefa (RArray2D& a, IArray1D& pivot, int& info)
 
     }
 
-    pivot(num_eqs) = num_eqs;
+    pivot(num_eqs-1) = num_eqs;
 
-    if (a(num_eqs,num_eqs) == 0.0e0_rt) {
+    if (a(num_eqs-1,num_eqs-1) == 0.0e0_rt) {
         info = num_eqs;
     }
 


### PR DESCRIPTION
`RArray1D` and `RArray2D` are one-based arrays, and that causes friction with the zero-based indexing of `xn` and other arrays. So we want to move everything to zero-based indexing.

The strategy will be to suffix function parameters with "1", e.g. `a` -> `a1`, and then do

```
auto& a = reinterpret_cast<Array2D<Real, 0, num_eqs-1, 0, num_eqs-1>&>(a1)
```

Then, in the function, we can convert all the calculations to zero-based indexing. When all of the conversions have been done, we can do one final sweep to convert `RArray1D` and `RArray2D` to be zero-based and then remove all the `reinterpret_cast` statements and rename the function parameters to their original names. This will allow us to do an incremental conversion.
