### PR TITLE
create a temp burn_state for NSE bailout

### DIFF
--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -233,15 +233,23 @@ int dvode (burn_t& state, dvode_t& vstate)
 
 #ifdef STRANG
            update_thermodynamics(state, vstate);
-#endif
-#ifdef SIMPLIFIED_SDC
-           vode_to_burn(vstate.tn, vstate, state);
-#endif
-
            if (in_nse(state)) {
                istate = -100;
                return istate;
            }
+
+#endif
+#ifdef SIMPLIFIED_SDC
+           burn_t burn_state_temp = state;
+           vode_to_burn(vstate.tn, vstate, burn_state_temp);
+
+           if (in_nse(burn_state_temp)) {
+               istate = -100;
+               return istate;
+           }
+
+#endif
+
        }
 #endif
 

--- a/integration/VODE/vode_type_simplified_sdc.H
+++ b/integration/VODE/vode_type_simplified_sdc.H
@@ -18,7 +18,7 @@
 
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void fill_unevolved_variables(const Real time, burn_t& state, dvode_t& vode_state)
+void fill_unevolved_variables(const Real time, burn_t& state, const dvode_t& vode_state)
 {
 
     // some quantities are only advected.  Here we update those state
@@ -77,10 +77,10 @@ void sdc_burn_to_eos (const burn_t& state, T& eos_state)
 
 #if NAUX_NET > 0
     // aux
-    for (int n = 0; n < NumAux; n++) {
-        eos_state.aux[n] = state.y[SFX+n] / eos_state.rho;
-    }
-    //set_nse_aux_from_X(eos_state);
+    //for (int n = 0; n < NumAux; n++) {
+    //    eos_state.aux[n] = state.y[SFX+n] / eos_state.rho;
+    //}
+    set_nse_aux_from_X(eos_state);
 #endif
 
     // we don't bother filling the other fields, since the EOS call
@@ -223,7 +223,7 @@ void burn_to_vode(burn_t& state, dvode_t& vode_state)
 
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void vode_to_burn(const Real time, dvode_t& vode_state, burn_t& state)
+void vode_to_burn(const Real time, const dvode_t& vode_state, burn_t& state)
 {
 
     // this makes burn_t represent the current integration state.  The

--- a/integration/utils/numerical_jacobian.H
+++ b/integration/utils/numerical_jacobian.H
@@ -100,6 +100,10 @@ void numerical_jac(burn_t& state, const jac_info_t& jac_info, JacNetArray2D& jac
 
         state_delp.xn[n-1] += dy;
 
+#ifdef NSE_THERMO
+    set_nse_aux_from_X(state_delp);
+#endif
+
         actual_rhs(state_delp, ydotp);
 
         // We integrate X, so convert from the Y we got back from the RHS

--- a/unit_test/burn_cell_sdc/GNUmakefile
+++ b/unit_test/burn_cell_sdc/GNUmakefile
@@ -1,0 +1,52 @@
+PRECISION  = DOUBLE
+PROFILE    = FALSE
+
+DEBUG      = FALSE
+
+DIM        = 3
+
+COMP	   = gnu
+
+USE_MPI    = FALSE
+USE_OMP    = FALSE
+
+USE_REACT = TRUE
+USE_SIMPLIFIED_SDC = TRUE
+
+EBASE = main
+
+USE_CXX_EOS = TRUE
+
+USE_CXX_REACTIONS = TRUE
+
+USE_EXTRA_THERMO = TRUE
+
+USE_FORT_MICROPHYSICS = FALSE
+BL_NO_FORT = TRUE
+
+ifeq ($(USE_CXX_REACTIONS),TRUE)
+  DEFINES += -DCXX_REACTIONS
+endif
+
+# define the location of the CASTRO top directory
+MICROPHYSICS_HOME  := ../..
+
+# This sets the EOS directory in Castro/EOS -- note: gamma_law will not work,
+# you'll need to use gamma_law_general
+EOS_DIR     := helmholtz
+
+# This sets the network directory in Castro/Networks
+NETWORK_DIR := aprox19
+INTEGRATOR_DIR =  VODE
+DEFINES += -DSDC_EVOLVE_ENERGY
+
+CONDUCTIVITY_DIR := stellar
+
+EXTERN_SEARCH += .
+
+Bpack   := ./Make.package
+Blocs   := .
+
+include $(MICROPHYSICS_HOME)/unit_test/Make.unit_test
+
+

--- a/unit_test/burn_cell_sdc/Make.package
+++ b/unit_test/burn_cell_sdc/Make.package
@@ -1,0 +1,2 @@
+CEXE_sources += main.cpp
+CEXE_headers += burn_cell.H

--- a/unit_test/burn_cell_sdc/_parameters
+++ b/unit_test/burn_cell_sdc/_parameters
@@ -38,5 +38,39 @@ X19           real       0.0d0
 X20           real       0.0d0
 X21           real       0.0d0
 
+Aux1          real       0.0d0
+Aux2          real       0.0d0
+Aux3          real       0.0d0
+
+
+Adv_rho           real       0.0d0
+Adv_rhoe          real       0.0d0
+
+Adv_X1            real       0.0d0
+Adv_X2            real       0.0d0
+Adv_X3            real       0.0d0
+Adv_X4            real       0.0d0
+Adv_X5            real       0.0d0
+Adv_X6            real       0.0d0
+Adv_X7            real       0.0d0
+Adv_X8            real       0.0d0
+Adv_X9            real       0.0d0
+Adv_X10           real       0.0d0
+Adv_X11           real       0.0d0
+Adv_X12           real       0.0d0
+Adv_X13           real       0.0d0
+Adv_X14           real       0.0d0
+Adv_X15           real       0.0d0
+Adv_X16           real       0.0d0
+Adv_X17           real       0.0d0
+Adv_X18           real       0.0d0
+Adv_X19           real       0.0d0
+Adv_X20           real       0.0d0
+Adv_X21           real       0.0d0
+
+Adv_Aux1          real       0.0d0
+Adv_Aux2          real       0.0d0
+Adv_Aux3          real       0.0d0
+
 
 

--- a/unit_test/burn_cell_sdc/_parameters
+++ b/unit_test/burn_cell_sdc/_parameters
@@ -1,0 +1,42 @@
+@namespace: unit_test
+
+small_temp    real       1.e5
+small_dens    real       1.e5
+
+# the final time to integrate to
+tmax          real       1.e-2
+
+# first output time -- we will output in nsteps logarithmically spaced steps between [tfirst, tmax]
+tfirst        real       0.0
+
+# number of steps (logarithmically spaced)
+nsteps        integer    100
+
+density       real       1.d7
+
+temperature   real       3.d9
+
+X1            real       1.0d0
+X2            real       0.0d0
+X3            real       0.0d0
+X4            real       0.0d0
+X5            real       0.0d0
+X6            real       0.0d0
+X7            real       0.0d0
+X8            real       0.0d0
+X9            real       0.0d0
+X10           real       0.0d0
+X11           real       0.0d0
+X12           real       0.0d0
+X13           real       0.0d0
+X14           real       0.0d0
+X15           real       0.0d0
+X16           real       0.0d0
+X17           real       0.0d0
+X18           real       0.0d0
+X19           real       0.0d0
+X20           real       0.0d0
+X21           real       0.0d0
+
+
+

--- a/unit_test/burn_cell_sdc/burn_cell.H
+++ b/unit_test/burn_cell_sdc/burn_cell.H
@@ -383,5 +383,5 @@ void burn_cell_c()
     state_over_time.close();
 
     std::cout << "successful? " << burn_state.success << std::endl;
-
+    std::cout << "number of RHS evals: " << burn_state.n_rhs << std::endl;
 }

--- a/unit_test/burn_cell_sdc/burn_cell.H
+++ b/unit_test/burn_cell_sdc/burn_cell.H
@@ -9,8 +9,6 @@
 void burn_cell_c()
 {
 
-    burn_t state;
-
     Real massfractions[NumSpec] = {-1.0};
 
     // Make sure user set all the mass fractions to values in the interval [0, 1]
@@ -220,24 +218,85 @@ void burn_cell_c()
         std::cout << "Mass Fraction (" << short_spec_names_cxx[n] << "): " << massfractions[n] << std::endl;
     }
 
-    state.T = temperature;
-    state.rho = density;
-    for (int n = 0; n < NumSpec; ++n) {
-        state.xn[n] = massfractions[n];
+    // load the state -- we need to create the conserved quantities.
+    // Since momentum and total energy don't matter, we'll assume that
+    // the velocity is zero and just zero out their advective terms
+
+    burn_t burn_state;
+
+    eos_t eos_state;
+    eos_state.rho = density;
+    eos_state.T = temperature;
+    for (int n = 0; n < NumSpec; n++) {
+      eos_state.xn[n] = massfractions[n];
+    }
+#ifdef NSE_THERMO
+    set_nse_aux_from_X(eos_state);
+#endif
+
+    eos(eos_input_rt, eos_state);
+
+    burn_state.rho = eos_state.rho;
+    burn_state.T = eos_state.T;
+
+    for (int n = 0; n < NumSpec; n++) {
+      burn_state.y[SFS+n] = burn_state.rho * eos_state.xn[n];
     }
 
-    // normalize -- just in case
+#if NAUX_NET > 0
+    for (int n = 0; n < NumAux; n++) {
+        burn_state.y[SFX+n] = burn_state.rho * eos_state.aux[n];
+    }
+#endif
 
-    normalize_abundances_burn(state);
+#if defined(SDC_EVOLVE_ENERGY)
+    std::cout << "density set" << std::endl;
+
+    burn_state.y[SRHO] = density;
+
+    // we will pick velocities to be 10% of the sound speed
+    burn_state.y[SMX] = 0.0;
+    burn_state.y[SMY] = 0.0;
+    burn_state.y[SMZ] = 0.0;
+
+    burn_state.y[SEINT] = burn_state.y[SRHO] * eos_state.e;
+    burn_state.y[SEDEN] = burn_state.y[SEINT];
+
+#elif defined(SDC_EVOLVE_ENTHALPY)
+    burn_state.y[SENTH] = burn_state.rho * eos_state.h;
+
+    burn_state.p0 = eos_state.p;
+#endif
+
+#if defined(SDC_EVOLVE_ENERGY)
+    Real rhoe_old = burn_state.y[SEINT];
+#elif defined (SDC_EVOLVE_ENTHALPY)
+    Real rhoh_old = burn_state.y[SENTH];
+#endif
+
+    // now initialize the advective terms -- the only ones that are
+    // actually used during the integration are for rho, (rho X), and
+    // (rho e)
+
+    for (int n = 0; n < NumSpec; n++) {
+        burn_state.ydot_a[SFS+n] = adv_species[n];
+    }
+
+    // these need to be initialized 
+
+    burn_state.sdc_iter = 1;
+    burn_state.num_sdc_iters = 1;
+
+    for (int n = 0; n < NumSpec; ++n) {
+        burn_state.xn[n] = massfractions[n];
+    }
+
+    burn_state.e = eos_state.e;
+
 
     // output initial burn type data
     Real time = 0.0_rt;
 
-    // call the EOS to set initial e -- it actually doesn't matter to
-    // the burn but we need to keep track of e to get a valid
-    // temperature for the burn if we substep
-
-    eos(eos_input_rt, state);
 
     std::ofstream state_over_time("state_over_time.txt");
 
@@ -255,7 +314,7 @@ void burn_cell_c()
     // save the initial state -- we'll use this to determine
     // how much things changed over the entire burn
 
-    burn_t state_in = state;
+    burn_t state_in = burn_state;
 
     // output the data in columns, one line per timestep
 
@@ -270,9 +329,9 @@ void burn_cell_c()
     Real t = 0.0;
 
     state_over_time << std::setw(10) << t;
-    state_over_time << std::setw(12) << state.T; 
+    state_over_time << std::setw(12) << burn_state.T; 
     for (int x = 0; x < NumSpec; ++x){
-        state_over_time << std::setw(12) << state.xn[x]; 
+        state_over_time << std::setw(12) << burn_state.xn[x]; 
     }
     state_over_time << std::endl;
 
@@ -280,7 +339,7 @@ void burn_cell_c()
     // store the initial internal energy -- we'll update this after
     // each substep
 
-    Real energy_initial = state.e;
+    Real energy_initial = burn_state.e;
 
     // loop over steps, burn, and output the current state
 
@@ -297,27 +356,27 @@ void burn_cell_c()
 
         Real dt = tend - t;
 
-    	burner(state, dt);
+    	burner(burn_state, dt);
 
-        // state.e represents the change in energy over the burn (for
+        // burn_state.e represents the change in energy over the burn (for
         // just this sybcycle), so turn it back into a physical energy
 
-        state.e += energy_initial;
+        burn_state.e += energy_initial;
 
         // reset the initial energy for the next subcycle
 
-        energy_initial = state.e;
+        energy_initial = burn_state.e;
 
         // get the updated T
 
-        eos(eos_input_re, state);
+        eos(eos_input_re, burn_state);
 
         t += dt;
 
 	state_over_time << std::setw(10) << t;
-	state_over_time << std::setw(12) << state.T; 
+	state_over_time << std::setw(12) << burn_state.T; 
 	for (int x = 0; x < NumSpec; ++x){
-	     state_over_time << std::setw(12) << state.xn[x]; 
+	     state_over_time << std::setw(12) << burn_state.xn[x]; 
 	}
 	state_over_time << std::endl;
     }
@@ -326,28 +385,28 @@ void burn_cell_c()
     // output diagnostics to the terminal
 
     std::cout << "------------------------------------" << std::endl;
-    std::cout << "successful? " << state.success << std::endl;
-    std::cout << " - Hnuc = " << (state.e - state_in.e) / tmax << std::endl;
-    std::cout << " - added e = " << state.e - state_in.e << std::endl;
-    std::cout << " - final T = " << state.T << std::endl;
+    std::cout << "successful? " << burn_state.success << std::endl;
+    std::cout << " - Hnuc = " << (burn_state.e - state_in.e) / tmax << std::endl;
+    std::cout << " - added e = " << burn_state.e - state_in.e << std::endl;
+    std::cout << " - final T = " << burn_state.T << std::endl;
 
 
     std::cout << "------------------------------------" << std::endl;
     std::cout << "e initial = " << state_in.e << std::endl;
-    std::cout << "e final =   " << state.e << std::endl;
+    std::cout << "e final =   " << burn_state.e << std::endl;
 
 
     std::cout << "------------------------------------" << std::endl;
     std::cout << "new mass fractions: " << std::endl;
     for (int n = 0; n < NumSpec; ++n) {
-        std::cout << state.xn[n] << std::endl;
+        std::cout << burn_state.xn[n] << std::endl;
     }
 
     std::cout << "------------------------------------" << std::endl;
     std::cout << "species creation rates: " << std::endl;
     for (int n = 0; n < NumSpec; ++n) {
         std::cout << "omegadot(" << short_spec_names_cxx[n] << "): "
-                  << (state.xn[n] - state_in.xn[n]) / tmax << std::endl;
+                  << (burn_state.xn[n] - state_in.xn[n]) / tmax << std::endl;
     }
 
 }

--- a/unit_test/burn_cell_sdc/burn_cell.H
+++ b/unit_test/burn_cell_sdc/burn_cell.H
@@ -1,0 +1,231 @@
+
+#include <extern_parameters.H>
+#include <eos.H>
+#include <network.H>
+#include <burner.H>
+#include <fstream>
+#include <iostream>
+
+void burn_cell_c()
+{
+
+    burn_t state;
+
+    Real massfractions[NumSpec] = {-1.0};
+
+    // Make sure user set all the mass fractions to values in the interval [0, 1]
+    for (int n = 1; n <= NumSpec; ++n) {
+        switch (n) {
+
+        case 1:
+            massfractions[n-1] = X1;
+            break;
+        case 2:
+            massfractions[n-1] = X2;
+            break;
+        case 3:
+            massfractions[n-1] = X3;
+            break;
+        case 4:
+            massfractions[n-1] = X4;
+            break;
+        case 5:
+            massfractions[n-1] = X5;
+            break;
+        case 6:
+            massfractions[n-1] = X6;
+            break;
+        case 7:
+            massfractions[n-1] = X7;
+            break;
+        case 8:
+            massfractions[n-1] = X8;
+            break;
+        case 9:
+            massfractions[n-1] = X9;
+            break;
+        case 10:
+            massfractions[n-1] = X10;
+            break;
+        case 11:
+            massfractions[n-1] = X11;
+            break;
+        case 12:
+            massfractions[n-1] = X12;
+            break;
+        case 13:
+            massfractions[n-1] = X13;
+            break;
+        case 14:
+            massfractions[n-1] = X14;
+            break;
+        case 15:
+            massfractions[n-1] = X15;
+            break;
+        case 16:
+            massfractions[n-1] = X16;
+            break;
+        case 17:
+            massfractions[n-1] = X17;
+            break;
+        case 18:
+            massfractions[n-1] = X18;
+            break;
+        case 19:
+            massfractions[n-1] = X19;
+            break;
+        case 20:
+            massfractions[n-1] = X20;
+            break;
+        case 21:
+            massfractions[n-1] = X21;
+            break;
+
+        }
+
+        if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
+            amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");
+        }
+
+    }
+
+    // Echo initial conditions at burn and fill burn state input
+
+    std::cout << "Maximum Time (s): " << tmax << std::endl;
+    std::cout << "State Density (g/cm^3): " << density << std::endl;
+    std::cout << "State Temperature (K): " << temperature << std::endl;
+    for (int n = 0; n < NumSpec; ++n) {
+        std::cout << "Mass Fraction (" << short_spec_names_cxx[n] << "): " << massfractions[n] << std::endl;
+    }
+
+    state.T = temperature;
+    state.rho = density;
+    for (int n = 0; n < NumSpec; ++n) {
+        state.xn[n] = massfractions[n];
+    }
+
+    // normalize -- just in case
+
+    normalize_abundances_burn(state);
+
+    // output initial burn type data
+    Real time = 0.0_rt;
+
+    // call the EOS to set initial e -- it actually doesn't matter to
+    // the burn but we need to keep track of e to get a valid
+    // temperature for the burn if we substep
+
+    eos(eos_input_rt, state);
+
+    std::ofstream state_over_time("state_over_time.txt");
+
+    // we will divide the total integration time into nsteps that are
+    // logarithmically spaced
+
+    Real dlogt = 0.0_rt;
+
+    if (tfirst == 0.0_rt) {
+        dlogt = std::log10(tmax) / nsteps;
+    } else {
+        dlogt = (std::log10(tmax) - std::log10(tfirst)) / (nsteps - 1);
+    }
+
+    // save the initial state -- we'll use this to determine
+    // how much things changed over the entire burn
+
+    burn_t state_in = state;
+
+    // output the data in columns, one line per timestep
+
+    state_over_time << std::setw(10) << "# Time";
+    state_over_time << std::setw(12) << "Temperature";
+    for(int x = 0; x < NumSpec; ++x){
+	std::string element = short_spec_names_cxx[x];
+	state_over_time << std::setw(12) << element; 
+    }
+    state_over_time << std::endl;
+
+    Real t = 0.0;
+
+    state_over_time << std::setw(10) << t;
+    state_over_time << std::setw(12) << state.T; 
+    for (int x = 0; x < NumSpec; ++x){
+        state_over_time << std::setw(12) << state.xn[x]; 
+    }
+    state_over_time << std::endl;
+
+
+    // store the initial internal energy -- we'll update this after
+    // each substep
+
+    Real energy_initial = state.e;
+
+    // loop over steps, burn, and output the current state
+
+    for (int n = 0; n < nsteps; n++){
+
+        // compute the time we wish to integrate to
+
+        Real tend;
+        if (tfirst == 0.0_rt) {
+            tend = std::pow(10.0_rt, dlogt * (n + 1));
+        } else {
+            tend = std::pow(10.0_rt, std::log10(tfirst) + dlogt * n);
+        }
+
+        Real dt = tend - t;
+
+    	burner(state, dt);
+
+        // state.e represents the change in energy over the burn (for
+        // just this sybcycle), so turn it back into a physical energy
+
+        state.e += energy_initial;
+
+        // reset the initial energy for the next subcycle
+
+        energy_initial = state.e;
+
+        // get the updated T
+
+        eos(eos_input_re, state);
+
+        t += dt;
+
+	state_over_time << std::setw(10) << t;
+	state_over_time << std::setw(12) << state.T; 
+	for (int x = 0; x < NumSpec; ++x){
+	     state_over_time << std::setw(12) << state.xn[x]; 
+	}
+	state_over_time << std::endl;
+    }
+    state_over_time.close();
+
+    // output diagnostics to the terminal
+
+    std::cout << "------------------------------------" << std::endl;
+    std::cout << "successful? " << state.success << std::endl;
+    std::cout << " - Hnuc = " << (state.e - state_in.e) / tmax << std::endl;
+    std::cout << " - added e = " << state.e - state_in.e << std::endl;
+    std::cout << " - final T = " << state.T << std::endl;
+
+
+    std::cout << "------------------------------------" << std::endl;
+    std::cout << "e initial = " << state_in.e << std::endl;
+    std::cout << "e final =   " << state.e << std::endl;
+
+
+    std::cout << "------------------------------------" << std::endl;
+    std::cout << "new mass fractions: " << std::endl;
+    for (int n = 0; n < NumSpec; ++n) {
+        std::cout << state.xn[n] << std::endl;
+    }
+
+    std::cout << "------------------------------------" << std::endl;
+    std::cout << "species creation rates: " << std::endl;
+    for (int n = 0; n < NumSpec; ++n) {
+        std::cout << "omegadot(" << short_spec_names_cxx[n] << "): "
+                  << (state.xn[n] - state_in.xn[n]) / tmax << std::endl;
+    }
+
+}

