### PR TITLE
we no longer use rtol_temp and atol_temp, so remove them

### DIFF
--- a/integration/_parameters
+++ b/integration/_parameters
@@ -1,4 +1,4 @@
-@namespace: integrator
+namespace: integrator
 
 # these are the parameters for the integration module
 
@@ -38,13 +38,11 @@ centered_diff_jac        logical   .false.
 burner_verbose           logical   .false.
 
 # Tolerances for the solver (relative and absolute), for the
-# species, temperature, and energy equations.
+# species and energy equations.
 rtol_spec                real      1.d-12
-rtol_temp                real      1.d-6
 rtol_enuc                real      1.d-6
 
 atol_spec                real      1.d-8
-atol_temp                real      1.d-6
 atol_enuc                real      1.d-6
 
 # If we fail to find a solution consistent with the tolerances,

--- a/integration/_parameters
+++ b/integration/_parameters
@@ -1,4 +1,4 @@
-namespace: integrator
+@namespace: integrator
 
 # these are the parameters for the integration module
 

--- a/networks/ECSN/inputs.burn_cell.VODE
+++ b/networks/ECSN/inputs.burn_cell.VODE
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /
 

--- a/networks/ignition_reaclib/C-burn-simple/inputs.burn_cell.VODE
+++ b/networks/ignition_reaclib/C-burn-simple/inputs.burn_cell.VODE
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /
 

--- a/networks/ignition_reaclib/C-test/inputs.burn_cell.VODE
+++ b/networks/ignition_reaclib/C-test/inputs.burn_cell.VODE
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /
 

--- a/networks/ignition_reaclib/URCA-simple/inputs.burn_cell.VODE
+++ b/networks/ignition_reaclib/URCA-simple/inputs.burn_cell.VODE
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /
 

--- a/networks/nova/inputs.burn_cell.VODE
+++ b/networks/nova/inputs.burn_cell.VODE
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /
 

--- a/networks/rprox/_parameters
+++ b/networks/rprox/_parameters
@@ -8,9 +8,6 @@
 atol_spec                real      1.0e-11 100
 rtol_spec                real      1.0e-12 100
 
-atol_temp                real      1.0e-8  100
-rtol_temp                real      1.0e-8  100
-
 atol_enuc                real      1.0e-8  100
 rtol_enuc                real      1.0e-8  100
 

--- a/networks/sn160/inputs.burn_cell.VODE
+++ b/networks/sn160/inputs.burn_cell.VODE
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /
 

--- a/networks/subch/inputs.burn_cell.VODE
+++ b/networks/subch/inputs.burn_cell.VODE
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /
 

--- a/networks/subch2/inputs.burn_cell.VODE
+++ b/networks/subch2/inputs.burn_cell.VODE
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /
 

--- a/networks/triple_alpha_plus_cago/_parameters
+++ b/networks/triple_alpha_plus_cago/_parameters
@@ -8,9 +8,6 @@
 atol_spec                real      1.0e-12 100
 rtol_spec                real      1.0e-12 100
 
-atol_temp                real      1.0e-8  100
-rtol_temp                real      1.0e-6  100
-
 atol_enuc                real      1.0e-8  100
 rtol_enuc                real      1.0e-6  100
 

--- a/networks/xrb_simple/_parameters
+++ b/networks/xrb_simple/_parameters
@@ -8,9 +8,6 @@
 atol_spec                real      1.0e-11 100
 rtol_spec                real      1.0e-12 100
 
-atol_temp                real      1.0e-8  100
-rtol_temp                real      1.0e-8  100
-
 atol_enuc                real      1.0e-8  100
 rtol_enuc                real      1.0e-8  100
 

--- a/python_library/StarKiller/StarKiller/examples/BurnProfile/probin_aprox21
+++ b/python_library/StarKiller/StarKiller/examples/BurnProfile/probin_aprox21
@@ -16,9 +16,7 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /

--- a/python_library/StarKiller/StarKiller/examples/ECSN/probin_ecsn
+++ b/python_library/StarKiller/StarKiller/examples/ECSN/probin_ecsn
@@ -14,10 +14,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   disable_thermal_neutrinos = .true.
 

--- a/python_library/StarKiller/StarKiller/examples/probin_aprox13
+++ b/python_library/StarKiller/StarKiller/examples/probin_aprox13
@@ -14,9 +14,7 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /

