### PR TITLE
change the NSE-SDC update

### DIFF
--- a/networks/aprox19/nse.H
+++ b/networks/aprox19/nse.H
@@ -353,9 +353,9 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
 
         // update the aux source terms
 
-        aux_source[iye] = 0.5_rt * (rho_old * dyedt_old + eos_state.rho * dyedt);
-        aux_source[iabar] = (eos_state.rho * abar_out - state.y[SFX+iabar]) / dt;
-        aux_source[ibea] = (eos_state.rho * dq_out - state.y[SFX+ibea]) / dt;   // this is actually not used
+        aux_source[iye] = 0.5_rt * rho_half * (dyedt_old + dyedt);
+        aux_source[iabar] = rho_half * (abar_out - state.y[SFX+iabar] / rho_old) / dt;
+        aux_source[ibea] = 0.0;   // this is actually not used in the EOS
 
     }
 

--- a/networks/aprox19/nse.H
+++ b/networks/aprox19/nse.H
@@ -291,6 +291,8 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
     nse_interp(state.T, state.rho, ye_in,
                abar_out, dq_out, dyedt, X);
 
+    Real dyedt_old = dyedt;
+
     // density and momentum have no reactive sources
     Real rho_old = state.y[SRHO];
     Real rho_bea_old = state.y[SFX+ibea];
@@ -300,42 +302,43 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
     state.y[SMY] += dt * state.ydot_a[SMY];
     state.y[SMZ] += dt * state.ydot_a[SMZ];
 
-    // predict the U^{n+1,*} state with only the Ye reaction term and advection to dt/2
+    // predict the U^{n+1,*} state with only estimates of the aux
+    // reaction terms and advection to dt
 
     eos_re_t eos_state;
+    eos_state.T = 1.e6_rt; // initial guess
 
     // initial aux_sources
     Real aux_source[NumAux] = {0.0_rt};
 
     aux_source[iye] = rho_old * dyedt;
 
-    Real rho_half;
-    Real rhoe_half;
-    Real rho_aux_half[NumAux];
+    Real rhoe_new;
+    Real rho_aux_new[NumAux];
     Real dq;
-    Real enucdot;
+    Real enucdot = 0.0_rt;
 