--- a/unit_test/burn_cell_sdc/burn_cell.H
+++ b/unit_test/burn_cell_sdc/burn_cell.H
@@ -319,6 +319,7 @@ void burn_cell_c()
     // output the data in columns, one line per timestep
 
     state_over_time << std::setw(10) << "# Time";
+    state_over_time << std::setw(12) << "Density";
     state_over_time << std::setw(12) << "Temperature";
     for(int x = 0; x < NumSpec; ++x){
 	std::string element = short_spec_names_cxx[x];
@@ -374,39 +375,15 @@ void burn_cell_c()
         t += dt;
 
 	state_over_time << std::setw(10) << t;
-	state_over_time << std::setw(12) << burn_state.T; 
+	state_over_time << std::setw(12) << burn_state.T;
+	state_over_time << std::setw(12) << burn_state.rho;
 	for (int x = 0; x < NumSpec; ++x){
-	     state_over_time << std::setw(12) << burn_state.xn[x]; 
+	     state_over_time << std::setw(12) << burn_state.y[SFS+x] / burn_state.rho; 
 	}
 	state_over_time << std::endl;
     }
     state_over_time.close();
 
-    // output diagnostics to the terminal
-
-    std::cout << "------------------------------------" << std::endl;
     std::cout << "successful? " << burn_state.success << std::endl;
