### PR TITLE
Template the eos_type output operator

### DIFF
--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -174,8 +174,17 @@ template <typename T>
 struct has_eta<T, typename std::enable_if<(sizeof(((T*)0)->eta) > 0)>::type>
     : std::true_type {};
 
+template <typename T, typename Enable = void>
+struct has_conductivity
+    : std::false_type {};
+
+template <typename T>
+struct has_conductivity<T, typename std::enable_if<(sizeof(((T*)0)->conductivity) > 0)>::type>
+    : std::true_type {};
+
+template <typename T>
 inline
-std::ostream& operator<< (std::ostream& o, eos_t const& eos_state)
+std::ostream& operator<< (std::ostream& o, T const& eos_state)
 {
     o << "rho = " << eos_state.rho << std::endl;
     o << "T =   " << eos_state.T << std::endl;
@@ -191,48 +200,82 @@ std::ostream& operator<< (std::ostream& o, eos_t const& eos_state)
     }
     o << std::endl;
 #endif
-    o << "p = " << eos_state.p << std::endl;
-    o << "e = " << eos_state.e << std::endl;
-    o << "h = " << eos_state.h << std::endl;
-    o << "s = " << eos_state.s << std::endl;
+    if constexpr (has_pressure<T>::value) {
+        o << "p = " << eos_state.p << std::endl;
+    }
+    if constexpr (has_energy<T>::value) {
+        o << "e = " << eos_state.e << std::endl;
+    }
+    if constexpr (has_enthalpy<T>::value) {
+        o << "h = " << eos_state.h << std::endl;
+    }
+    if constexpr (has_entropy<T>::value) {
+        o << "s = " << eos_state.s << std::endl;
+    }
 
-    o << "dpdT = " << eos_state.dpdT << std::endl;
-    o << "dpdr = " << eos_state.dpdr << std::endl;
-    o << "dedT = " << eos_state.dedT << std::endl;
-    o << "dedr = " << eos_state.dedr << std::endl;
-    o << "dhdT = " << eos_state.dhdT << std::endl;
-    o << "dhdr = " << eos_state.dhdr << std::endl;
-    o << "dsdT = " << eos_state.dsdT << std::endl;
-    o << "dsdr = " << eos_state.dsdr << std::endl;
-    o << "dpde = " << eos_state.dpde << std::endl;
-  o << "dpdr_e = " << eos_state.dpdr_e  << std::endl;
+    if constexpr (has_pressure<T>::value) {
+        o << "dpdT = " << eos_state.dpdT << std::endl;
+        o << "dpdr = " << eos_state.dpdr << std::endl;
+    }
+    if constexpr (has_energy<T>::value) {
+        o << "dedT = " << eos_state.dedT << std::endl;
+        o << "dedr = " << eos_state.dedr << std::endl;
+    }
+    if constexpr (has_enthalpy<T>::value) {
+        o << "dhdT = " << eos_state.dhdT << std::endl;
+        o << "dhdr = " << eos_state.dhdr << std::endl;
+    }
+    if constexpr (has_entropy<T>::value) {
+        o << "dsdT = " << eos_state.dsdT << std::endl;
+        o << "dsdr = " << eos_state.dsdr << std::endl;
+    }
+    if constexpr (has_pressure<T>::value) {
+        o << "dpde = " << eos_state.dpde << std::endl;
+        o << "dpdr_e = " << eos_state.dpdr_e  << std::endl;
+    }
 
-  o << "cv = " << eos_state.cv << std::endl;
-  o << "cp = " << eos_state.cp << std::endl;
-  o << "xne = " << eos_state.xne << std::endl;
-  o << "xnp = " << eos_state.xnp << std::endl;
-  o << "eta = " << eos_state.eta << std::endl;
-  o << "pele = " << eos_state.pele << std::endl;
-  o << "ppos = " << eos_state.ppos << std::endl;
-  o << "mu = " << eos_state.mu << std::endl;
-  o << "mu_e = " << eos_state.mu_e << std::endl;
-  o << "y_e = " << eos_state.y_e << std::endl;
-  o << "gam1 = " << eos_state.gam1 << std::endl;
-  o << "cs = " << eos_state.cs << std::endl;
+    o << "cv = " << eos_state.cv << std::endl;
+    if constexpr (has_pressure<T>::value) {
+        o << "cp = " << eos_state.cp << std::endl;
+    }
+    if constexpr (has_xne_xnp<T>::value) {
+        o << "xne = " << eos_state.xne << std::endl;
+        o << "xnp = " << eos_state.xnp << std::endl;
+    }
+    if constexpr (has_eta<T>::value) {
+        o << "eta = " << eos_state.eta << std::endl;
+    }
+    if constexpr (has_pele_ppos<T>::value) {
+        o << "pele = " << eos_state.pele << std::endl;
+        o << "ppos = " << eos_state.ppos << std::endl;
+    }
+    o << "mu = " << eos_state.mu << std::endl;
+    o << "mu_e = " << eos_state.mu_e << std::endl;
+    o << "y_e = " << eos_state.y_e << std::endl;
+    if constexpr (has_pressure<T>::value) {
+        o << "gam1 = " << eos_state.gam1 << std::endl;
+        o << "cs = " << eos_state.cs << std::endl;
+    }
 
-  o << "abar = " << eos_state.abar << std::endl;
-  o << "zbar = " << eos_state.zbar << std::endl;
+    o << "abar = " << eos_state.abar << std::endl;
+    o << "zbar = " << eos_state.zbar << std::endl;
 
 #ifdef EXTRA_THERMO