--- a/python_library/StarKiller/StarKiller/examples/probin_burn_subch
+++ b/python_library/StarKiller/StarKiller/examples/probin_burn_subch
@@ -14,9 +14,7 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /

--- a/python_library/StarKiller/StarKiller/examples/rotating_star/probin_aprox21
+++ b/python_library/StarKiller/StarKiller/examples/rotating_star/probin_aprox21
@@ -16,9 +16,7 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /

--- a/sphinx_docs/source/integrators.rst
+++ b/sphinx_docs/source/integrators.rst
@@ -437,7 +437,7 @@ so :math:`10^{-9}` should be used as the default tolerance in future simulations
    to a run with an ODE tolerance of :math:`10^{-12}`.
 
 The integration tolerances for the burn are controlled by
-``rtol_spec``, ``rtol_enuc``, and ``rtol_temp``,
+``rtol_spec`` and  ``rtol_enuc``,
 which are the relative error tolerances for
 :eq:`eq:spec_integrate`, :eq:`eq:enuc_integrate`, and
 :eq:`eq:temp_integrate`, respectively. There are corresponding

--- a/unit_test/burn_cell/inputs_aprox13_mott
+++ b/unit_test/burn_cell/inputs_aprox13_mott
@@ -32,10 +32,8 @@ integrator.renormalize_abundances = 0
 
 integrator.rtol_spec = 1.0e-6
 integrator.rtol_enuc = 1.0e-6
-integrator.rtol_temp = 1.0e-6
 integrator.atol_spec = 1.0e-6
 integrator.atol_enuc = 1.0e-6
-integrator.atol_temp = 1.0e-6
 
 integrator.call_eos_in_rhs = 0
 

--- a/unit_test/burn_cell/probin_aprox13
+++ b/unit_test/burn_cell/probin_aprox13
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax     = 1.e-2
 

--- a/unit_test/burn_cell/probin_aprox19
+++ b/unit_test/burn_cell/probin_aprox19
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax    = 1.e-2
 

--- a/unit_test/burn_cell/probin_aprox21
+++ b/unit_test/burn_cell/probin_aprox21
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax     = 1.0d-8
 

--- a/unit_test/burn_cell/probin_aprox21_rot1
+++ b/unit_test/burn_cell/probin_aprox21_rot1
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax     = 1.0d-15
 

--- a/unit_test/burn_cell/probin_aprox21_rot2
+++ b/unit_test/burn_cell/probin_aprox21_rot2
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax     = 1.0d-15
 

--- a/unit_test/burn_cell/probin_ignition
+++ b/unit_test/burn_cell/probin_ignition
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax    = 1.0d0 
 

--- a/unit_test/burn_cell/probin_iso7
+++ b/unit_test/burn_cell/probin_iso7
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax    = 1.e-2
 

--- a/unit_test/burn_cell/probin_rprox
+++ b/unit_test/burn_cell/probin_rprox
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax     = 1.e-2
 

--- a/unit_test/burn_cell/probin_triple
+++ b/unit_test/burn_cell/probin_triple
@@ -16,10 +16,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   tmax    = 1.0d-3
 

--- a/unit_test/burn_cell_python/probin_aprox13
+++ b/unit_test/burn_cell_python/probin_aprox13
@@ -14,9 +14,7 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /

--- a/unit_test/burn_cell_python/probin_burn_subch
+++ b/unit_test/burn_cell_python/probin_burn_subch
@@ -14,9 +14,7 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
 /

--- a/unit_test/burn_cell_python/probin_ecsn
+++ b/unit_test/burn_cell_python/probin_ecsn
@@ -14,10 +14,8 @@
 
   rtol_spec = 1.0d-9
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-9
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   disable_thermal_neutrinos = .true.
 

--- a/unit_test/test_react/inputs_iso7
+++ b/unit_test/test_react/inputs_iso7
@@ -20,8 +20,5 @@ unit_test.primary_species_3 = "oxygen-16"
 integrator.rtol_spec = 1.e-6
 integrator.atol_spec = 1.e-6
 
-integrator.rtol_temp = 1.e-6
-integrator.atol_temp = 1.e-6
-
 integrator.rtol_enuc = 1.e-6
 integrator.atol_enuc = 1.e-6