-    std::cout << " - Hnuc = " << (burn_state.e - state_in.e) / tmax << std::endl;
-    std::cout << " - added e = " << burn_state.e - state_in.e << std::endl;
-    std::cout << " - final T = " << burn_state.T << std::endl;
-
-
-    std::cout << "------------------------------------" << std::endl;
-    std::cout << "e initial = " << state_in.e << std::endl;
-    std::cout << "e final =   " << burn_state.e << std::endl;
-
-
-    std::cout << "------------------------------------" << std::endl;
-    std::cout << "new mass fractions: " << std::endl;
-    for (int n = 0; n < NumSpec; ++n) {
-        std::cout << burn_state.xn[n] << std::endl;
-    }
-
-    std::cout << "------------------------------------" << std::endl;
-    std::cout << "species creation rates: " << std::endl;
-    for (int n = 0; n < NumSpec; ++n) {
-        std::cout << "omegadot(" << short_spec_names_cxx[n] << "): "
-                  << (burn_state.xn[n] - state_in.xn[n]) / tmax << std::endl;
-    }
 
 }

--- a/unit_test/burn_cell_sdc/burn_cell.H
+++ b/unit_test/burn_cell_sdc/burn_cell.H
@@ -89,6 +89,128 @@ void burn_cell_c()
 
     }
 
