### PR TITLE
fix the case of an immediate NSE bailout

### DIFF
--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -104,7 +104,10 @@ void actual_integrator (burn_t& state, Real dt)
     // we only evolved (rho e), not (rho E), so we need to update the
     // total energy now to ensure we are conservative
 
-    Real rho_Sdot = (vode_state.y(SEINT+1) - state.rhoe_orig) / state.time - state.ydot_a[SEINT];
+    Real rho_Sdot = 0.0_rt;
+    if (state.time > 0) {
+        rho_Sdot = (vode_state.y(SEINT+1) - state.rhoe_orig) / state.time - state.ydot_a[SEINT];
+    }
 
     state.y[SEDEN] += state.time * (state.ydot_a[SEDEN] + rho_Sdot);
 


### PR DESCRIPTION
if we bailout after the first step, then t = 0 and we generate
an Inf if we try to compate an energy generation rate.  Now we
protect against this.