-    for (int iter = 0; iter < 2; iter++) {
+    Real rho_half = 0.5_rt * (rho_old + state.y[SRHO]);
 
-        rho_half = rho_old + 0.5_rt * dt * state.ydot_a[SRHO];
-        rhoe_half = state.y[SEINT] + 0.5_rt * dt * state.ydot_a[SEINT];;
+    for (int iter = 0; iter < 3; iter++) {
+
+        rhoe_new = state.y[SEINT] + dt * state.ydot_a[SEINT] + dt * rho_half * enucdot;
 
         for (int n = 0; n < NumAux; n++) {
-            rho_aux_half[n] = state.y[SFX+n] + 0.5_rt * dt * state.ydot_a[SFX+n] + 0.5_rt * dt * aux_source[n];
+            rho_aux_new[n] = state.y[SFX+n] + dt * state.ydot_a[SFX+n] + dt * aux_source[n];
         }
 
         // call the EOS to get the updated T*
 
-        eos_state.rho = rho_half;
-        eos_state.T = 1.e6_rt;   // initial guess
-        eos_state.e = rhoe_half / rho_half;
+        eos_state.rho = state.y[SRHO];
+        eos_state.e = rhoe_new / state.y[SRHO];
         for (int n = 0; n < NumAux; n++) {
-            eos_state.aux[n] = rho_aux_half[n] / rho_half;
+            eos_state.aux[n] = rho_aux_new[n] / state.y[SRHO];
         }
 
         eos(eos_input_re, eos_state);
 
-        // call the NSE table using the * state to get the t^{n+1/2} source estimates
+        // call the NSE table using the * state to get the t^{n+1} source estimates
 
         nse_interp(eos_state.T, eos_state.rho, eos_state.aux[iye],
                    abar_out, dq_out, dyedt, X);
@@ -346,48 +349,20 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
         dq = dq_out - rho_bea_old/rho_old;
 
         // convert the energy to erg / cm**3
-        enucdot  = dq * C::MeV2eV * C::ev2erg * C::n_A / (0.5_rt * dt);
+        enucdot  = dq * C::MeV2eV * C::ev2erg * C::n_A / dt;
 
         // update the aux source terms
 
-        aux_source[iye] = rho_half * dyedt;
-        aux_source[iabar] = (eos_state.rho * abar_out - state.y[SFX+iabar]) / (0.5_rt * dt);
-        aux_source[ibea] = (eos_state.rho * dq_out - state.y[SFX+ibea]) / (0.5_rt * dt);
+        aux_source[iye] = 0.5_rt * (rho_old * dyedt_old + eos_state.rho * dyedt);
+        aux_source[iabar] = (eos_state.rho * abar_out - state.y[SFX+iabar]) / dt;
+        aux_source[ibea] = (eos_state.rho * dq_out - state.y[SFX+ibea]) / dt;
 
     }
 
-    // now redo the update, starting from time n and advance to n+1 using these new sources
-
-    Real rhoe_new = state.y[SEINT] + dt * state.ydot_a[SEINT] + dt * rho_half * enucdot;
-
-    Real rho_aux_new[NumAux];
-
-    for (int n = 0; n < NumAux; n++) {
-        rho_aux_new[n] = state.y[SFX+n] + dt * state.ydot_a[SFX+n] + dt * aux_source[n];
-    }
-
-    // call the EOS to get the updated T*
-
-    eos_state.rho = state.y[SRHO];   // SRHO is rho^{n+1} here
-    eos_state.e = rhoe_new / state.y[SRHO];
-    for (int n = 0; n < NumAux; n++) {
-        eos_state.aux[n] = rho_aux_new[n] / state.y[SRHO];
-    }
-
-    eos(eos_input_re, eos_state);
-
-    // call the NSE table using the new state
-
-    nse_interp(eos_state.T, eos_state.rho, eos_state.aux[iye],
-               abar_out, dq_out, dyedt, X);
-
-    // compute the energy release
-
-    // this is MeV / nucleon * g / cm**3
-    dq = dq_out - rho_bea_old/rho_old;
+    // now update the aux quantities
 
     // convert the energy to erg / cm**3
-    Real enuc  = dq * C::MeV2eV * C::ev2erg * C::n_A;
+    Real enuc  = enucdot * dt;
 
 
     // the new mass fractions are just those that come from the table

--- a/networks/aprox19/nse.H
+++ b/networks/aprox19/nse.H
@@ -355,15 +355,11 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
 
         aux_source[iye] = 0.5_rt * (rho_old * dyedt_old + eos_state.rho * dyedt);
         aux_source[iabar] = (eos_state.rho * abar_out - state.y[SFX+iabar]) / dt;
-        aux_source[ibea] = (eos_state.rho * dq_out - state.y[SFX+ibea]) / dt;
+        aux_source[ibea] = (eos_state.rho * dq_out - state.y[SFX+ibea]) / dt;   // this is actually not used
 
     }
 
     // now update the aux quantities
-
-    // convert the energy to erg / cm**3
-    Real enuc  = enucdot * dt;
-
 
     // the new mass fractions are just those that come from the table
 
@@ -381,8 +377,8 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
 
     // update the total and internal energy now
 
-    state.y[SEINT] += dt * state.ydot_a[SEINT] + rho_half * enuc;
-    state.y[SEDEN] += dt * state.ydot_a[SEDEN] + rho_half * enuc;
+    state.y[SEINT] += dt * state.ydot_a[SEINT] + dt * rho_half * enucdot;
+    state.y[SEDEN] += dt * state.ydot_a[SEDEN] + dt * rho_half * enucdot;
 
 }
 

--- a/networks/aprox19/nse.H
+++ b/networks/aprox19/nse.H
@@ -300,57 +300,67 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
     state.y[SMY] += dt * state.ydot_a[SMY];
     state.y[SMZ] += dt * state.ydot_a[SMZ];
 
-    // predict the U* state with only the Ye reaction term and advection to dt/2
-
-    Real rho_half = rho_old + 0.5_rt * dt * state.ydot_a[SRHO];
-    Real rhoe_half = state.y[SEINT] + 0.5_rt * dt * state.ydot_a[SEINT];;
-
-    Real rho_aux_new[NumAux];
-    for (int n = 0; n < NumAux; n++) {
-        rho_aux_new[n] = state.y[SFX+n] + 0.5_rt * dt * state.ydot_a[SFX+n];
-    }
-
-    // override the source for Ye
-
-    rho_aux_new[iye] = state.y[SFX+iye] + 0.5_rt * dt * state.ydot_a[SFX+iye] + 0.5_rt * dt * rho_old * dyedt;
-
-    // call the EOS to get the updated T*
+    // predict the U^{n+1,*} state with only the Ye reaction term and advection to dt/2
 
     eos_re_t eos_state;
 
