### PR TITLE
bail out of integration if we hit NSE

### DIFF
--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -130,25 +130,31 @@ void actual_integrator (burn_t& state, Real dt)
     // If we failed, print out the current state of the integration.
 
     if (!state.success) {
-#ifndef AMREX_USE_CUDA
-        std::cout << "ERROR: integration failed in net" << std::endl;
-        std::cout << "istate = " << istate << std::endl;
-        std::cout << "time = " << vode_state.t << std::endl;
-        std::cout << "dens = " << state.rho << std::endl;
-        std::cout << "temp start = " << T_in << std::endl;
-        std::cout << "xn start = ";
-        for (int n = 0; n < NumSpec; ++n) {
-            std::cout << xn_in[n] << " ";
-        }
-        std::cout << std::endl;
-        std::cout << "temp current = " << state.T << std::endl;
-        std::cout << "xn current = ";
-        for (int n = 0; n < NumSpec; ++n) {
-            std::cout << state.xn[n] << " ";
-        }
-        std::cout << std::endl;
-        std::cout << "energy generated = " << state.e << std::endl;
+        if (istate != -100) {
+#ifndef AMREX_USE_GPU
+            std::cout << "ERROR: integration failed in net" << std::endl;
+            std::cout << "istate = " << istate << std::endl;
+            std::cout << "time = " << vode_state.t << std::endl;
+            std::cout << "dens = " << state.rho << std::endl;
+            std::cout << "temp start = " << T_in << std::endl;
+            std::cout << "xn start = ";
+            for (int n = 0; n < NumSpec; ++n) {
+                std::cout << xn_in[n] << " ";
+            }
+            std::cout << std::endl;
+            std::cout << "temp current = " << state.T << std::endl;
+            std::cout << "xn current = ";
+            for (int n = 0; n < NumSpec; ++n) {
+                std::cout << state.xn[n] << " ";
+            }
+            std::cout << std::endl;
+            std::cout << "energy generated = " << state.e << std::endl;
 #endif
+        } else {
+#ifndef AMREX_USE_GPU
+            std::cout << "burn entered NSE during integration" << std::endl;
+#endif
+        }
     }
 
 }

--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -160,24 +160,30 @@ void actual_integrator (burn_t& state, Real dt)
     // If we failed, print out the current state of the integration.
 
     if (!state.success) {
-#ifndef AMREX_USE_CUDA
-        std::cout << "ERROR: integration failed in net" << std::endl;
-        std::cout << "istate = " << istate << std::endl;
-        std::cout << "time = " << vode_state.t << std::endl;
-        std::cout << "dens = " << state.rho << std::endl;
-        std::cout << "temp start = " << eos_state.T << std::endl;
-        std::cout << "xn start = ";
-        for (int n = 0; n < NumSpec; ++n) {
-            std::cout << eos_state.xn[n] << " ";
-        }
-        std::cout << std::endl;
-        std::cout << "temp current = " << state.T << std::endl;
-        std::cout << "xn current = ";
-        for (int n = 0; n < NumSpec; ++n) {
-            std::cout << state.xn[n] << " ";
-        }
-        std::cout << std::endl;
+        if (istate != -100) {
+#ifndef AMREX_USE_GPU
+            std::cout << "ERROR: integration failed in net" << std::endl;
+            std::cout << "istate = " << istate << std::endl;
+            std::cout << "time = " << vode_state.t << std::endl;
+            std::cout << "dens = " << state.rho << std::endl;
+            std::cout << "temp start = " << eos_state.T << std::endl;
+            std::cout << "xn start = ";
+            for (int n = 0; n < NumSpec; ++n) {
+                std::cout << eos_state.xn[n] << " ";
+            }
+            std::cout << std::endl;
+            std::cout << "temp current = " << state.T << std::endl;
+            std::cout << "xn current = ";
+            for (int n = 0; n < NumSpec; ++n) {
+                std::cout << state.xn[n] << " ";
+            }
+            std::cout << std::endl;
 #endif
+        } else {
+#ifndef AMREX_USE_GPU
+            std::cout << "burn entered NSE during integration" << std::endl;
+#endif
+        }
     }
 
 }

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -13,6 +13,9 @@
 #ifdef TRUE_SDC
 #include <vode_rhs_true_sdc.H>
 #endif
+#ifdef NSE_THERMO
+#include <nse.H>
+#endif
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int dvode (burn_t& state, dvode_t& vstate)
@@ -180,6 +183,7 @@ int dvode (burn_t& state, dvode_t& vstate)
 
        int kflag = dvstep(state, vstate);
 
+
        // Branch on KFLAG. KFLAG can be 0, -1, or -2.
 
        if (kflag == -1) {
@@ -214,6 +218,27 @@ int dvode (burn_t& state, dvode_t& vstate)
            return istate;
 
        }
+
+#ifdef NSE_THERMO
+       // check if, during the course of integration, we hit NSE, and
+       // if so, bail out we rely on the state being consistent after
+       // the call to dvstep, even if the step failed.
+
+       // first we need to make the burn_t in sync
+
+#ifdef STRANG
+       update_thermodynamics(state, vstate);
+#endif
+#ifdef SIMPLIFIED_SDC
+       vode_to_burn(vstate.tn, vstate, state);
+#endif
+
+       if (in_nse(state)) {
+           istate = -100;
+           return istate;
+       }
+#endif
+
 
        // Otherwise, we've had a successful return from the integrator (kflag = 0).
        // Test for our stopping condition.

--- a/interfaces/burner.H
+++ b/interfaces/burner.H
@@ -50,14 +50,15 @@ void burner (burn_t& state, Real dt)
         // burn.
 
         if (in_nse(state) && state.success == false) {
-            // ideally, we want to replace dt with just the dt
-            // remaining from the failed VODE burn.  This will append
-            // to state.e the amount additional energy released from
-            // adjusting to the new NSE state
+            // replace dt with just the remaining integration time
+            // left after the failure
+            Real dt_remaining = amrex::max(dt - state.time, 0.0_rt);
+            // This will append to state.e the amount additional
+            // energy released from adjusting to the new NSE state
 #ifdef SIMPLIFIED_SDC
-            sdc_nse_burn(state, dt);
+            sdc_nse_burn(state, dt_remaining);
 #else
-            nse_burn(state, dt);
+            nse_burn(state, dt_remaining);
 #endif
         }
     }


### PR DESCRIPTION
this changes the behavor of VODE to detect if we hit NSE during
the course of integration, and if so, we return a new error code
and we will catch that and finish the burn via NSE