### PR TITLE
store the integration time achieved in the burn_t

### DIFF
--- a/integration/ForwardEuler/actual_integrator.H
+++ b/integration/ForwardEuler/actual_integrator.H
@@ -173,6 +173,8 @@ void actual_integrator (burn_t& state, Real dt)
         state.success = false;
     }
 
+    state.time = t;
+
 #ifndef AMREX_USE_CUDA
     if (burner_verbose) {
         // Print out some integration statistics, if desired.

--- a/integration/QSS/actual_integrator.H
+++ b/integration/QSS/actual_integrator.H
@@ -474,6 +474,8 @@ void actual_integrator (burn_t& state, Real dt)
         state.success = false;
     }
 
+    state.time = t;
+
 #ifndef AMREX_USE_CUDA
     if (burner_verbose) {
         // Print out some integration statistics, if desired.

--- a/integration/VODE/vode_type_simplified_sdc.H
+++ b/integration/VODE/vode_type_simplified_sdc.H
@@ -260,6 +260,8 @@ void vode_to_burn(const Real time, dvode_t& vode_state, burn_t& state)
     // this makes burn_t represent the current integration state.  The
     // main thing this really does is compute the current temperature
 
+    state.time = time;
+
     for (int n = 0; n < SVAR_EVOLVE; n++) {
         // note vode_state uses 1-based indexing
         state.y[n] = vode_state.y(n+1);

--- a/integration/VODE/vode_type_strang.H
+++ b/integration/VODE/vode_type_strang.H
@@ -12,6 +12,8 @@ void vode_to_burn (const dvode_t& vode_state, burn_t& state)
     }
 
     state.e = vode_state.y(net_ienuc);
+
+    state.time = vode_state.t;
 }
 
 

--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -77,6 +77,10 @@ typedef ArrayUtil::MathArray2D<1, neqs, 1, neqs> JacNetArray2D;
 struct burn_t
 {
 
+  // on exit, this will be set to the integration time we achieved
+
+  Real time;
+
   // this first group are the quantities the network RHS uses
 
   Real rho;


### PR DESCRIPTION
this can be used to recover from failed burns, e.g., the NSE bailout