### PR TITLE
iso7 28/∞

### DIFF
--- a/interfaces/rhs_utilities.H
+++ b/interfaces/rhs_utilities.H
@@ -210,14 +210,14 @@ constexpr int density_exponent_reverse ()
 
     int exponent = 0;
 
-    if constexpr (rhs_data.species_C >= 0) {
-        exponent += rhs_data.exponent_C;
-    }
     if constexpr (rhs_data.species_D >= 0) {
         exponent += rhs_data.exponent_D;
     }
     if constexpr (rhs_data.species_E >= 0) {
         exponent += rhs_data.exponent_E;
+    }
+    if constexpr (rhs_data.species_F >= 0) {
+        exponent += rhs_data.exponent_F;
     }
 
     if (exponent > 0) {

--- a/interfaces/rhs_utilities.H
+++ b/interfaces/rhs_utilities.H
@@ -173,6 +173,60 @@ constexpr int num_rhs ()
     return RHS_impl::num_rhs_impl<species>(std::make_integer_sequence<int, Rates::NumRates>{});
 }
 
+// Calculate the density dependence term for tabulated rates. The RHS has a term
+// that goes as rho**(exp_A + exp_B + exp_C) / rho (the denominator is because the
+// LHS is X, not rho * X).
+template<int rate>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+constexpr int density_exponent_forward ()
+{
+    constexpr rhs_t rhs_data = RHS::rhs_data(rate);
+
+    int exponent = 0;
+
+    if constexpr (rhs_data.species_A >= 0) {
+        exponent += rhs_data.exponent_A;
+    }
+    if constexpr (rhs_data.species_B >= 0) {
+        exponent += rhs_data.exponent_B;
+    }
+    if constexpr (rhs_data.species_C >= 0) {
+        exponent += rhs_data.exponent_C;
+    }
+
+    if (exponent > 0) {
+        exponent -= 1;
+    }
+
+    return exponent;
+}
+
+// Same as the above but for the reverse reaction.
+template <int rate>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+constexpr int density_exponent_reverse ()
+{
+    constexpr rhs_t rhs_data = RHS::rhs_data(rate);
+
+    int exponent = 0;
+
+    if constexpr (rhs_data.species_C >= 0) {
+        exponent += rhs_data.exponent_C;
+    }
+    if constexpr (rhs_data.species_D >= 0) {
+        exponent += rhs_data.exponent_D;
+    }
+    if constexpr (rhs_data.species_E >= 0) {
+        exponent += rhs_data.exponent_E;
+    }
+
+    if (exponent > 0) {
+        exponent -= 1;
+    }
+
+    return exponent;
+}
+
 // Calculate the j'th RHS term for a given species.
 //
 // The general form of a reaction is

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -85,53 +85,82 @@ void iso7tab(const Real btemp, const Real bden,
         Real forward_dtab = 0.0_rt;
         Real reverse_dtab = 0.0_rt;
 
+        int forward_exponent, reverse_exponent;
+
         // Set the density dependence
 
         switch (rateindex) {
 
         case (C12_He4_to_O16):
-            forward_dtab = bden;
-            reverse_dtab = 1.0e0_rt;
+            forward_exponent = RHS::density_exponent_forward<C12_He4_to_O16>();
+            reverse_exponent = RHS::density_exponent_reverse<C12_He4_to_O16>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent);
             break;
 
         case (He4_He4_He4_to_C12):
-            forward_dtab = bden * bden;
-            reverse_dtab = 1.0e0_rt;
+            forward_exponent = RHS::density_exponent_forward<He4_He4_He4_to_C12>();
+            reverse_exponent = RHS::density_exponent_reverse<He4_He4_He4_to_C12>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent);
             break;
 
         case (C12_C12_to_Ne20_He4):
-            forward_dtab = bden;
-            reverse_dtab = bden; // rate is zero in this net
+            forward_exponent = RHS::density_exponent_forward<C12_C12_to_Ne20_He4>();
+            reverse_exponent = RHS::density_exponent_reverse<C12_C12_to_Ne20_He4>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent); // rate is zero in this net
             break;
 
         case (C12_O16_to_Mg24_He4):
-            forward_dtab = bden;
-            reverse_dtab = bden; // rate is zero in this net
+            forward_exponent = RHS::density_exponent_forward<C12_O16_to_Mg24_He4>();
+            reverse_exponent = RHS::density_exponent_reverse<C12_O16_to_Mg24_He4>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent); // rate is zero in this net
             break;
 
         case (C12_O16_to_Si28):
-            forward_dtab = bden;
-            reverse_dtab = 1.0_rt; // rate is zero in this net
+            forward_exponent = RHS::density_exponent_forward<C12_O16_to_Si28>();
+            reverse_exponent = RHS::density_exponent_reverse<C12_O16_to_Si28>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent); // rate is zero in this net
             break;
 
         case (O16_O16_to_Si28_He4):
-            forward_dtab = bden;
-            reverse_dtab = bden; // rate is zero in this net
+            forward_exponent = RHS::density_exponent_forward<O16_O16_to_Si28_He4>();
+            reverse_exponent = RHS::density_exponent_reverse<O16_O16_to_Si28_He4>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent); // rate is zero in this net
             break;
 
         case (O16_He4_to_Ne20):
-            forward_dtab = bden;
-            reverse_dtab = 1.0e0_rt;
+            forward_exponent = RHS::density_exponent_forward<O16_He4_to_Ne20>();
+            reverse_exponent = RHS::density_exponent_reverse<O16_He4_to_Ne20>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent);
             break;
 
         case (Ne20_He4_to_Mg24):
-            forward_dtab = bden;
-            reverse_dtab = 1.0e0_rt;
+            forward_exponent = RHS::density_exponent_forward<Ne20_He4_to_Mg24>();
+            reverse_exponent = RHS::density_exponent_reverse<Ne20_He4_to_Mg24>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent);
             break;
 
         case (Mg24_He4_to_Si28):
-            forward_dtab = bden;
-            reverse_dtab = 1.0e0_rt;
+            forward_exponent = RHS::density_exponent_forward<Mg24_He4_to_Si28>();
+            reverse_exponent = RHS::density_exponent_reverse<Mg24_He4_to_Si28>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent);
             break;
 
         case (Ca40_He4_to_Ti44):


### PR DESCRIPTION
Adds a function to automatically compute density dependence of tabulated rates.

The Ca40 + He4 <-> Ti44 rate is not dealt with yet since it doesn't have an entry in rhs_data().