### PR TITLE
iso7 18/∞

### DIFF
--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -95,7 +95,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(He4, He4_He4_He4_to_C12_forward):
-            data.prefactor  = -1.0_rt;
+            data.prefactor  = -3.0_rt;
             data.specindex1 = He4;
             data.specindex2 = He4;
             data.specindex3 = He4;
@@ -174,7 +174,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(C12, He4_He4_He4_to_C12_forward):
-            data.prefactor  = 1.0_rt / 3.0_rt;
+            data.prefactor  = 1.0_rt;
             data.specindex1 = He4;
             data.specindex2 = He4;
             data.specindex3 = He4;
@@ -385,7 +385,7 @@ namespace RHS {
         switch (jac_rate<NumSpec, NumRates>(species1, species2, rateindex)) {
 
         case jac_rate<NumSpec, NumRates>(He4, He4, He4_He4_He4_to_C12_forward):
-            data.prefactor = -3.0_rt;
+            data.prefactor = -9.0_rt;
             data.specindex1 = He4;
             data.specindex2 = He4;
             break;
@@ -492,7 +492,7 @@ namespace RHS {
             break;
 
         case jac_rate<NumSpec, NumRates>(C12, He4, He4_He4_He4_to_C12_forward):
-            data.prefactor = 1.0_rt;
+            data.prefactor = 3.0_rt;
             data.specindex1 = He4;
             data.specindex2 = He4;
             break;

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -95,7 +95,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(He4, He4_He4_He4_to_C12_forward):
-            data.prefactor  = -0.5_rt;
+            data.prefactor  = -1.0_rt;
             data.specindex1 = He4;
             data.specindex2 = He4;
             data.specindex3 = He4;
@@ -113,7 +113,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(He4, C12_C12_to_Ne20_He4_forward):
-            data.prefactor  = 0.5_rt;
+            data.prefactor  = 1.0_rt;
             data.specindex1 = C12;
             data.specindex2 = C12;
             break;
@@ -125,7 +125,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(He4, O16_O16_to_Si28_He4_forward):
-            data.prefactor  = 0.5_rt;
+            data.prefactor  = 1.0_rt;
             data.specindex1 = O16;
             data.specindex2 = O16;
             break;
@@ -174,7 +174,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(C12, He4_He4_He4_to_C12_forward):
-            data.prefactor  = 1.0_rt / 6.0_rt;
+            data.prefactor  = 1.0_rt / 3.0_rt;
             data.specindex1 = He4;
             data.specindex2 = He4;
             data.specindex3 = He4;
@@ -197,7 +197,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(C12, C12_C12_to_Ne20_He4_forward):
-            data.prefactor  = -1.0_rt;
+            data.prefactor  = -2.0_rt;
             data.specindex1 = C12;
             data.specindex2 = C12;
             break;
@@ -238,7 +238,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(O16, O16_O16_to_Si28_He4_forward):
-            data.prefactor  = -1.0_rt;
+            data.prefactor  = -2.0_rt;
             data.specindex1 = O16;
             data.specindex2 = O16;
             break;
@@ -255,7 +255,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(Ne20, C12_C12_to_Ne20_He4_forward):
-            data.prefactor  = 0.5_rt;
+            data.prefactor  = 1.0_rt;
             data.specindex1 = C12;
             data.specindex2 = C12;
             break;
@@ -317,7 +317,7 @@ namespace RHS {
             break;
 
         case rhs_rate<NumRates>(Si28, O16_O16_to_Si28_He4_forward):
-            data.prefactor  = 0.5_rt;
+            data.prefactor  = 1.0_rt;
             data.specindex1 = O16;
             data.specindex2 = O16;
             break;
@@ -385,7 +385,7 @@ namespace RHS {
         switch (jac_rate<NumSpec, NumRates>(species1, species2, rateindex)) {
 
         case jac_rate<NumSpec, NumRates>(He4, He4, He4_He4_He4_to_C12_forward):
-            data.prefactor = -1.5_rt;
+            data.prefactor = -3.0_rt;
             data.specindex1 = He4;
             data.specindex2 = He4;
             break;
@@ -432,7 +432,7 @@ namespace RHS {
             break;
 
         case jac_rate<NumSpec, NumRates>(He4, C12, C12_C12_to_Ne20_He4_forward):
-            data.prefactor = 1.0_rt;
+            data.prefactor = 2.0_rt;
             data.specindex1 = C12;
             break;
 
@@ -451,7 +451,7 @@ namespace RHS {
             break;
 
         case jac_rate<NumSpec, NumRates>(He4, O16, O16_O16_to_Si28_He4_forward):
-            data.prefactor = 1.0_rt;
+            data.prefactor = 2.0_rt;
             data.specindex1 = O16;
             break;
 
@@ -492,7 +492,7 @@ namespace RHS {
             break;
 
         case jac_rate<NumSpec, NumRates>(C12, He4, He4_He4_He4_to_C12_forward):
-            data.prefactor = 0.5_rt;
+            data.prefactor = 1.0_rt;
             data.specindex1 = He4;
             data.specindex2 = He4;
             break;
@@ -512,7 +512,7 @@ namespace RHS {
             break;
 
         case jac_rate<NumSpec, NumRates>(C12, C12, C12_C12_to_Ne20_He4_forward):
-            data.prefactor = -2.0_rt;
+            data.prefactor = -4.0_rt;
             data.specindex1 = C12;
             break;
 
@@ -580,7 +580,7 @@ namespace RHS {
             break;
 
         case jac_rate<NumSpec, NumRates>(O16, O16, O16_O16_to_Si28_He4_forward):
-            data.prefactor = -2.0_rt;
+            data.prefactor = -4.0_rt;
             data.specindex1 = O16;
             break;
 
@@ -604,7 +604,7 @@ namespace RHS {
             break;
 
         case jac_rate<NumSpec, NumRates>(Ne20, C12, C12_C12_to_Ne20_He4_forward):
-            data.prefactor = 1.0_rt;
+            data.prefactor = 2.0_rt;
             data.specindex1 = C12;
             break;
 
@@ -687,7 +687,7 @@ namespace RHS {
             break;
 
         case jac_rate<NumSpec, NumRates>(Si28, O16, O16_O16_to_Si28_He4_forward):
-            data.prefactor = 1.0_rt;
+            data.prefactor = 2.0_rt;
             data.specindex1 = O16;
             break;
 

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -288,6 +288,11 @@ void screen_iso7(const Real btemp, const Real bden,
     dratedt(He4_He4_He4_to_C12_forward) = dratedt(He4_He4_He4_to_C12_forward) * sc3a + rate(He4_He4_He4_to_C12_forward) * sc3adt;
     rate(He4_He4_He4_to_C12_forward)    = rate(He4_He4_He4_to_C12_forward) * sc3a;
 
+    // Identical particle factor (He4 + He4)
+
+    rate(He4_He4_He4_to_C12_forward)    *= 0.5_rt;
+    dratedt(He4_He4_He4_to_C12_forward) *= 0.5_rt;
+
     // c12 to o16
     jscr++;
     screen5(pstate,jscr,
@@ -305,6 +310,11 @@ void screen_iso7(const Real btemp, const Real bden,
 
     dratedt(C12_C12_to_Ne20_He4_forward) = dratedt(C12_C12_to_Ne20_He4_forward) * sc1a + rate(C12_C12_to_Ne20_He4_forward) * sc1adt;
     rate(C12_C12_to_Ne20_He4_forward)    = rate(C12_C12_to_Ne20_He4_forward) * sc1a;
+
+    // Identical particle factor (C12 + C12)
+
+    rate(C12_C12_to_Ne20_He4_forward)    *= 0.5_rt;
+    dratedt(C12_C12_to_Ne20_He4_forward) *= 0.5_rt;
 
     // c12 + o16
     jscr++;
@@ -331,6 +341,11 @@ void screen_iso7(const Real btemp, const Real bden,
 
     dratedt(O16_O16_to_Si28_He4_forward) = dratedt(O16_O16_to_Si28_He4_forward) * sc1a + rate(O16_O16_to_Si28_He4_forward) * sc1adt;
     rate(O16_O16_to_Si28_He4_forward)    = rate(O16_O16_to_Si28_He4_forward) * sc1a;
+
+    // Identical particle factor (O16 + O16)
+
+    rate(O16_O16_to_Si28_He4_forward)    *= 0.5_rt;
+    dratedt(O16_O16_to_Si28_He4_forward) *= 0.5_rt;
 
     // o16 to ne20
     jscr++;

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -288,10 +288,10 @@ void screen_iso7(const Real btemp, const Real bden,
     dratedt(He4_He4_He4_to_C12_forward) = dratedt(He4_He4_He4_to_C12_forward) * sc3a + rate(He4_He4_He4_to_C12_forward) * sc3adt;
     rate(He4_He4_He4_to_C12_forward)    = rate(He4_He4_He4_to_C12_forward) * sc3a;
 
-    // Identical particle factor (He4 + He4)
+    // Identical particle factor (He4 + He4 + He4)
 
-    rate(He4_He4_He4_to_C12_forward)    *= 0.5_rt;
-    dratedt(He4_He4_He4_to_C12_forward) *= 0.5_rt;
+    rate(He4_He4_He4_to_C12_forward)    *= 1.0_rt / 6.0_rt;
+    dratedt(He4_He4_He4_to_C12_forward) *= 1.0_rt / 6.0_rt;
 
     // c12 to o16
     jscr++;


### PR DESCRIPTION
Three reactions in iso7 include reactions of identical particles. At the moment, the factor of 1/2 implied by this is not included in the reaction rate, but rather applied in the RHS directly.

To continue the RHS generalization process we're doing, it will be useful if we don't have to worry about this factor, so this PR moves the term directly into the reaction rate, multiplying the RHS by the inverse factor.

For example, the C12 + C12 term currently looks like

```
dydt(He4)  = (1/2) * Y(C12) * Y(C12) * rate(ir1212)
dydt(C12)  =        -Y(C12) * Y(C12) * rate(ir1212)
dydt(Ne20) = (1/2) * Y(C12) * Y(C12) * rate(ir1212)
```

and it will now look like

```
rate(ir1212) *= 1/2;

dydt(He4)  =      Y(C12) * Y(C12) * rate(ir1212)
dydt(C12)  = -2 * Y(C12) * Y(C12) * rate(ir1212)
dydt(Ne20) =      Y(C12) * Y(C12) * rate(ir1212)
```

This makes it very clear that the reaction produces one He4 nucleus and one Ne20 nucleus, and consumes two C12 nuclei. This rewrite is practically useful (see below), and if we choose to think of it this way, it's generally fair to consider the identical particle factor as a modification of the cross-section, instead of a term that appears explicitly in the RHS.

The step that this helps enables next is to generalize the RHS term further. We want to write that the forward rate `ir1212` is a special case of the reaction class A + B -> C + D, which is one of the classes we can apply automated reaction infrastructure to (see e.g. the appendix of [this paper](https://iopscience.iop.org/article/10.1088/1749-4699/6/1/015003/pdf)). In our implementation of the automated infrastructure, all we need to do is provide the species indices of A, B, C, and D, as well as the reaction rate, and the infrastructure then adds the relevant contributions to the RHS for each species. The factor of 2 would automatically be captured as a result of A and B being the same.