+
+#ifdef NSE_THERMO
+    Real auxdata[NumAux] = {-1.0};
+
+    // Make sure user set all the mass fractions to values in the interval [0, 1]
+    for (int n = 1; n <= NumAux; ++n) {
+        switch (n) {
+
+        case 1:
+            auxdata[n-1] = Aux1;
+            break;
+        case 2:
+            auxdata[n-1] = Aux2;
+            break;
+        case 3:
+            auxdata[n-1] = Aux3;
+            break;
+
+        }
+
+    }
+#endif
+
+
+    Real adv_species[NumSpec] = {0.0};
+
+    // Make sure user set all the mass fractions to values in the interval [0, 1]
+    for (int n = 1; n <= NumSpec; ++n) {
+        switch (n) {
+
+        case 1:
+            adv_species[n-1] = Adv_X1;
+            break;
+        case 2:
+            adv_species[n-1] = Adv_X2;
+            break;
+        case 3:
+            adv_species[n-1] = Adv_X3;
+            break;
+        case 4:
+            adv_species[n-1] = Adv_X4;
+            break;
+        case 5:
+            adv_species[n-1] = Adv_X5;
+            break;
+        case 6:
+            adv_species[n-1] = Adv_X6;
+            break;
+        case 7:
+            adv_species[n-1] = Adv_X7;
+            break;
+        case 8:
+            adv_species[n-1] = Adv_X8;
+            break;
+        case 9:
+            adv_species[n-1] = Adv_X9;
+            break;
+        case 10:
+            adv_species[n-1] = Adv_X10;
+            break;
+        case 11:
+            adv_species[n-1] = Adv_X11;
+            break;
+        case 12:
+            adv_species[n-1] = Adv_X12;
+            break;
+        case 13:
+            adv_species[n-1] = Adv_X13;
+            break;
+        case 14:
+            adv_species[n-1] = Adv_X14;
+            break;
+        case 15:
+            adv_species[n-1] = Adv_X15;
+            break;
+        case 16:
+            adv_species[n-1] = Adv_X16;
+            break;
+        case 17:
+            adv_species[n-1] = Adv_X17;
+            break;
+        case 18:
+            adv_species[n-1] = Adv_X18;
+            break;
+        case 19:
+            adv_species[n-1] = Adv_X19;
+            break;
+        case 20:
+            adv_species[n-1] = Adv_X20;
+            break;
+        case 21:
+            adv_species[n-1] = Adv_X21;
+            break;
+
+        }
+
+    }
+
+
+#ifdef NSE_THERMO
+    Real adv_aux[NumAux] = {0.0};
+
+    // Make sure user set all the mass fractions to values in the interval [0, 1]
+    for (int n = 1; n <= NumAux; ++n) {
+        switch (n) {
+
+        case 1:
+            adv_aux[n-1] = Adv_Aux1;
+            break;
+        case 2:
+            adv_aux[n-1] = Adv_Aux2;
+            break;
+        case 3:
+            adv_aux[n-1] = Adv_Aux3;
+            break;
+
+        }
+
+    }
+#endif
+
+
     // Echo initial conditions at burn and fill burn state input
 
     std::cout << "Maximum Time (s): " << tmax << std::endl;

