### PR TITLE
Re-enable call_eos_in_rhs option

### DIFF
--- a/integration/ForwardEuler/actual_integrator.H
+++ b/integration/ForwardEuler/actual_integrator.H
@@ -68,7 +68,9 @@ void clean_state (burn_t& state)
 
     // Evaluate the EOS to get T from e.
 
-    eos(eos_input_re, state);
+    if (call_eos_in_rhs) {
+        eos(eos_input_re, state);
+    }
 
     // Ensure that the temperature always stays within reasonable limits.
 

--- a/integration/QSS/actual_integrator.H
+++ b/integration/QSS/actual_integrator.H
@@ -19,7 +19,9 @@ void clean_state (burn_t& state)
 
     // Evaluate the EOS to get T from e.
 
-    eos(eos_input_re, state);
+    if (call_eos_in_rhs) {
+        eos(eos_input_re, state);
+    }
 
     // Ensure that the temperature always stays within reasonable limits.
 

--- a/integration/VODE/vode_type_strang.H
+++ b/integration/VODE/vode_type_strang.H
@@ -97,7 +97,9 @@ void update_thermodynamics (burn_t& state, const dvode_t& vode_state)
 
     // Get T from e (also updates composition quantities).
 
-    eos(eos_input_re, state);
+    if (call_eos_in_rhs) {
+        eos(eos_input_re, state);
+    }
 }
 
 #endif

--- a/integration/_parameters
+++ b/integration/_parameters
@@ -6,15 +6,11 @@
 # or a constant pressure (do_constant_volume_burn = F)?
 do_constant_volume_burn  logical   .true.
 
-# Do we call the EOS each time we enter the EOS?  This is expensive,
-# but more accurate.  Otherwise, we instead call the EOS at the start
-# of the integration and freeze the thermodynamics throughout the RHS
-# evalulation.  This only affects the temperature integration (which
-# is the input to the rate evaluation). In particular, since we
-# calculate the composition factors either way, this determines
-# whether we're updating the thermodynamic derivatives and other
-# quantities (cp and cv) as we go.
-call_eos_in_rhs          logical   .false.
+# Normally we update the temperature during a burn to be consistent with
+# the current internal energy. This is done with an EOS call, which can
+# be turned off if desired. This will freeze the temperature and specific heat
+# to the values at the beginning of the burn, which is inaccurate but cheaper.
+call_eos_in_rhs          logical   .true.
 
 # If we want to call the EOS in general, but don't want to overdo it,
 # we can set a fraction ``dT_crit`` such that we only do the EOS call


### PR DESCRIPTION
For now, this is done for Strang only.

Note: in principle this could break a setup that was previously explicitly setting `call_eos_in_rhs = F`. However, I think this is pretty unlikely to have happened, I only found one setup (Castro xrb_mixed) that is doing it.