--- a/unit_test/test_react/inputs_reaclib_cburn
+++ b/unit_test/test_react/inputs_reaclib_cburn
@@ -27,9 +27,7 @@ network.small_x = 1.e-16
 
 integrator.rtol_spec = 1.0e-12
 integrator.rtol_enuc = 1.0e-9
-integrator.rtol_temp = 1.0e-9
 integrator.atol_spec = 1.0e-12
 integrator.atol_enuc = 1.0e-9
-integrator.atol_temp = 1.0e-9
 
 integrator.burner_verbose = 0

--- a/unit_test/test_react/inputs_reaclib_ctest
+++ b/unit_test/test_react/inputs_reaclib_ctest
@@ -29,9 +29,7 @@ network.small_x = 1.e-16
 
 integrator.rtol_spec = 1.0e-12
 integrator.rtol_enuc = 1.0e-9
-integrator.rtol_temp = 1.0e-9
 integrator.atol_spec = 1.0e-12
 integrator.atol_enuc = 1.0e-9
-integrator.atol_temp = 1.0e-9
 
 

--- a/unit_test/test_react/inputs_reaclib_urca
+++ b/unit_test/test_react/inputs_reaclib_urca
@@ -26,9 +26,7 @@ integrator.renormalize_abundances = 0
 
 integrator.rtol_spec = 1.0e-12
 integrator.rtol_enuc = 1.0e-9
-integrator.rtol_temp = 1.0e-9
 integrator.atol_spec = 1.0e-12
 integrator.atol_enuc = 1.0e-9
-integrator.atol_temp = 1.0e-9
 
 

--- a/unit_test/test_react/old/inputs_reaclib_cburn.128
+++ b/unit_test/test_react/old/inputs_reaclib_cburn.128
@@ -27,9 +27,7 @@
 
   rtol_spec = 1.0d-12
   rtol_enuc = 1.0d-9
-  rtol_temp = 1.0d-9
   atol_spec = 1.0d-12
   atol_enuc = 1.0d-9
-  atol_temp = 1.0d-9
   
 /

--- a/unit_test/test_react/old/inputs_reaclib_cburn.32
+++ b/unit_test/test_react/old/inputs_reaclib_cburn.32
@@ -27,9 +27,7 @@
 
   rtol_spec = 1.0d-12
   rtol_enuc = 1.0d-9
-  rtol_temp = 1.0d-9
   atol_spec = 1.0d-12
   atol_enuc = 1.0d-9
-  atol_temp = 1.0d-9
-  
+
 /

--- a/unit_test/test_react/old/inputs_reaclib_cburn.64
+++ b/unit_test/test_react/old/inputs_reaclib_cburn.64
@@ -27,9 +27,7 @@
 
   rtol_spec = 1.0d-12
   rtol_enuc = 1.0d-9
-  rtol_temp = 1.0d-9
   atol_spec = 1.0d-12
   atol_enuc = 1.0d-9
-  atol_temp = 1.0d-9
-  
+
 /

--- a/unit_test/test_react/old/inputs_reaclib_urca.32
+++ b/unit_test/test_react/old/inputs_reaclib_urca.32
@@ -25,9 +25,7 @@
 
   rtol_spec = 1.0d-12
   rtol_enuc = 1.0d-9
-  rtol_temp = 1.0d-9
   atol_spec = 1.0d-12
   atol_enuc = 1.0d-9
-  atol_temp = 1.0d-9
 
 /

--- a/unit_test/test_react/old/inputs_reaclib_urca.64
+++ b/unit_test/test_react/old/inputs_reaclib_urca.64
@@ -25,9 +25,7 @@
 
   rtol_spec = 1.0d-12
   rtol_enuc = 1.0d-9
-  rtol_temp = 1.0d-9
   atol_spec = 1.0d-12
   atol_enuc = 1.0d-9
-  atol_temp = 1.0d-9
 
 /

--- a/unit_test/test_sdc_vode_rhs/probin.aprox19
+++ b/unit_test/test_sdc_vode_rhs/probin.aprox19
@@ -9,10 +9,8 @@
 
   rtol_spec = 1.0d-6
   rtol_enuc = 1.0d-6
-  rtol_temp = 1.0d-6
   atol_spec = 1.0d-6
   atol_enuc = 1.0d-6
-  atol_temp = 1.0d-6
 
   density      = 1.d6
   temperature  = 3.d9


### PR DESCRIPTION
note: any application probin's that use these need to be updated