--- a/unit_test/burn_cell_sdc/burn_cell.H
+++ b/unit_test/burn_cell_sdc/burn_cell.H
@@ -250,8 +250,6 @@ void burn_cell_c()
 #endif
 
 #if defined(SDC_EVOLVE_ENERGY)
-    std::cout << "density set" << std::endl;
-
     burn_state.y[SRHO] = density;
 
     // we will pick velocities to be 10% of the sound speed

--- a/unit_test/burn_cell_sdc/inputs_aprox19
+++ b/unit_test/burn_cell_sdc/inputs_aprox19
@@ -1,0 +1,36 @@
+
+unit_test.small_temp = 1.e5
+unit_test.small_dens = 1.e5
+
+unit_test.tmax = 1.e-5
+unit_test.nsteps = 1
+
+unit_test.density = 1.e6
+unit_test.temperature = 3.e9
+
+unit_test.X1  = 0.7
+unit_test.X2  = 0.025
+unit_test.X3  = 0.2
+unit_test.X4  = 0.025
+unit_test.X5  = 0.025
+unit_test.X6  = 0.025
+unit_test.X7  = 0.0
+unit_test.X8  = 0.0
+unit_test.X9  = 0.0
+unit_test.X10 = 0.0
+unit_test.X11 = 0.0
+unit_test.X12 = 0.0
+unit_test.X13 = 0.0
+unit_test.X14 = 0.0
+unit_test.X15 = 0.0
+unit_test.X16 = 0.0
+unit_test.X17 = 0.0
+unit_test.X18 = 0.0
+unit_test.X19 = 0.0
+
+integrator.jacobian = 2
+
+integrator.rtol_spec = 1.0e-6
+integrator.rtol_enuc = 1.0e-6
+integrator.atol_spec = 1.0e-6
+integrator.atol_enuc = 1.0e-6

