### PR TITLE
Remove Jacobian infrastructure for d(rate)/dY

### DIFF
--- a/interfaces/network_utilities.H
+++ b/interfaces/network_utilities.H
@@ -26,18 +26,6 @@ struct rhs_t {
     int exponent_F;
 };
 
-struct jac_t {
-    amrex::Real prefactor;
-    int specindex1;
-    int specindex2;
-    int specindex3;
-
-    amrex::Real rate_prefactor;
-    int rate_specindex1;
-    int rate_specindex2;
-    int rate_specindex3;
-};
-
 // Form a unique numerical identifier from a given
 // (species, rate) combination.
 template<int num_rates>

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -243,69 +243,6 @@ namespace RHS {
         return data;
     }
 
-    // Contribution to the Jacobian from d(RHS(species1)) / d(species2)
-    AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    constexpr jac_t jac_data (int species1, int species2, int rateindex)
-    {
-        using namespace Species;
-        using namespace Rates;
-
-        jac_t data{};
-
-        // The RHS for species 1 has the form prefactor * Y(speciesA) * Y(speciesB) * Y(speciesC) * rate.
-        // If species2 is one of species{A,B,C}, then the Jacobian has a contribution from the derivative
-        // of the RHS term with respect to Y(species2). Additionally, the rate itself may have a functional
-        // dependence on species2 so we also return the same format for d(rate) / d(species2) if it exists.
-
-        data.prefactor  = 0.0_rt;
-        data.specindex1 = -1;
-        data.specindex2 = -1;
-        data.specindex3 = -1;
-
-        data.rate_prefactor = 0.0_rt;
-        data.rate_specindex1 = -1;
-        data.rate_specindex2 = -1;
-        data.rate_specindex3 = -1;
-
-        switch (jac_rate<NumSpec, NumRates>(species1, species2, rateindex)) {
-
-        case jac_rate<NumSpec, NumRates>(He4, He4, Si28_7He4_to_Ni56_forward):
-            data.rate_prefactor = -7.0_rt;
-            data.rate_specindex1 = He4;
-            data.rate_specindex2 = Si28;
-            break;
-
-        case jac_rate<NumSpec, NumRates>(He4, He4, Si28_7He4_to_Ni56_reverse):
-            data.rate_prefactor = 7.0_rt;
-            data.rate_specindex1 = Ni56;
-            break;
-
-        case jac_rate<NumSpec, NumRates>(Si28, He4, Si28_7He4_to_Ni56_forward):
-            data.rate_prefactor = -1.0_rt;
-            data.rate_specindex1 = He4;
-            data.rate_specindex2 = Si28;
-            break;
-
-        case jac_rate<NumSpec, NumRates>(Si28, He4, Si28_7He4_to_Ni56_reverse):
-            data.rate_prefactor = 1.0_rt;
-            data.rate_specindex1 = Ni56;
-            break;
-
-        case jac_rate<NumSpec, NumRates>(Ni56, He4, Si28_7He4_to_Ni56_forward):
-            data.rate_prefactor = 1.0_rt;
-            data.rate_specindex1 = He4;
-            data.rate_specindex2 = Si28;
-            break;
-
-        case jac_rate<NumSpec, NumRates>(Ni56, He4, Si28_7He4_to_Ni56_reverse):
-            data.rate_prefactor = -1.0_rt;
-            data.rate_specindex1 = Ni56;
-            break;
-
-        }
-
-        return data;
-    }
 }
 
 #endif

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -587,40 +587,6 @@ void dfdy_isotopes_iso7(Array1D<Real, 1, NumSpec> const& y,
         }
     }
 
-    for (int spec1 = 1; spec1 <= NumSpec; ++spec1) {
-
-        for (int spec2 = 1; spec2 <= NumSpec; ++spec2) {
-
-            // Now handle the terms that include a d(rate)/dY contribution.
-
-            for (int rate = 1; rate <= NumRates; ++rate) {
-                jac_t jac_data = RHS::jac_data(spec1, spec2, rate);
-
-                if (std::abs(jac_data.rate_prefactor) > 0.0_rt) {
-                    Real term = jac_data.rate_prefactor;
-
-                    if (jac_data.rate_specindex1 >= 0) {
-                        term *= y(jac_data.rate_specindex1);
-                    }
-
-                    if (jac_data.rate_specindex2 >= 0) {
-                        term *= y(jac_data.rate_specindex2);
-                    }
-
-                    if (jac_data.rate_specindex3 >= 0) {
-                        term *= y(jac_data.rate_specindex3);
-                    }
-
-                    term *= rr(2 + spec2).rates(rate);
-
-                    jac(spec1, spec2) += term;
-                }
-            }
-
-        }
-
-    }
-
 }
 
 template<class T>


### PR DESCRIPTION
Now that #567 is done, we can remove the custom infrastructure for the Jacobian. Now in iso7, both the RHS and the Jacobian are automatically constructed from a single source of truth in actual_network.H.