### PR TITLE
remove some unnecessary calls in Strang

### DIFF
--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -25,6 +25,22 @@ void rhs (const Real /*time*/, burn_t& state, dvode_t& vode_state, RArray1D& ydo
     // y(1:NumSpec) = dX/dt
     // y(net_ienuc) = denuc/dt
 
+    // we come in with (dvode_t) vode_state having the current
+    // solution (or predicted) state and we need to copy this over to
+    // the (burn_t) state to interface with the actual reaction
+    // network
+
+    // Fix the state as necessary -- this ensures that the mass
+    // fractions that enter are valud (and optionally normalized)
+
+    clean_state(vode_state);
+
+    // Update the thermodynamics as necessary -- this primarily takes
+    // the information in vode_state (X and e), copies it to the
+    // (burn_t) state and calls the EOS to get state.T
+
+    update_thermodynamics(state, vode_state);
+
     // Only do the burn if the incoming temperature is within the temperature
     // bounds. Otherwise set the RHS to zero and return.
 
@@ -38,21 +54,17 @@ void rhs (const Real /*time*/, burn_t& state, dvode_t& vode_state, RArray1D& ydo
 
     }
 
-    // Fix the state as necessary.    
+    state.time = vode_state.t;
 
-    clean_state(vode_state);
-
-    // Update the thermodynamics as necessary.
-
-    update_thermodynamics(state, vode_state);
+    // at this point, the (burn_t) state is synchronized with VODE
+    // and is thermodynamically consistent.
 
     // Call the specific network routine to get the RHS.
-
-    vode_to_burn(vode_state, state);
 
     actual_rhs(state, ydot);
 
     // We integrate X, not Y
+
     for (int n = 1; n <= NumSpec; ++n) {
         ydot(n) *= aion[n-1];
     }
@@ -64,13 +76,12 @@ void rhs (const Real /*time*/, burn_t& state, dvode_t& vode_state, RArray1D& ydo
     }
 
     // apply fudge factor:
+
     if (react_boost > 0.0_rt) {
         for (int n = 1; n <= VODE_NEQS; ++n) {
             ydot(n) *= react_boost;
         }
     }
-
-    burn_to_vode(state, vode_state);
 
 }
 


### PR DESCRIPTION
update_thermodynamics already ensures that the burn_t is valid, so we don't need a vode_to_burn (or later burn_to_vode) call in vode_rhs.