### PR TITLE
fix rprox GPU / C++

### DIFF
--- a/networks/rprox/Make.package
+++ b/networks/rprox/Make.package
@@ -10,6 +10,8 @@ ifeq ($(USE_REACT),TRUE)
     endif
   endif
 
+  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
+
   F90EXE_sources += actual_rhs.F90
   F90EXE_sources += tfactors.F90
   F90EXE_sources += rates_module.F90

--- a/networks/rprox/actual_rhs.H
+++ b/networks/rprox/actual_rhs.H
@@ -451,8 +451,12 @@ void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
     // Energy release
     ener_gener_rate(ydot, ydot(net_ienuc));
 
-    // Temperature ODE
-    temperature_rhs(state, ydot);
+#ifdef STRANG
+    // Append the temperature equation
+
+    ydot(net_itemp) = temperature_rhs(state, ydot(net_ienuc));
+#endif
+
 }
 
 


### PR DESCRIPTION
rprox was not actually using the C++ implementaiton.  This fixes that and fixes compilation.  This now runs on the GPU.