-  o << "dpdA = " << eos_state.dpdA << std::endl;
-  o << "dpdZ = " << eos_state.dpdZ << std::endl;
-  o << "dedA = " << eos_state.dedA << std::endl;
-  o << "dedZ = " << eos_state.dedZ << std::endl;
+    if constexpr (has_pressure<T>::value) {
+        o << "dpdA = " << eos_state.dpdA << std::endl;
+        o << "dpdZ = " << eos_state.dpdZ << std::endl;
+    }
+    if constexpr (has_energy<T>::value) {
+        o << "dedA = " << eos_state.dedA << std::endl;
+        o << "dedZ = " << eos_state.dedZ << std::endl;
+    }
 #endif
 
-  o << "conductivity = " << eos_state.conductivity << std::endl;
+    if constexpr (has_conductivity<T>::value) {
+        o << "conductivity = " << eos_state.conductivity << std::endl;
+    }
 
-  return o;
+    return o;
 }
 
 enum eos_input_t {eos_input_rt = 0,

--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -4,7 +4,9 @@
 #include <AMReX.H>
 #include <network.H>
 
-struct eos_t {
+struct eos_base_t {};
+
+struct eos_t:eos_base_t {
     amrex::Real rho;
     amrex::Real T;
     amrex::Real p;
@@ -52,7 +54,7 @@ struct eos_t {
     amrex::Real conductivity;
 };
 
-struct eos_re_t {
+struct eos_re_t:eos_base_t {
     amrex::Real rho;
     amrex::Real T;
     amrex::Real e;
@@ -79,7 +81,7 @@ struct eos_re_t {
 #endif
 };
 
-struct eos_rep_t {
+struct eos_rep_t:eos_base_t {
     amrex::Real rho;
     amrex::Real T;
     amrex::Real e;
@@ -182,24 +184,34 @@ template <typename T>
 struct has_conductivity<T, typename std::enable_if<(sizeof(((T*)0)->conductivity) > 0)>::type>
     : std::true_type {};
 
+template <typename T, typename Enable = void>
+struct has_base_variables
+    : std::false_type {};
+
+template <typename T>
+struct has_base_variables<T, typename std::enable_if<(sizeof(((T*)0)->rho) > 0)>::type>
+    : std::true_type {};
+
 template <typename T>
 inline
-std::ostream& operator<< (std::ostream& o, T const& eos_state)
+std::ostream& print_state (std::ostream& o, T const& eos_state)
 {
-    o << "rho = " << eos_state.rho << std::endl;
-    o << "T =   " << eos_state.T << std::endl;
-    o << "xn = ";
-    for (int n = 0; n < NumSpec; ++n) {
-        o << eos_state.xn[n] << " ";
-    }
-    o << std::endl;
+    if constexpr (has_base_variables<T>::value) {
+        o << "rho = " << eos_state.rho << std::endl;
+        o << "T =   " << eos_state.T << std::endl;
+        o << "xn = ";
+        for (int n = 0; n < NumSpec; ++n) {
+            o << eos_state.xn[n] << " ";
+        }
+        o << std::endl;
 #if NAUX_NET > 0
-    o << "aux = ";
-    for (int n = 0; n < NumAux; ++n) {
-        o << eos_state.aux[n] << " ";
-    }
-    o << std::endl;
+        o << "aux = ";
+        for (int n = 0; n < NumAux; ++n) {
+            o << eos_state.aux[n] << " ";
+        }
+        o << std::endl;
 #endif
+    }
     if constexpr (has_pressure<T>::value) {
         o << "p = " << eos_state.p << std::endl;
     }
@@ -234,7 +246,9 @@ std::ostream& operator<< (std::ostream& o, T const& eos_state)
         o << "dpdr_e = " << eos_state.dpdr_e  << std::endl;
     }
 
-    o << "cv = " << eos_state.cv << std::endl;
+    if constexpr (has_base_variables<T>::value) {
+        o << "cv = " << eos_state.cv << std::endl;
+    }
     if constexpr (has_pressure<T>::value) {
         o << "cp = " << eos_state.cp << std::endl;
     }
@@ -249,16 +263,20 @@ std::ostream& operator<< (std::ostream& o, T const& eos_state)
         o << "pele = " << eos_state.pele << std::endl;
         o << "ppos = " << eos_state.ppos << std::endl;
     }
-    o << "mu = " << eos_state.mu << std::endl;
-    o << "mu_e = " << eos_state.mu_e << std::endl;
-    o << "y_e = " << eos_state.y_e << std::endl;
+    if constexpr (has_base_variables<T>::value) {
+        o << "mu = " << eos_state.mu << std::endl;
+        o << "mu_e = " << eos_state.mu_e << std::endl;
+        o << "y_e = " << eos_state.y_e << std::endl;
+    }
     if constexpr (has_pressure<T>::value) {
         o << "gam1 = " << eos_state.gam1 << std::endl;
         o << "cs = " << eos_state.cs << std::endl;
     }
 
-    o << "abar = " << eos_state.abar << std::endl;
-    o << "zbar = " << eos_state.zbar << std::endl;
+    if constexpr (has_base_variables<T>::value) {
+        o << "abar = " << eos_state.abar << std::endl;
+        o << "zbar = " << eos_state.zbar << std::endl;
+    }
 
 #ifdef EXTRA_THERMO
     if constexpr (has_pressure<T>::value) {
@@ -276,6 +294,12 @@ std::ostream& operator<< (std::ostream& o, T const& eos_state)
     }
 
     return o;
+}
+
+inline
+std::ostream& operator<< (std::ostream& o, eos_base_t const& eos_state)
+{
+    return print_state(o, eos_state);
 }
 
 enum eos_input_t {eos_input_rt = 0,


### PR DESCRIPTION
This templates the `<<` operator for the structs in `eos_type.H`, adding checks to see whether variables exist in the struct so it should now work for any of the eos structs defined in that file.

This addresses #629.