### PR TITLE
Add concept of extra species that do not directly react

### DIFF
--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -17,6 +17,10 @@
 
 constexpr int NumSpec = @@NSPEC@@;
 
+#define NUM_EXTRA_SPECIES @@NEXTRASPEC@@
+
+constexpr int NumSpecExtra = NUM_EXTRA_SPECIES;
+
 // filled via the preprocessor by including NAUX_NETWORK
 constexpr int NumAux = NAUX_NET;
 
@@ -26,21 +30,51 @@ static AMREX_GPU_MANAGED amrex::Real aion[NumSpec] MICROPHYSICS_UNUSED = {
    @@AION@@
   };
 
+#if NUM_EXTRA_SPECIES > 0
+static AMREX_GPU_MANAGED amrex::Real extra_aion[NumSpecExtra] MICROPHYSICS_UNUSED = {
+   @@EXTRA_AION@@
+  };
+#endif
+
 static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpec] MICROPHYSICS_UNUSED = {
    @@AION_INV@@
   };
+
+#if NUM_EXTRA_SPECIES > 0
+static AMREX_GPU_MANAGED amrex::Real extra_aion_inv[NumSpecExtra] MICROPHYSICS_UNUSED = {
+   @@EXTRA_AION_INV@@
+  };
+#endif
 
 static AMREX_GPU_MANAGED amrex::Real zion[NumSpec] MICROPHYSICS_UNUSED = {
    @@ZION@@
   };
 
+#if NUM_EXTRA_SPECIES > 0
+static AMREX_GPU_MANAGED amrex::Real extra_zion[NumSpecExtra] MICROPHYSICS_UNUSED = {
+   @@EXTRA_ZION@@
+  };
+#endif
+
 static const std::vector<std::string> short_spec_names_cxx MICROPHYSICS_UNUSED = {
    @@SHORT_SPEC_NAMES@@
   };
 
+#if NUM_EXTRA_SPECIES > 0
+static const std::vector<std::string> extra_short_spec_names_cxx MICROPHYSICS_UNUSED = {
+   @@EXTRA_SHORT_SPEC_NAMES@@
+  };
+#endif
+
 static const std::vector<std::string> spec_names_cxx MICROPHYSICS_UNUSED = {
    @@SPEC_NAMES@@
   };
+
+#if NUM_EXTRA_SPECIES > 0
+static const std::vector<std::string> extra_spec_names_cxx MICROPHYSICS_UNUSED = {
+   @@EXTRA_SPEC_NAMES@@
+  };
+#endif
 
 #if NAUX_NET > 0
 static const std::vector<std::string> short_aux_names_cxx MICROPHYSICS_UNUSED = {
@@ -66,6 +100,14 @@ namespace Species {
    };
 }
 
