### PR TITLE
cap the timestep so we don't go beyond tout

### DIFF
--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -223,15 +223,19 @@ int dvode (burn_t& state, dvode_t& vstate)
        // Otherwise, we've had a successful return from the integrator (kflag = 0).
        // Test for our stopping condition.
 
-       // make sure that our step doesn't take us past tout
-       // this is essentially the logic that was in vode originally
-       // for itask = 4
-       Real tnext = vstate.tn + vstate.HNEW * (1.0_rt + 4.0_rt * UROUND);
-       if ((tnext - vstate.tout) * vstate.H > 0.0_rt) {
-           vstate.H = (vstate.tout - vstate.tn)*(1.0_rt - 4.0_rt * UROUND);
-       }
 
-       if ((vstate.tn - vstate.tout) * vstate.H < 0.0_rt) continue;
+       if ((vstate.tn - vstate.tout) * vstate.H < 0.0_rt) {
+
+           // make sure that our step doesn't take us past tout
+           // this is essentially the logic that was in vode originally
+           // for itask = 4
+           Real tnext = vstate.tn + vstate.HNEW * (1.0_rt + 4.0_rt * UROUND);
+           if ((tnext - vstate.tout) * vstate.H > 0.0_rt) {
+               vstate.H = (vstate.tout - vstate.tn)*(1.0_rt - 4.0_rt * UROUND);
+           }
+
+           continue;
+       }
 
        // If TOUT has been reached, interpolate.
 

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -72,6 +72,10 @@ int dvode (burn_t& state, dvode_t& vstate)
     // Call DVHIN to set initial step size H0 to be attempted.
     H0 = 0.0_rt;
     dvhin(state, vstate, H0, NITER, IER);
+
+    // don't let the step be larger than tout / 2
+    H0 = amrex::min(H0, 0.5_rt * vstate.tout);
+
     vstate.NFE += NITER;
 
     if (IER != 0) {
@@ -218,6 +222,14 @@ int dvode (burn_t& state, dvode_t& vstate)
 
        // Otherwise, we've had a successful return from the integrator (kflag = 0).
        // Test for our stopping condition.
+
+       // make sure that our step doesn't take us past tout
+       // this is essentially the logic that was in vode originally
+       // for itask = 4
+       Real tnext = vstate.tn + vstate.HNEW * (1.0_rt + 4.0_rt * UROUND);
+       if ((tnext - vstate.tout) * vstate.H > 0.0_rt) {
+           vstate.H = (vstate.tout - vstate.tn)*(1.0_rt - 4.0_rt * UROUND);
+       }
 
        if ((vstate.tn - vstate.tout) * vstate.H < 0.0_rt) continue;
 

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -111,6 +111,7 @@ int dvode (burn_t& state, dvode_t& vstate)
     vstate.NEWH = 0;
     vstate.NSLP = 0;
     vstate.IPUP = 1;
+    vstate.KUTH = 0;
 
     bool skip_loop_start = true;
 
@@ -232,6 +233,7 @@ int dvode (burn_t& state, dvode_t& vstate)
            Real tnext = vstate.tn + vstate.HNEW * (1.0_rt + 4.0_rt * UROUND);
            if ((tnext - vstate.tout) * vstate.H > 0.0_rt) {
                vstate.H = (vstate.tout - vstate.tn)*(1.0_rt - 4.0_rt * UROUND);
+               vstate.KUTH = 1;
            }
 
            continue;

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -95,6 +95,11 @@ int dvstep (burn_t& state, dvode_t& vstate)
     // If a change of order was dictated on the previous step, then
     // it is done here and appropriate adjustments in the history are made.
 
+    if (vstate.KUTH == 1) {
+        vstate.ETA = amrex::min(vstate.ETA, vstate.H/vstate.HSCAL);
+        vstate.NEWH = 1;
+    }
+
     if (vstate.NEWH != 0) {
 
         if (vstate.NEWQ < vstate.NQ) {

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -62,6 +62,10 @@ struct dvode_t
     int NEWH, NEWQ, NQ, NQNYH, NQWAIT, NSLJ;
     int NSLP;
 
+    // input flag to dvstep showing whether H was reduced by
+    // the driver
+    int KUTH;
+
     amrex::Array1D<Real, 1, VODE_LMAX> el;
     amrex::Array1D<Real, 1, VODE_LMAX> tau;
     amrex::Array1D<Real, 1, 5> tq;


### PR DESCRIPTION
this attempts to do the logic that was in the original VODE (itask = 4) to prevent the timestep from taking us beyond tout.