--- a/unit_test/burn_cell_sdc/inputs_aprox19_failure
+++ b/unit_test/burn_cell_sdc/inputs_aprox19_failure
@@ -1,0 +1,59 @@
+
+unit_test.small_temp = 1.e5
+unit_test.small_dens = 1.e5
+
+unit_test.tmax = 0.00159393349
+unit_test.nsteps = 1
+
+unit_test.density = 10401431.73
+unit_test.temperature = 3341630190
+
+unit_test.X1 = 1.000000065e-30
+unit_test.X2 = 1.54177989e-15
+unit_test.X3 = 1.479545232e-05
+unit_test.X4 = 7.261406208e-07
+unit_test.X5 = 1.22387355e-21
+unit_test.X6 = 4.377578785e-05
+unit_test.X7 = 1.443776137e-08
+unit_test.X8 = 2.451915546e-06
+unit_test.X9 = 0.07145976437
+unit_test.X10 = 0.04604485728
+unit_test.X11 = 0.009705192069
+unit_test.X12 = 0.008119185656
+unit_test.X13 = 9.75929e-06
+unit_test.X14 = 0.001088471818
+unit_test.X15 = 0.005605354314
+unit_test.X16 = 0.5778938814
+unit_test.X17 = 0.2800052354
+unit_test.X18 = 2.337699362e-11
+unit_test.X19 = 6.534650153e-06
+
+
+unit_test.Adv_rho = -22291648.91
+unit_test.Adv_rhoe = -8.133430393e+24
+unit_test.Adv_X1 = -3.811874806e-24
+unit_test.Adv_X2 = 7.060981868e-07
+unit_test.Adv_X3 = -1196.417734
+unit_test.Adv_X4 = 365.0844044
+unit_test.Adv_X5 = -8.076653644e-12
+unit_test.Adv_X6 = 30387.13382
+unit_test.Adv_X7 = 9.321854156
+unit_test.Adv_X8 = 978.9658416
+unit_test.Adv_X9 = 27704370.13
+unit_test.Adv_X10 = 17734748.28
+unit_test.Adv_X11 = 3665980.768
+unit_test.Adv_X12 = 3427828.306
+unit_test.Adv_X13 = 2558.630108
+unit_test.Adv_X14 = -200945.1842
+unit_test.Adv_X15 = -523860.6429
+unit_test.Adv_X16 = -37653909.62
+unit_test.Adv_X17 = -36478261.12
+unit_test.Adv_X18 = 0.004751096435
+unit_test.Adv_X19 = -702.5507917 
+
+integrator.jacobian = 3
+
+integrator.rtol_spec = 1.0e-5
+integrator.rtol_enuc = 1.0e-5
+integrator.atol_spec = 1.0e-5
+integrator.atol_enuc = 1.0e-5

