### PR TITLE
iso7 30/∞

### DIFF
--- a/interfaces/rhs_utilities.H
+++ b/interfaces/rhs_utilities.H
@@ -159,7 +159,19 @@ constexpr int is_rate_used ()
         rhs_data.species_D == species ||
         rhs_data.species_E == species ||
         rhs_data.species_F == species) {
-        return 1;
+        // Exclude intermediate rates that don't appear in the RHS.
+        // We can identify these by the presence of an "extra" species
+        // whose numerical ID is > NumSpec.
+        if (rhs_data.species_A > NumSpec ||
+            rhs_data.species_B > NumSpec ||
+            rhs_data.species_C > NumSpec ||
+            rhs_data.species_D > NumSpec ||
+            rhs_data.species_E > NumSpec ||
+            rhs_data.species_F > NumSpec) {
+            return 0;
+        } else {
+            return 1;
+        }
     } else {
         return 0;
     }

--- a/interfaces/rhs_utilities.H
+++ b/interfaces/rhs_utilities.H
@@ -465,6 +465,16 @@ Array2D<Real, 1, NumSpec, 1, NumSpec> species_jac (const burn_t& state, rate_fr_
             for (int rate = 1; rate <= Rates::NumRatesFR; ++rate) {
                 rhs_t rhs_data = RHS::rhs_data(rate);
 
+                // Skip this rate if it is an intermediate rate involving "extra" species.
+                if (rhs_data.species_A > NumSpec ||
+                    rhs_data.species_B > NumSpec ||
+                    rhs_data.species_C > NumSpec ||
+                    rhs_data.species_D > NumSpec ||
+                    rhs_data.species_E > NumSpec ||
+                    rhs_data.species_F > NumSpec) {
+                    continue;
+                }
+
                 // Compute the forward term. It only has a contribution if
                 // the species we're taking the derivative with respect to
                 // (spec2) is one of (A, B, C). For the species that is spec2,

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -224,6 +224,20 @@ namespace RHS {
             data.exponent_D = 1;
             break;
 
+        case Ca40_He4_to_Ti44:
+            data.species_A = Ca40;
+            data.species_B = He4;
+            data.species_D = Ti44;
+
+            data.number_A = 1;
+            data.number_B = 1;
+            data.number_D = 1;
+
+            data.exponent_A = 1;
+            data.exponent_B = 1;
+            data.exponent_D = 1;
+            break;
+
         case Si28_7He4_to_Ni56:
             data.species_A = Si28;
             data.species_B = He4;

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -164,8 +164,11 @@ void iso7tab(const Real btemp, const Real bden,
             break;
 
         case (Ca40_He4_to_Ti44):
-            forward_dtab = RHS::density_exponent_forward<Ca40_He4_to_Ti44>();
-            reverse_dtab = RHS::density_exponent_reverse<Ca40_He4_to_Ti44>();
+            forward_exponent = RHS::density_exponent_forward<Ca40_He4_to_Ti44>();
+            reverse_exponent = RHS::density_exponent_reverse<Ca40_He4_to_Ti44>();
+
+            forward_dtab = std::pow(bden, forward_exponent);
+            reverse_dtab = std::pow(bden, reverse_exponent);
             break;
 
         case (Si28_7He4_to_Ni56):

--- a/networks/iso7/actual_rhs.H
+++ b/networks/iso7/actual_rhs.H
@@ -164,8 +164,8 @@ void iso7tab(const Real btemp, const Real bden,
             break;
 
         case (Ca40_He4_to_Ti44):
-            forward_dtab = bden;
-            reverse_dtab = 1.0e0_rt;
+            forward_dtab = RHS::density_exponent_forward<Ca40_He4_to_Ti44>();
+            reverse_dtab = RHS::density_exponent_reverse<Ca40_He4_to_Ti44>();
             break;
 
         case (Si28_7He4_to_Ni56):


### PR DESCRIPTION
We now have automatic tabulated rate density factor for Ca40->Ti44. The rate is added to rhs_data, but to exclude it from the actual RHS construction we make sure that we ignore reactions involving species whose ID is larger than NumSpec, which must be "extra" species.