### PR TITLE
Move mion and bion to generic network namespace

### DIFF
--- a/networks/aprox13/actual_network.H
+++ b/networks/aprox13/actual_network.H
@@ -35,7 +35,7 @@ namespace C
 
 const std::string network_name = "aprox13";
 
-namespace aprox13
+namespace network
 {
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;

--- a/networks/aprox13/actual_network_data.cpp
+++ b/networks/aprox13/actual_network_data.cpp
@@ -1,7 +1,7 @@
 #include <AMReX_Vector.H>
 #include <actual_network.H>
 
-namespace aprox13
+namespace network
 {
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
@@ -10,7 +10,7 @@ namespace aprox13
 void actual_network_init()
 {
     using namespace Species;
-    using namespace aprox13;
+    using namespace network;
 
     // Set the binding energy of the element
     bion(He4)  =  28.29603e0_rt;

--- a/networks/aprox13/actual_rhs.H
+++ b/networks/aprox13/actual_rhs.H
@@ -1752,7 +1752,7 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ener_gener_rate(T const& dydt, Real& enuc)
 {
 
-    using namespace aprox13;
+    using namespace network;
 
     // Computes the instantaneous energy generation rate
 
@@ -1773,7 +1773,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 Real ener_rhs (const burn_t& state, Array1D<Real, 1, NumSpec>& dydt)
 {
-    using namespace aprox13;
+    using namespace network;
 
     Real Xdot = 0.0_rt;
 

--- a/networks/aprox19/actual_network.H
+++ b/networks/aprox19/actual_network.H
@@ -38,7 +38,7 @@ const std::string network_name = "aprox19";
 const std::string network_name = "aprox19_nse";
 #endif
 
-namespace aprox19
+namespace network
 {
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;

--- a/networks/aprox19/actual_network_data.cpp
+++ b/networks/aprox19/actual_network_data.cpp
@@ -4,7 +4,7 @@
 #include <nse.H>
 #endif
 
-namespace aprox19
+namespace network
 {
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
@@ -30,7 +30,7 @@ namespace table
 void actual_network_init()
 {
     using namespace Species;
-    using namespace aprox19;
+    using namespace network;
 
 #ifdef NSE_TABLE
     init_nse();

--- a/networks/aprox19/actual_rhs.H
+++ b/networks/aprox19/actual_rhs.H
@@ -2606,7 +2606,7 @@ template<class T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ener_gener_rate (T const& dydt, Real& enuc)
 {
-    using namespace aprox19;
+    using namespace network;
 
     // This is basically e = m c**2
 

--- a/networks/aprox19/nse.H
+++ b/networks/aprox19/nse.H
@@ -139,7 +139,7 @@ void set_nse_aux_from_X(state_t& state) {
   for (int n = 0; n < NumSpec; n++) {
     state.aux[iye] += state.xn[n] * zion[n] * aion_inv[n];
     state.aux[iabar] += state.xn[n] * aion_inv[n];
-    state.aux[ibea] += state.xn[n] * aprox19::bion(n+1) * aion_inv[n];
+    state.aux[ibea] += state.xn[n] * network::bion(n+1) * aion_inv[n];
   }
   state.aux[iabar] = 1.0_rt/state.aux[iabar];
 

--- a/networks/aprox21/actual_network.H
+++ b/networks/aprox21/actual_network.H
@@ -34,7 +34,7 @@ namespace C
 
 const std::string network_name = "aprox21";
 
-namespace aprox21
+namespace network
 {
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;

--- a/networks/aprox21/actual_network_data.cpp
+++ b/networks/aprox21/actual_network_data.cpp
@@ -1,7 +1,7 @@
 #include <AMReX_Vector.H>
 #include <actual_network.H>
 
-namespace aprox21
+namespace network
 {
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
@@ -10,7 +10,7 @@ namespace aprox21
 void actual_network_init()
 {
     using namespace Species;
-    using namespace aprox21;
+    using namespace network;
 
     // Set the binding energy of the element
     bion(H1)   = 0.0e0_rt;

--- a/networks/aprox21/actual_rhs.H
+++ b/networks/aprox21/actual_rhs.H
@@ -2752,7 +2752,7 @@ template<class T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ener_gener_rate (T const& dydt, Real& enuc)
 {
-    using namespace aprox21;
+    using namespace network;
 
     // This is basically e = m c**2
 

--- a/networks/ignition_simple/actual_network.H
+++ b/networks/ignition_simple/actual_network.H
@@ -31,7 +31,7 @@ namespace C
 
 const std::string network_name = "ignition_simple";
 
-namespace ignition_simple
+namespace network
 {
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;

--- a/networks/ignition_simple/actual_network_data.cpp
+++ b/networks/ignition_simple/actual_network_data.cpp
@@ -1,6 +1,6 @@
 #include <actual_network.H>
 
-namespace ignition_simple
+namespace network
 {
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
@@ -9,7 +9,7 @@ namespace ignition_simple
 void actual_network_init()
 {
     using namespace Species;
-    using namespace ignition_simple;
+    using namespace network;
 
     // Binding energies per nucleus in MeV
     bion(C12)  = 92.16294e0_rt;

--- a/networks/ignition_simple/actual_rhs.H
+++ b/networks/ignition_simple/actual_rhs.H
@@ -69,7 +69,7 @@ void ener_gener_rate (const Real& dydt, Real& enuc)
 {
     using namespace Species;
     using namespace C::Legacy;
-    using namespace ignition_simple;
+    using namespace network;
 
     // This is basically e = m c**2
 

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -35,7 +35,7 @@ namespace C
 
 const std::string network_name = "iso7";
 
-namespace iso7
+namespace network
 {
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;

--- a/networks/iso7/actual_network_data.cpp
+++ b/networks/iso7/actual_network_data.cpp
@@ -1,7 +1,7 @@
 #include <AMReX_Vector.H>
 #include <actual_network.H>
 
-namespace iso7
+namespace network
 {
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
@@ -11,7 +11,7 @@ namespace iso7
 void actual_network_init()
 {
     using namespace Species;
-    using namespace iso7;
+    using namespace network;
 
     // Set the binding energy of the element
     bion(He4)  = 28.29603e0_rt;

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -653,7 +653,7 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ener_gener_rate(T const& dydt, Real& enuc)
 {
 
-    using namespace iso7;
+    using namespace network;
 
     // Computes the instantaneous energy generation rate
 
@@ -675,7 +675,7 @@ void ener_gener_rate(T const& dydt, Real& enuc)
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 Real ener_rhs(const burn_t& state, Array1D<Real, 1, NumSpec>& dydt)
 {
-    using namespace iso7;
+    using namespace network;
 
     Real Xdot = 0.0_rt;
 

--- a/networks/rprox/actual_network.H
+++ b/networks/rprox/actual_network.H
@@ -25,7 +25,7 @@ namespace C
 
 const std::string network_name = "rprox";
 
-namespace rprox
+namespace network
 {
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> ebin;
 }

--- a/networks/rprox/actual_network_data.cpp
+++ b/networks/rprox/actual_network_data.cpp
@@ -1,7 +1,7 @@
 #include <AMReX_Vector.H>
 #include <actual_network.H>
 
-namespace rprox
+namespace network
 {
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> ebin;
 }
@@ -9,7 +9,7 @@ namespace rprox
 void actual_network_init()
 {
     using namespace Species;
-    using namespace rprox;
+    using namespace network;
 
     // Our convention is that binding energy is negative.  The
     // following are the binding energies in MeV.

--- a/networks/rprox/actual_rhs.H
+++ b/networks/rprox/actual_rhs.H
@@ -421,7 +421,7 @@ void ener_gener_rate(T& dydt, Real& enuc)
     enuc = 0.0_rt;
 
     for (int i = 1; i <= NumSpec; ++i) {
-        enuc -= dydt(i) * aion[i-1] * rprox::ebin(i);
+        enuc -= dydt(i) * aion[i-1] * network::ebin(i);
     }
 }
 

--- a/networks/triple_alpha_plus_cago/actual_network.H
+++ b/networks/triple_alpha_plus_cago/actual_network.H
@@ -14,7 +14,7 @@ void actual_network_init();
 
 const std::string network_name = "triple_alpha_plus_cago";
 
-namespace triple_alpha_plus_cago
+namespace network
 {
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
 }

--- a/networks/triple_alpha_plus_cago/actual_network_data.cpp
+++ b/networks/triple_alpha_plus_cago/actual_network_data.cpp
@@ -1,7 +1,7 @@
 #include <AMReX_Vector.H>
 #include <actual_network.H>
 
-namespace triple_alpha_plus_cago
+namespace network
 {
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> bion;
 }
@@ -9,7 +9,7 @@ namespace triple_alpha_plus_cago
 void actual_network_init ()
 {
     using namespace Species;
-    using namespace triple_alpha_plus_cago;
+    using namespace network;
 
     // our convention is that binding energy is negative.  The following are
     // the binding energies per unit mass (erg / g) obtained by converting

--- a/networks/triple_alpha_plus_cago/actual_rhs.H
+++ b/networks/triple_alpha_plus_cago/actual_rhs.H
@@ -265,7 +265,7 @@ template<class T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void ener_gener_rate (T& dydt, Real& enuc)
 {
-    using namespace triple_alpha_plus_cago;
+    using namespace network;
 
     enuc = 0.0_rt;
 


### PR DESCRIPTION
This will be helpful later for building a generic energy RHS function that just assumes the network supplies mion, so we can reduce redundancy.