--- a/unit_test/burn_cell_sdc/main.cpp
+++ b/unit_test/burn_cell_sdc/main.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <cstring>
+#include <vector>
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_MultiFab.H>
+using namespace amrex;
+
+#include <extern_parameters.H>
+#include <eos.H>
+#include <network.H>
+#include <burn_cell.H>
+#include <unit_test.H>
+
+int main(int argc, char *argv[]) {
+
+  amrex::Initialize(argc, argv);
+
+  std::cout << "starting the single zone burn..." << std::endl;
+
+  ParmParse ppa("amr");
+
+  std::string probin_file = "probin";
+
+  ppa.query("probin_file", probin_file);
+
+  std::cout << "probin = " << probin_file << std::endl;
+
+  const int probin_file_length = probin_file.length();
+  Vector<int> probin_file_name(probin_file_length);
+
+  for (int i = 0; i < probin_file_length; i++)
+    probin_file_name[i] = probin_file[i];
+
+  init_unit_test(probin_file_name.dataPtr(), &probin_file_length);
+
+  // C++ EOS initialization (must be done after Fortran eos_init and init_extern_parameters)
+  eos_init(small_temp, small_dens);
+
+  // C++ Network, RHS, screening, rates initialization
+  network_init();
+
+  burn_cell_c();
+
+  amrex::Finalize();
+}

--- a/unit_test/burn_cell_sdc/main.cpp
+++ b/unit_test/burn_cell_sdc/main.cpp
@@ -24,8 +24,6 @@ int main(int argc, char *argv[]) {
 
   ppa.query("probin_file", probin_file);
 
-  std::cout << "probin = " << probin_file << std::endl;
-
   const int probin_file_length = probin_file.length();
   Vector<int> probin_file_name(probin_file_length);
 


### PR DESCRIPTION
something in the update of the burn_state to check for NSE causes
the integration to fail at times when running with SDC+NSE.  This
works around that.  This can be tested with the new burn_cell_sdc
problem and the inputs_aprox19_failure inputs.
