### PR TITLE
only check for NSE bailout after 10 steps

### DIFF
--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -215,7 +215,7 @@ void actual_integrator (burn_t& state, Real dt)
 #endif
         } else {
 #ifndef AMREX_USE_GPU
-            std::cout << "burn entered NSE during integration" << std::endl;
+            std::cout << "burn entered NSE during integration (after " << vode_state.NST << " steps)" << std::endl;
 #endif
         }
     }

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -224,18 +224,24 @@ int dvode (burn_t& state, dvode_t& vstate)
        // if so, bail out we rely on the state being consistent after
        // the call to dvstep, even if the step failed.
 
-       // first we need to make the burn_t in sync
+       // we only do this after MIN_NSE_BAILOUT_STEPS to prevent us
+       // from hitting this right at the start when VODE might do so
+       // wild exploration.
+
+       if (vstate.NST > MIN_NSE_BAILOUT_STEPS) {
+           // first we need to make the burn_t in sync
 
 #ifdef STRANG
-       update_thermodynamics(state, vstate);
+           update_thermodynamics(state, vstate);
 #endif
 #ifdef SIMPLIFIED_SDC
-       vode_to_burn(vstate.tn, vstate, state);
+           vode_to_burn(vstate.tn, vstate, state);
 #endif
 
-       if (in_nse(state)) {
-           istate = -100;
-           return istate;
+           if (in_nse(state)) {
+               istate = -100;
+               return istate;
+           }
        }
 #endif
 

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -53,6 +53,10 @@ const int VODE_LMAX = VODE_MAXORD + 1;
 // How many timesteps should pass before refreshing the Jacobian
 const int max_steps_between_jacobian_evals = 50;
 
+#ifdef NSE_THERMO
+const int MIN_NSE_BAILOUT_STEPS = 10;
+#endif
+
 // Type dvode_t contains the integration solution and control variables
 struct dvode_t
 {


### PR DESCRIPTION
VODE sometimes does some initial exploration that is rejected, but may
trigger the NSE bailout, resulting in a very bad state with huge NSE
energy release.  Now we instead don't check for the NSE bailout until after
10 steps have been taken.  The number 10 is arbitrary, but seems sufficient
for VODE to have settled down.