-    eos_state.rho = rho_half;
-    eos_state.T = 1.e6_rt;   // initial guess
-    eos_state.e = rhoe_half / rho_half;
-    for (int n = 0; n < NumAux; n++) {
-        eos_state.aux[n] = rho_aux_new[n] / rho_half;
+    // initial aux_sources
+    Real aux_source[NumAux] = {0.0_rt};
+
+    aux_source[iye] = rho_old * dyedt;
+
+    Real rho_half;
+    Real rhoe_half;
+    Real rho_aux_half[NumAux];
+    Real dq;
+    Real enucdot;
+
+    for (int iter = 0; iter < 2; iter++) {
+
+        rho_half = rho_old + 0.5_rt * dt * state.ydot_a[SRHO];
+        rhoe_half = state.y[SEINT] + 0.5_rt * dt * state.ydot_a[SEINT];;
+
+        for (int n = 0; n < NumAux; n++) {
+            rho_aux_half[n] = state.y[SFX+n] + 0.5_rt * dt * state.ydot_a[SFX+n] + 0.5_rt * dt * aux_source[n];
+        }
+
+        // call the EOS to get the updated T*
+
+        eos_state.rho = rho_half;
+        eos_state.T = 1.e6_rt;   // initial guess
+        eos_state.e = rhoe_half / rho_half;
+        for (int n = 0; n < NumAux; n++) {
+            eos_state.aux[n] = rho_aux_half[n] / rho_half;
+        }
+
+        eos(eos_input_re, eos_state);
+
+        // call the NSE table using the * state to get the t^{n+1/2} source estimates
+
+        nse_interp(eos_state.T, eos_state.rho, eos_state.aux[iye],
+                   abar_out, dq_out, dyedt, X);
+
+        // compute the energy release
+
+        // this is MeV / nucleon * g / cm**3
+        dq = dq_out - rho_bea_old/rho_old;
+
+        // convert the energy to erg / cm**3
+        enucdot  = dq * C::MeV2eV * C::ev2erg * C::n_A / (0.5_rt * dt);
+
+        // update the aux source terms
+
+        aux_source[iye] = rho_half * dyedt;
+        aux_source[iabar] = (eos_state.rho * abar_out - state.y[SFX+iabar]) / (0.5_rt * dt);
+        aux_source[ibea] = (eos_state.rho * dq_out - state.y[SFX+ibea]) / (0.5_rt * dt);
+
     }
-
-    eos(eos_input_re, eos_state);
-
-    // call the NSE table using the * state to get the t^{n+1/2} source estimates
-
-    nse_interp(eos_state.T, eos_state.rho, eos_state.aux[iye],
-               abar_out, dq_out, dyedt, X);
-
-    // compute the energy release
-
-    // this is MeV / nucleon * g / cm**3
-    Real dq = dq_out - rho_bea_old/rho_old;
-
-    // convert the energy to erg / cm**3
-    Real enucdot  = dq * C::MeV2eV * C::ev2erg * C::n_A / (0.5_rt * dt);
-
-    // compute the aux source terms
-    Real aux_source[NumAux];
-
-    // construct the final U^{n+1}
-    aux_source[iye] = rho_half * dyedt;
-    aux_source[iabar] = (eos_state.rho * abar_out - state.y[SFX+iabar]) / (0.5_rt * dt);
-    aux_source[ibea] = (eos_state.rho * dq_out - state.y[SFX+ibea]) / (0.5_rt * dt);
 
     // now redo the update, starting from time n and advance to n+1 using these new sources
 
     Real rhoe_new = state.y[SEINT] + dt * state.ydot_a[SEINT] + dt * rho_half * enucdot;
+
+    Real rho_aux_new[NumAux];
 
     for (int n = 0; n < NumAux; n++) {
         rho_aux_new[n] = state.y[SFX+n] + dt * state.ydot_a[SFX+n] + dt * aux_source[n];

--- a/networks/aprox19/nse.H
+++ b/networks/aprox19/nse.H
@@ -300,38 +300,34 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
     state.y[SMY] += dt * state.ydot_a[SMY];
     state.y[SMZ] += dt * state.ydot_a[SMZ];
 
-    // predict the U* state with advection and a lagged reactive term
-    // we actually only need to predict the energy and auxiliary data
-    // here, since that's all that is used (along with rho) for the
-    // equation of state.
+    // predict the U* state with only the Ye reaction term and advection to dt/2
 
-    Real rho_half = 0.5_rt * (rho_old + state.y[SRHO]);
-
-    Real rhoe_new = state.y[SEINT] + dt * state.ydot_a[SEINT] + dt * state.Iq_rhoe;
+    Real rho_half = rho_old + 0.5_rt * dt * state.ydot_a[SRHO];
+    Real rhoe_half = state.y[SEINT] + 0.5_rt * dt * state.ydot_a[SEINT];;
 
     Real rho_aux_new[NumAux];
     for (int n = 0; n < NumAux; n++) {
-        rho_aux_new[n] = state.y[SFX+n] + dt * state.ydot_a[SFX+n] + dt * rho_half * state.Iq_aux[n];
+        rho_aux_new[n] = state.y[SFX+n] + 0.5_rt * dt * state.ydot_a[SFX+n];
     }
 
     // override the source for Ye
 
-    rho_aux_new[iye] = state.y[SFX+iye] + dt * state.ydot_a[SFX+iye] + dt * rho_half * dyedt;
+    rho_aux_new[iye] = state.y[SFX+iye] + 0.5_rt * dt * state.ydot_a[SFX+iye] + 0.5_rt * dt * rho_old * dyedt;
 
     // call the EOS to get the updated T*
 
     eos_re_t eos_state;
 
-    eos_state.rho = state.y[SRHO];
+    eos_state.rho = rho_half;
     eos_state.T = 1.e6_rt;   // initial guess
-    eos_state.e = rhoe_new / state.y[SRHO];
+    eos_state.e = rhoe_half / rho_half;
     for (int n = 0; n < NumAux; n++) {
-        eos_state.aux[n] = rho_aux_new[n] / state.y[SRHO];
+        eos_state.aux[n] = rho_aux_new[n] / rho_half;
     }
 
     eos(eos_input_re, eos_state);
 
-    // call the NSE table using the * state to get the t^{n+1} composition data
+    // call the NSE table using the * state to get the t^{n+1/2} source estimates
 
     nse_interp(eos_state.T, eos_state.rho, eos_state.aux[iye],
                abar_out, dq_out, dyedt, X);
@@ -342,8 +338,47 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
     Real dq = dq_out - rho_bea_old/rho_old;
 
     // convert the energy to erg / cm**3
-    Real enuc = dq * C::MeV2eV * C::ev2erg * C::n_A;
+    Real enucdot  = dq * C::MeV2eV * C::ev2erg * C::n_A / (0.5_rt * dt);
+
+    // compute the aux source terms
+    Real aux_source[NumAux];
+
     // construct the final U^{n+1}
+    aux_source[iye] = rho_half * dyedt;
+    aux_source[iabar] = (eos_state.rho * abar_out - state.y[SFX+iabar]) / (0.5_rt * dt);
+    aux_source[ibea] = (eos_state.rho * dq_out - state.y[SFX+ibea]) / (0.5_rt * dt);
+
+    // now redo the update, starting from time n and advance to n+1 using these new sources
+
+    Real rhoe_new = state.y[SEINT] + dt * state.ydot_a[SEINT] + dt * rho_half * enucdot;
+
+    for (int n = 0; n < NumAux; n++) {
+        rho_aux_new[n] = state.y[SFX+n] + dt * state.ydot_a[SFX+n] + dt * aux_source[n];
+    }
+
+    // call the EOS to get the updated T*
+
+    eos_state.rho = state.y[SRHO];   // SRHO is rho^{n+1} here
+    eos_state.e = rhoe_new / state.y[SRHO];
+    for (int n = 0; n < NumAux; n++) {
+        eos_state.aux[n] = rho_aux_new[n] / state.y[SRHO];
+    }
+
+    eos(eos_input_re, eos_state);
+
+    // call the NSE table using the new state
+
+    nse_interp(eos_state.T, eos_state.rho, eos_state.aux[iye],
+               abar_out, dq_out, dyedt, X);
+
+    // compute the energy release
+
+    // this is MeV / nucleon * g / cm**3
+    dq = dq_out - rho_bea_old/rho_old;
+
+    // convert the energy to erg / cm**3
+    Real enuc  = dq * C::MeV2eV * C::ev2erg * C::n_A;
+
 
     // the new mass fractions are just those that come from the table
 


### PR DESCRIPTION
We now do the NSE SDC update by iteratively constructing the source terms to the aux data.  This no longer requires the lagged source terms from the previous iteration and seems to converge better than what we were doing.