### PR TITLE
kappa_floor should only be applied to Rosseland opacity

### DIFF
--- a/opacity/rad_power_law/actual_opacity.H
+++ b/opacity/rad_power_law/actual_opacity.H
@@ -28,7 +28,6 @@ void actual_opacity (Real& kp, Real& kr, Real rho, Real temp, Real rhoYe, Real n
         }
 #endif
         kp = const_kappa_p * std::pow(rho, kappa_p_exp_m) * std::pow(teff, -kappa_p_exp_n) * nup_kpp;
-        kp = amrex::max(kp, kappa_floor);
     }
 
     if (get_Rosseland_mean) {

--- a/opacity/rad_power_law/opacity_table_module.F90
+++ b/opacity/rad_power_law/opacity_table_module.F90
@@ -56,7 +56,6 @@ contains
        end if
 #endif
        kp = const_kappa_p * (rho**kappa_p_exp_m) * (teff**(-kappa_p_exp_n)) * nup_kpp
-       kp = max(kp, kappa_floor)
     end if
 
     if (get_Rosseland_mean) then


### PR DESCRIPTION
In Castro originally the floor on kappa was only applied to the Rosseland opacity for numerical stability reasons. This change reverts to that previous behavior. This error in the port explains AMReX-Astro/Castro#1539; in that problem setup we had kappa_floor = 1.e-5, which is larger than the actual constant kappa for the Planck mean. We could still have separate floors for kappa_r and kappa_p but that would be done in a separate change.