+namespace ExtraSpecies {
+#if NUM_EXTRA_SPECIES > 0
+   enum NetworkExtraSpecies {
+     @@EXTRA_SPECIES_ENUM@@
+   };
+#endif
+}
+
 namespace NetworkProperties {
    AMREX_GPU_HOST_DEVICE AMREX_INLINE constexpr amrex::Real aion (int spec)
    {
@@ -80,6 +122,21 @@ namespace NetworkProperties {
        return a;
    }
 
+#if NUM_EXTRA_SPECIES > 0
+   AMREX_GPU_HOST_DEVICE AMREX_INLINE constexpr amrex::Real extra_aion (int spec)
+   {
+       using namespace ExtraSpecies;
+
+       amrex::Real a = -1.0;
+
+       switch (spec) {
+           @@EXTRA_AION_CONSTEXPR@@
+       }
+
+       return a;
+   }
+#endif
+
    AMREX_GPU_HOST_DEVICE AMREX_INLINE constexpr amrex::Real zion (int spec)
    {
        using namespace Species;
@@ -92,5 +149,20 @@ namespace NetworkProperties {
 
        return z;
    }
+
+#if NUM_EXTRA_SPECIES > 0
+   AMREX_GPU_HOST_DEVICE AMREX_INLINE constexpr amrex::Real extra_zion (int spec)
+   {
+       using namespace ExtraSpecies;
+
+       amrex::Real z = -1.0;
+
+       switch (spec) {
+           @@EXTRA_ZION_CONSTEXPR@@
+       }
+
+       return z;
+   }
+#endif
 }
 #endif

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -379,6 +379,7 @@ void screen_iso7(const Real btemp, const Real bden,
                  Array2D<Real, 1, NumSpec, 1, Rates::NumRates>& dratedY)
 {
     using namespace Species;
+    using namespace ExtraSpecies;
     using namespace Rates;
 
     /*
@@ -418,7 +419,7 @@ void screen_iso7(const Real btemp, const Real bden,
 
     jscr++;
     screen5(pstate,jscr,
-            zion[He4-1], aion[He4-1], 4.0_rt, 8.0_rt,
+            zion[He4-1], aion[He4-1], extra_zion[Be8-1], extra_aion[Be8-1],
             sc2a,sc2adt,sc2add);
 
     sc3a   = sc1a * sc2a;
@@ -501,7 +502,7 @@ void screen_iso7(const Real btemp, const Real bden,
     // ca40 to ti44
     jscr++;
     screen5(pstate,jscr,
-            20.0_rt, 40.0_rt, zion[He4-1], aion[He4-1],
+            extra_zion[Ca40-1], extra_aion[Ca40-1], zion[He4-1], aion[He4-1],
             sc1a,sc1adt,sc1add);
 
     dratedt.forward(Ca40_He4_to_Ti44) = dratedt.forward(Ca40_He4_to_Ti44) * sc1a + rate.forward(Ca40_He4_to_Ti44) * sc1adt;
@@ -748,12 +749,13 @@ void set_up_screening_factors()
     // Compute and store the more expensive screening factors
 
     using namespace Species;
+    using namespace ExtraSpecies;
 
     // note: we need to set these up in the same order that we evaluate the
     // rates in actual_rhs.H (yes, it's ugly)
     int jscr = 0;
     add_screening_factor(jscr++, zion[He4-1], aion[He4-1], zion[He4-1], aion[He4-1]);
-    add_screening_factor(jscr++, zion[He4-1], aion[He4-1],  4.0e0_rt,  8.0e0_rt);
+    add_screening_factor(jscr++, zion[He4-1], aion[He4-1], extra_zion[Be8-1], extra_aion[Be8-1]);
     add_screening_factor(jscr++, zion[C12-1], aion[C12-1], zion[He4-1], aion[He4-1]);
     add_screening_factor(jscr++, zion[C12-1], aion[C12-1], zion[C12-1], aion[C12-1]);
     add_screening_factor(jscr++, zion[C12-1], aion[C12-1], zion[O16-1], aion[O16-1]);
@@ -761,7 +763,7 @@ void set_up_screening_factors()
     add_screening_factor(jscr++, zion[O16-1], aion[O16-1], zion[He4-1], aion[He4-1]);
     add_screening_factor(jscr++, zion[Ne20-1], aion[Ne20-1], zion[He4-1], aion[He4-1]);
     add_screening_factor(jscr++, zion[Mg24-1], aion[Mg24-1], zion[He4-1], aion[He4-1]);
-    add_screening_factor(jscr++,  20.0e0_rt,  40.0e0_rt, zion[He4-1], aion[He4-1]);
+    add_screening_factor(jscr++, extra_zion[Ca40-1], extra_aion[Ca40-1], zion[He4-1], aion[He4-1]);
 
 }
 

--- a/networks/iso7/iso7.net
+++ b/networks/iso7/iso7.net
@@ -1,10 +1,13 @@
 # This is a null network corresponding to the iso7 burner.
 
-# name       short name    aion     zion
- helium-4       He4          4.0      2.0
- carbon-12      C12         12.0      6.0
- oxygen-16      O16         16.0      8.0
- neon-20        Ne20        20.0     10.0
- magnesium-24   Mg24        24.0     12.0
- silicon-28     Si28        28.0     14.0
- nickel-56      Ni56        56.0     28.0
+# name              short name      aion     zion
+ helium-4                  He4       4.0      2.0
+ __extra_beryllium-8       Be8       8.0      4.0
+ carbon-12                 C12      12.0      6.0
+ oxygen-16                 O16      16.0      8.0
+ neon-20                  Ne20      20.0     10.0
+ magnesium-24             Mg24      24.0     12.0
+ silicon-28               Si28      28.0     14.0
+ __extra_calcium-40       Ca40      40.0     20.0
+ __extra_titanium-44      Ti44      44.0     22.0
+ nickel-56                Ni56      56.0     28.0


### PR DESCRIPTION
We can now define additional auxiliary species to the network that aren't directly reacting but are used in intermediate rate calculations (such as the Ca40 + He4 -> Ti44 intermediate rate used in iso7 which is used to construct the overall Si28 -> Ni56 rate).