### PR TITLE
iso7 17/∞

### DIFF
--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -47,9 +47,14 @@ namespace Rates {
                        C12_He4_to_O16_reverse,
                        He4_He4_He4_to_C12_forward,
                        He4_He4_He4_to_C12_reverse,
-                       C12_C12,
-                       C12_O16,
-                       O16_O16,
+                       C12_C12_to_Ne20_He4_forward,
+                       C12_C12_to_Ne20_He4_reverse,
+                       C12_O16_to_Mg24_He4_forward,
+                       C12_O16_to_Mg24_He4_reverse,
+                       C12_O16_to_Si28_forward,
+                       C12_O16_to_Si28_reverse,
+                       O16_O16_to_Si28_He4_forward,
+                       O16_O16_to_Si28_He4_reverse,
                        O16_He4_to_Ne20_forward,
                        O16_He4_to_Ne20_reverse,
                        Ne20_He4_to_Mg24_forward,
@@ -107,19 +112,19 @@ namespace RHS {
             data.specindex2 = He4;
             break;
 
-        case rhs_rate<NumRates>(He4, C12_C12):
+        case rhs_rate<NumRates>(He4, C12_C12_to_Ne20_He4_forward):
             data.prefactor  = 0.5_rt;
             data.specindex1 = C12;
             data.specindex2 = C12;
             break;
 
-        case rhs_rate<NumRates>(He4, C12_O16):
-            data.prefactor  = 0.5_rt;
+        case rhs_rate<NumRates>(He4, C12_O16_to_Mg24_He4_forward):
+            data.prefactor  = 1.0_rt;
             data.specindex1 = C12;
             data.specindex2 = O16;
             break;
 
-        case rhs_rate<NumRates>(He4, O16_O16):
+        case rhs_rate<NumRates>(He4, O16_O16_to_Si28_He4_forward):
             data.prefactor  = 0.5_rt;
             data.specindex1 = O16;
             data.specindex2 = O16;
@@ -191,13 +196,19 @@ namespace RHS {
             data.specindex2 = He4;
             break;
 
-        case rhs_rate<NumRates>(C12, C12_C12):
+        case rhs_rate<NumRates>(C12, C12_C12_to_Ne20_He4_forward):
             data.prefactor  = -1.0_rt;
             data.specindex1 = C12;
             data.specindex2 = C12;
             break;
 
-        case rhs_rate<NumRates>(C12, C12_O16):
+        case rhs_rate<NumRates>(C12, C12_O16_to_Mg24_He4_forward):
+            data.prefactor  = -1.0_rt;
+            data.specindex1 = C12;
+            data.specindex2 = O16;
+            break;
+
+        case rhs_rate<NumRates>(C12, C12_O16_to_Si28_forward):
             data.prefactor  = -1.0_rt;
             data.specindex1 = C12;
             data.specindex2 = O16;
@@ -214,13 +225,19 @@ namespace RHS {
             data.specindex2 = He4;
             break;
 
-        case rhs_rate<NumRates>(O16, C12_O16):
+        case rhs_rate<NumRates>(O16, C12_O16_to_Mg24_He4_forward):
             data.prefactor  = -1.0_rt;
             data.specindex1 = C12;
             data.specindex2 = O16;
             break;
 
-        case rhs_rate<NumRates>(O16, O16_O16):
+        case rhs_rate<NumRates>(O16, C12_O16_to_Si28_forward):
+            data.prefactor  = -1.0_rt;
+            data.specindex1 = C12;
+            data.specindex2 = O16;
+            break;
+
+        case rhs_rate<NumRates>(O16, O16_O16_to_Si28_He4_forward):
             data.prefactor  = -1.0_rt;
             data.specindex1 = O16;
             data.specindex2 = O16;
@@ -237,7 +254,7 @@ namespace RHS {
             data.specindex1 = Ne20;
             break;
 
-        case rhs_rate<NumRates>(Ne20, C12_C12):
+        case rhs_rate<NumRates>(Ne20, C12_C12_to_Ne20_He4_forward):
             data.prefactor  = 0.5_rt;
             data.specindex1 = C12;
             data.specindex2 = C12;
@@ -265,8 +282,8 @@ namespace RHS {
             data.specindex2 = He4;
             break;
 
-        case rhs_rate<NumRates>(Mg24, C12_O16):
-            data.prefactor  = 0.5_rt;
+        case rhs_rate<NumRates>(Mg24, C12_O16_to_Mg24_He4_forward):
+            data.prefactor  = 1.0_rt;
             data.specindex1 = C12;
             data.specindex2 = O16;
             break;
@@ -293,13 +310,13 @@ namespace RHS {
             data.specindex2 = He4;
             break;
 
-        case rhs_rate<NumRates>(Si28, C12_O16):
-            data.prefactor  = 0.5_rt;
+        case rhs_rate<NumRates>(Si28, C12_O16_to_Si28_forward):
+            data.prefactor  = 1.0_rt;
             data.specindex1 = C12;
             data.specindex2 = O16;
             break;
 
-        case rhs_rate<NumRates>(Si28, O16_O16):
+        case rhs_rate<NumRates>(Si28, O16_O16_to_Si28_He4_forward):
             data.prefactor  = 0.5_rt;
             data.specindex1 = O16;
             data.specindex2 = O16;
@@ -414,13 +431,13 @@ namespace RHS {
             data.specindex1 = He4;
             break;
 
-        case jac_rate<NumSpec, NumRates>(He4, C12, C12_C12):
+        case jac_rate<NumSpec, NumRates>(He4, C12, C12_C12_to_Ne20_He4_forward):
             data.prefactor = 1.0_rt;
             data.specindex1 = C12;
             break;
 
-        case jac_rate<NumSpec, NumRates>(He4, C12, C12_O16):
-            data.prefactor = 0.5_rt;
+        case jac_rate<NumSpec, NumRates>(He4, C12, C12_O16_to_Mg24_He4_forward):
+            data.prefactor = 1.0_rt;
             data.specindex1 = O16;
             break;
 
@@ -428,12 +445,12 @@ namespace RHS {
             data.prefactor = 1.0_rt;
             break;
 
-        case jac_rate<NumSpec, NumRates>(He4, O16, C12_O16):
-            data.prefactor = 0.5_rt;
+        case jac_rate<NumSpec, NumRates>(He4, O16, C12_O16_to_Mg24_He4_forward):
+            data.prefactor = 1.0_rt;
             data.specindex1 = C12;
             break;
 
-        case jac_rate<NumSpec, NumRates>(He4, O16, O16_O16):
+        case jac_rate<NumSpec, NumRates>(He4, O16, O16_O16_to_Si28_He4_forward):
             data.prefactor = 1.0_rt;
             data.specindex1 = O16;
             break;
@@ -494,12 +511,17 @@ namespace RHS {
             data.specindex1 = He4;
             break;
 
-        case jac_rate<NumSpec, NumRates>(C12, C12, C12_C12):
+        case jac_rate<NumSpec, NumRates>(C12, C12, C12_C12_to_Ne20_He4_forward):
             data.prefactor = -2.0_rt;
             data.specindex1 = C12;
             break;
 
-        case jac_rate<NumSpec, NumRates>(C12, C12, C12_O16):
+        case jac_rate<NumSpec, NumRates>(C12, C12, C12_O16_to_Mg24_He4_forward):
+            data.prefactor = -1.0_rt;
+            data.specindex1 = O16;
+            break;
+
+        case jac_rate<NumSpec, NumRates>(C12, C12, C12_O16_to_Si28_forward):
             data.prefactor = -1.0_rt;
             data.specindex1 = O16;
             break;
@@ -508,7 +530,12 @@ namespace RHS {
             data.prefactor = 1.0_rt;
             break;
 
-        case jac_rate<NumSpec, NumRates>(C12, O16, C12_O16):
+        case jac_rate<NumSpec, NumRates>(C12, O16, C12_O16_to_Mg24_He4_forward):
+            data.prefactor = -1.0_rt;
+            data.specindex1 = C12;
+            break;
+
+        case jac_rate<NumSpec, NumRates>(C12, O16, C12_O16_to_Si28_forward):
             data.prefactor = -1.0_rt;
             data.specindex1 = C12;
             break;
@@ -528,7 +555,12 @@ namespace RHS {
             data.specindex1 = He4;
             break;
 
-        case jac_rate<NumSpec, NumRates>(O16, C12, C12_O16):
+        case jac_rate<NumSpec, NumRates>(O16, C12, C12_O16_to_Mg24_He4_forward):
+            data.prefactor = -1.0_rt;
+            data.specindex1 = O16;
+            break;
+
+        case jac_rate<NumSpec, NumRates>(O16, C12, C12_O16_to_Si28_forward):
             data.prefactor = -1.0_rt;
             data.specindex1 = O16;
             break;
@@ -537,12 +569,17 @@ namespace RHS {
             data.prefactor = -1.0_rt;
             break;
 
-        case jac_rate<NumSpec, NumRates>(O16, O16, C12_O16):
+        case jac_rate<NumSpec, NumRates>(O16, O16, C12_O16_to_Mg24_He4_forward):
             data.prefactor = -1.0_rt;
             data.specindex1 = C12;
             break;
 
-        case jac_rate<NumSpec, NumRates>(O16, O16, O16_O16):
+        case jac_rate<NumSpec, NumRates>(O16, O16, C12_O16_to_Si28_forward):
+            data.prefactor = -1.0_rt;
+            data.specindex1 = C12;
+            break;
+
+        case jac_rate<NumSpec, NumRates>(O16, O16, O16_O16_to_Si28_He4_forward):
             data.prefactor = -2.0_rt;
             data.specindex1 = O16;
             break;
@@ -566,7 +603,7 @@ namespace RHS {
             data.specindex1 = Ne20;
             break;
 
-        case jac_rate<NumSpec, NumRates>(Ne20, C12, C12_C12):
+        case jac_rate<NumSpec, NumRates>(Ne20, C12, C12_C12_to_Ne20_He4_forward):
             data.prefactor = 1.0_rt;
             data.specindex1 = C12;
             break;
@@ -599,13 +636,13 @@ namespace RHS {
             data.specindex1 = Mg24;
             break;
 
-        case jac_rate<NumSpec, NumRates>(Mg24, C12, C12_O16):
-            data.prefactor = 0.5_rt;
+        case jac_rate<NumSpec, NumRates>(Mg24, C12, C12_O16_to_Mg24_He4_forward):
+            data.prefactor = 1.0_rt;
             data.specindex1 = O16;
             break;
 
-        case jac_rate<NumSpec, NumRates>(Mg24, O16, C12_O16):
-            data.prefactor = 0.5_rt;
+        case jac_rate<NumSpec, NumRates>(Mg24, O16, C12_O16_to_Mg24_He4_forward):
+            data.prefactor = 1.0_rt;
             data.specindex1 = C12;
             break;
 
@@ -644,18 +681,18 @@ namespace RHS {
             data.rate_specindex1 = Ni56;
             break;
 
-        case jac_rate<NumSpec, NumRates>(Si28, C12, C12_O16):
-            data.prefactor = 0.5_rt;
-            data.specindex1 = O16;
-            break;
-
-        case jac_rate<NumSpec, NumRates>(Si28, O16, O16_O16):
+        case jac_rate<NumSpec, NumRates>(Si28, C12, C12_O16_to_Si28_forward):
             data.prefactor = 1.0_rt;
             data.specindex1 = O16;
             break;
 
-        case jac_rate<NumSpec, NumRates>(Si28, O16, C12_O16):
-            data.prefactor = 0.5_rt;
+        case jac_rate<NumSpec, NumRates>(Si28, O16, O16_O16_to_Si28_He4_forward):
+            data.prefactor = 1.0_rt;
+            data.specindex1 = O16;
+            break;
+
+        case jac_rate<NumSpec, NumRates>(Si28, O16, C12_O16_to_Si28_forward):
+            data.prefactor = 1.0_rt;
             data.specindex1 = C12;
             break;
 

--- a/networks/iso7/actual_network_data.cpp
+++ b/networks/iso7/actual_network_data.cpp
@@ -46,9 +46,14 @@ void actual_network_init()
         names[C12_He4_to_O16_reverse-1]     = "roga";
         names[He4_He4_He4_to_C12_forward-1] = "r3a";
         names[He4_He4_He4_to_C12_reverse-1] = "rg3a";
-        names[C12_C12-1]                    = "r1212";
-        names[C12_O16-1]                    = "r1216";
-        names[O16_O16-1]                    = "r1616";
+        names[C12_C12_to_Ne20_He4_forward-1] = "r1212";
+        names[C12_C12_to_Ne20_He4_reverse-1] = "r1212_r";
+        names[C12_O16_to_Mg24_He4_forward-1] = "r1216";
+        names[C12_O16_to_Mg24_He4_reverse-1] = "r1216_r";
+        names[C12_O16_to_Si28_forward-1]    = "r1216_Si";
+        names[C12_O16_to_Si28_reverse-1]    = "r1216_Si_r";
+        names[O16_O16_to_Si28_He4_forward-1] = "r1616";
+        names[O16_O16_to_Si28_He4_reverse-1] = "r1616_r";
         names[O16_He4_to_Ne20_forward-1]    = "roag";
         names[O16_He4_to_Ne20_reverse-1]    = "rnega";
         names[Ne20_He4_to_Mg24_forward-1]   = "rneag";

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -62,9 +62,14 @@ void iso7tab(const Real btemp, const Real bden,
         dtab(C12_He4_to_O16_reverse)  = 1.0e0_rt;
         dtab(He4_He4_He4_to_C12_forward)   = bden*bden;
         dtab(He4_He4_He4_to_C12_reverse)  = 1.0e0_rt;
-        dtab(C12_C12) = bden;
-        dtab(C12_O16) = bden;
-        dtab(O16_O16) = bden;
+        dtab(C12_C12_to_Ne20_He4_forward) = bden;
+        dtab(C12_C12_to_Ne20_He4_reverse) = bden; // rate is zero in this net
+        dtab(C12_O16_to_Mg24_He4_forward) = bden;
+        dtab(C12_O16_to_Mg24_He4_reverse) = bden; // rate is zero in this net
+        dtab(C12_O16_to_Si28_forward) = bden;
+        dtab(C12_O16_to_Si28_reverse) = bden; // rate is zero in this net
+        dtab(O16_O16_to_Si28_He4_forward) = bden;
+        dtab(O16_O16_to_Si28_He4_reverse) = bden; // rate is zero in this net
         dtab(O16_He4_to_Ne20_forward)  = bden;
         dtab(O16_He4_to_Ne20_reverse) = 1.0e0_rt;
         dtab(Ne20_He4_to_Mg24_forward) = bden;
@@ -162,17 +167,17 @@ void iso7rat(const Real btemp, const Real bden,
 
     // c12 + c12
     rate_c12c12(tf,bden,
-                rate(C12_C12),dratedt(C12_C12),
+                rate(C12_C12_to_Ne20_He4_forward),dratedt(C12_C12_to_Ne20_He4_forward),
                 rrate,drratedt);
 
     // c12 + o16
     rate_c12o16(tf,bden,
-                rate(C12_O16),dratedt(C12_O16),
+                rate(C12_O16_to_Mg24_He4_forward),dratedt(C12_O16_to_Mg24_He4_forward),
                 rrate,drratedt);
 
     // 16o + 16o
     rate_o16o16(tf,bden,
-                rate(O16_O16),dratedt(O16_O16),
+                rate(O16_O16_to_Si28_He4_forward),dratedt(O16_O16_to_Si28_He4_forward),
                 rrate,drratedt);
 
     // o16(a,g)ne20
@@ -298,8 +303,8 @@ void screen_iso7(const Real btemp, const Real bden,
             zion[C12-1], aion[C12-1], zion[C12-1], aion[C12-1],
             sc1a,sc1adt,sc1add);
 
-    dratedt(C12_C12) = dratedt(C12_C12) * sc1a + rate(C12_C12) * sc1adt;
-    rate(C12_C12)    = rate(C12_C12) * sc1a;
+    dratedt(C12_C12_to_Ne20_He4_forward) = dratedt(C12_C12_to_Ne20_He4_forward) * sc1a + rate(C12_C12_to_Ne20_He4_forward) * sc1adt;
+    rate(C12_C12_to_Ne20_He4_forward)    = rate(C12_C12_to_Ne20_He4_forward) * sc1a;
 
     // c12 + o16
     jscr++;
@@ -307,8 +312,16 @@ void screen_iso7(const Real btemp, const Real bden,
             zion[C12-1], aion[C12-1], zion[O16-1], aion[O16-1],
             sc1a,sc1adt,sc1add);
 
-    dratedt(C12_O16) = dratedt(C12_O16) * sc1a + rate(C12_O16) * sc1adt;
-    rate(C12_O16)    = rate(C12_O16) * sc1a;
+    dratedt(C12_O16_to_Mg24_He4_forward) = dratedt(C12_O16_to_Mg24_He4_forward) * sc1a + rate(C12_O16_to_Mg24_He4_forward) * sc1adt;
+    rate(C12_O16_to_Mg24_He4_forward)    = rate(C12_O16_to_Mg24_He4_forward) * sc1a;
+
+    // Equal probability branching ratio between (Mg24 + He4) and (Si28) endpoints
+
+    rate(C12_O16_to_Mg24_He4_forward) *= 0.5;
+    dratedt(C12_O16_to_Mg24_He4_forward) *= 0.5;
+
+    rate(C12_O16_to_Si28_forward) = rate(C12_O16_to_Mg24_He4_forward);
+    dratedt(C12_O16_to_Si28_forward) = dratedt(C12_O16_to_Mg24_He4_forward);
 
     // o16 + o16
     jscr++;
@@ -316,8 +329,8 @@ void screen_iso7(const Real btemp, const Real bden,
             zion[O16-1], aion[O16-1], zion[O16-1], aion[O16-1],
             sc1a,sc1adt,sc1add);
 
-    dratedt(O16_O16) = dratedt(O16_O16) * sc1a + rate(O16_O16) * sc1adt;
-    rate(O16_O16)    = rate(O16_O16) * sc1a;
+    dratedt(O16_O16_to_Si28_He4_forward) = dratedt(O16_O16_to_Si28_He4_forward) * sc1a + rate(O16_O16_to_Si28_He4_forward) * sc1adt;
+    rate(O16_O16_to_Si28_He4_forward)    = rate(O16_O16_to_Si28_He4_forward) * sc1a;
 
     // o16 to ne20
     jscr++;


### PR DESCRIPTION
There are two parts to this change, which concentrate on the heavy-ion reactions (C12+C12, C12+O16, O16+O16).

1) Each of these is currently only written as a forward reaction, not a reverse reaction. However, the goal here is to refactor the rate infrastructure so that each rate automatically has forward and reverse components, rather than storing them as separate scalars as we do today. So we need to know what the reverse rate is, even though it's zero in this case. The reverse rates are added and just left as zero.

2) C12+O16 has two endpoints in this network, Mg24+He4 and Si28, and the two cases implicitly have equal probabilities. This is now made explicit by splitting this reaction into two rates, each of which is 0.5 * the old rate.

This change increases the number of rates in the network (although it still represents the same physics) and so slightly decreases the performance.