### PR TITLE
Implement RHS using a compile-time for loop

### DIFF
--- a/interfaces/rhs_utilities.H
+++ b/interfaces/rhs_utilities.H
@@ -58,81 +58,15 @@ constexpr int factorial (int n)
     }
 }
 
-// Base case for recursion.
-template<int species>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr int add_nonzero_rates ()
+// Implementation of "constexpr for" based on
+// https://artificial-mind.net/blog/2020/10/31/constexpr-for
+template<auto I, auto N, class F>
+constexpr void rhs_for (F&& f)
 {
-    return 0;
-}
-
-// Recursively add nonzero rates.
-template<int species, int rate, int... rates>
-constexpr int add_nonzero_rates ()
-{
-    return RHS::is_rate_used<species, rate + 1>() + add_nonzero_rates<species, rates...>();
-}
-
-template<int species, int... rates>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr int num_rhs_impl (std::integer_sequence<int, rates...>)
-{
-    return add_nonzero_rates<species, rates...>();
-}
-
-// Base case for recursion (no rates were found).
-template<int species, int j>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr int actual_rhs_term_impl (int count)
-{
-    return -1;
-}
-
-// If we have counted up j nonzero rates, return the
-// current rate index. Otherwise, keep counting.
-template<int species, int j, int rate, int... rates>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr int actual_rhs_term_impl (int count)
-{
-    count += RHS::is_rate_used<species, rate + 1>();
-
-    if (count == j) {
-        return rate + 1;
+    if constexpr (I < N) {
+        f(std::integral_constant<decltype(I), I>());
+        rhs_for<I+1, N>(f);
     }
-    else {
-        return actual_rhs_term_impl<species, j, rates...>(count);
-    }
-}
-
-// Return the rate corresponding to the j'th contribution to the RHS.
-// We obtain this by looping through the rates, and counting each one
-// with a nonzero contribution. We stop when we have hit j of them.
-template<int species, int j, int... rates>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr int rhs_term_impl (std::integer_sequence<int, rates...>)
-{
-    return actual_rhs_term_impl<species, j, rates...>(0);
-}
-
-// Implicitly construct an Array1D by expanding the integer sequence.
-// Note that the integer sequence is zero-indexed but the terms are
-// one-indexed.
-template<int species, int... j>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr Array1D<Real, 1, sizeof...(j)>
-make_RHS_Array1D_impl (const burn_t& state, rate_fr_t const& rr, std::integer_sequence<int, j...>)
-{
-    return {{RHS::rhs_term<species, j+1>(state, rr)...}};
-}
-
-// Implicitly construct an Array1D by expanding the integer sequence.
-// Note that the integer sequence is zero-indexed but the terms are
-// one-indexed.
-template<int... species>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-Array1D<Real, 1, NumSpec> species_rhs_impl (const burn_t& state, rate_fr_t const& rr, std::integer_sequence<int, species...>)
-{
-    return {{RHS::species_rhs_n<species + 1>(state, rr)...}};
 }
 
 } // namespace RHS_impl
@@ -163,14 +97,6 @@ constexpr int is_rate_used ()
     } else {
         return 0;
     }
-}
-
-// Count number of nonzero RHS terms.
-template<int species>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr int num_rhs ()
-{
-    return RHS_impl::num_rhs_impl<species>(std::make_integer_sequence<int, Rates::NumRates>{});
 }
 
 // Calculate the density dependence term for tabulated rates. The RHS has a term
@@ -227,148 +153,6 @@ constexpr int density_exponent_reverse ()
     return exponent;
 }
 
-// Calculate the j'th RHS term for a given species.
-//
-// The general form of a reaction is
-// n_a A + n_b B + n_c C <-> n_d D + n_e E + n_f F
-// for species A, B, C, D, E, and F, where n_a particles of A,
-// n_b particles of B, and n_C particles of C are consumed in
-// the forward reaction and produced in the reverse reaction.
-//
-// For a given species, such as species A, the forward reaction
-// term is of the form
-// -n_A * Y(A)**a * Y(B)**b * Y(C)**c * forward_rate,
-// and the reverse reaction term is of the form
-//  n_A * Y(D)**d * Y(E)**e * Y(F)**f * reverse_rate.
-// Here a, b, and c are reaction-specific exponents which usually,
-// but not always, are equal to n_a, n_b, and n_c respectively.
-//
-// For example, in C12 + He4 <-> O16, species A is C12, species B
-// is He4, species D is O16 (the other species are unused). Then
-// n_a = n_b = n_d = 1, and a = b = d = 1. In the triple alpha forward
-// reaction we have A = He4, D = C12, n_a = 3, a = 3, and n_d = 1.
-//
-// We assume the reaction rates do not include the identical particle
-// factor, so we account for that here by dividing the rate by n!
-// Note that we use the exponent to determine this factorial term, not
-// the number consumed, because there are some reactions with special handling
-// like the Si28 + 7 * He4 <-> Ni56 reaction in iso7, where the number
-// of He4 consumed is not directly related to the actual reaction rate.
-// In every other case than that, the exponent should be equal to the
-// number consumed/produced, so there would be no difference.
-//
-// If a given reaction uses fewer than three species, we infer
-// this by calling its index -1 and then not accessing it
-// in the multiplication.
-template<int species, int j>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr Real rhs_term (const burn_t& state, rate_fr_t const& rr)
-{
-    constexpr int rate = RHS_impl::rhs_term_impl<species, j>(std::make_integer_sequence<int, Rates::NumRates>{});
-
-    constexpr rhs_t rhs_data = RHS::rhs_data(rate);
-
-    // First, compute the Y * rate component of both the forward and
-    // reverse reactions, which is the same regardless of which species
-    // we're producing or consuming.
-
-    Real forward_term = rr.forward(rate);
-
-    if constexpr (rhs_data.species_A >= 0) {
-        Real Y_A = state.xn[rhs_data.species_A-1] * aion_inv[rhs_data.species_A-1];
-        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_A);
-        forward_term *= std::pow(Y_A, rhs_data.exponent_A) /
-                        static_cast<Real>(identical_particle_factor);
-    }
-
-    if constexpr (rhs_data.species_B >= 0) {
-        Real Y_B = state.xn[rhs_data.species_B-1] * aion_inv[rhs_data.species_B-1];
-        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_B);
-        forward_term *= std::pow(Y_B, rhs_data.exponent_B) /
-                        static_cast<Real>(identical_particle_factor);
-    }
-
-    if constexpr (rhs_data.species_C >= 0) {
-        Real Y_C = state.xn[rhs_data.species_C-1] * aion_inv[rhs_data.species_C-1];
-        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_C);
-        forward_term *= std::pow(Y_C, rhs_data.exponent_C) /
-                        static_cast<Real>(identical_particle_factor);
-    }
-
-    Real reverse_term = rr.reverse(rate);
-
-    if constexpr (rhs_data.species_D >= 0) {
-        Real Y_D = state.xn[rhs_data.species_D-1] * aion_inv[rhs_data.species_D-1];
-        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_D);
-        reverse_term *= std::pow(Y_D, rhs_data.exponent_D) /
-                        static_cast<Real>(identical_particle_factor);
-    }
-
-    if constexpr (rhs_data.species_E >= 0) {
-        Real Y_E = state.xn[rhs_data.species_E-1] * aion_inv[rhs_data.species_E-1];
-        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_E);
-        reverse_term *= std::pow(Y_E, rhs_data.exponent_E) /
-                        static_cast<Real>(identical_particle_factor);
-    }
-
-    if constexpr (rhs_data.species_F >= 0) {
-        Real Y_F = state.xn[rhs_data.species_F-1] * aion_inv[rhs_data.species_F-1];
-        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_F);
-        reverse_term *= std::pow(Y_F, rhs_data.exponent_F) /
-                        static_cast<Real>(identical_particle_factor);
-    }
-
-    // Now compute the total contribution to this species.
-
-    Real term = 0.0_rt;
-
-    if constexpr (rhs_data.species_A == species) {
-        term = rhs_data.number_A * (reverse_term - forward_term);
-    }
-    if constexpr (rhs_data.species_B == species) {
-        term = rhs_data.number_B * (reverse_term - forward_term);
-    }
-    if constexpr (rhs_data.species_C == species) {
-        term = rhs_data.number_C * (reverse_term - forward_term);
-    }
-    if constexpr (rhs_data.species_D == species) {
-        term = rhs_data.number_D * (forward_term - reverse_term);
-    }
-    if constexpr (rhs_data.species_E == species) {
-        term = rhs_data.number_E * (forward_term - reverse_term);
-    }
-    if constexpr (rhs_data.species_F == species) {
-        term = rhs_data.number_F * (forward_term - reverse_term);
-    }
-
-    return term;
-}
-
-// Calculate the set of RHS terms.
-template<int species, int N>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-constexpr Array1D<Real, 1, N>
-make_RHS_Array1D (const burn_t& state, rate_fr_t const& rr)
-{
-    return RHS_impl::make_RHS_Array1D_impl<species>(state, rr, std::make_integer_sequence<int, N>{});
-}
-
-// Calculate the RHS for a given species by constructing the array of terms
-// and then summing them up.
-template<int species>
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-Real species_rhs_n (const burn_t& state, rate_fr_t const& rr)
-{
-    constexpr int nrhs = num_rhs<species>();
-    Array1D<Real, 1, nrhs> a = make_RHS_Array1D<species, nrhs>(state, rr);
-
-    Real sum = 0.0_rt;
-    for (int n = 1; n <= nrhs; ++n) {
-        sum += a(n);
-    }
-    return sum;
-}
-
 // Calculate the array of RHS terms over all species.
 // Legacy interface using old-style rate array.
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -382,14 +166,138 @@ Array1D<Real, 1, NumSpec> species_rhs (const burn_t& state, rate_t const& rr)
         rr_fr.reverse(j) = rr.rates(2 * j);
     }
 
-    return RHS_impl::species_rhs_impl(state, rr_fr, std::make_integer_sequence<int, NumSpec>{});
+    return species_rhs(state, rr_fr);
 }
 
 // Calculate the array of RHS terms over all species.
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 Array1D<Real, 1, NumSpec> species_rhs (const burn_t& state, rate_fr_t const& rr)
 {
-    return RHS_impl::species_rhs_impl(state, rr, std::make_integer_sequence<int, NumSpec>{});
+    Array1D<Real, 1, NumSpec> spec_rhs = {0.0};
+
+    // For every species, loop over all rates, and if that rate involves
+    // the given species, add its contribution to the RHS.
+
+    RHS_impl::rhs_for<1, NumSpec+1>([&] (auto species)
+    {
+        RHS_impl::rhs_for<1, Rates::NumRates+1>([&] (auto rate)
+        {
+            if constexpr (!is_rate_used<species, rate>()) {
+                return;
+            }
+
+            // The general form of a reaction is
+            // n_a A + n_b B + n_c C <-> n_d D + n_e E + n_f F
+            // for species A, B, C, D, E, and F, where n_a particles of A,
+            // n_b particles of B, and n_C particles of C are consumed in
+            // the forward reaction and produced in the reverse reaction.
+            //
+            // For a given species, such as species A, the forward reaction
+            // term is of the form
+            // -n_A * Y(A)**a * Y(B)**b * Y(C)**c * forward_rate,
+            // and the reverse reaction term is of the form
+            //  n_A * Y(D)**d * Y(E)**e * Y(F)**f * reverse_rate.
+            // Here a, b, and c are reaction-specific exponents which usually,
+            // but not always, are equal to n_a, n_b, and n_c respectively.
+            //
+            // For example, in C12 + He4 <-> O16, species A is C12, species B
+            // is He4, species D is O16 (the other species are unused). Then
+            // n_a = n_b = n_d = 1, and a = b = d = 1. In the triple alpha forward
+            // reaction we have A = He4, D = C12, n_a = 3, a = 3, and n_d = 1.
+            //
+            // We assume the reaction rates do not include the identical particle
+            // factor, so we account for that here by dividing the rate by n!
+            // Note that we use the exponent to determine this factorial term, not
+            // the number consumed, because there are some reactions with special handling
+            // like the Si28 + 7 * He4 <-> Ni56 reaction in iso7, where the number
+            // of He4 consumed is not directly related to the actual reaction rate.
+            // In every other case than that, the exponent should be equal to the
+            // number consumed/produced, so there would be no difference.
+            //
+            // If a given reaction uses fewer than three species, we infer
+            // this by calling its index -1 and then not accessing it
+            // in the multiplication.
+
+            constexpr rhs_t rhs_data = RHS::rhs_data(rate);
+
+            // First, compute the Y * rate component of both the forward and
+            // reverse reactions, which is the same regardless of which species
+            // we're producing or consuming.
+
+            Real forward_term = rr.forward(rate);
+
+            if constexpr (rhs_data.species_A >= 0) {
+                Real Y_A = state.xn[rhs_data.species_A-1] * aion_inv[rhs_data.species_A-1];
+                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_A);
+                forward_term *= std::pow(Y_A, rhs_data.exponent_A) /
+                    static_cast<Real>(identical_particle_factor);
+            }
+
+            if constexpr (rhs_data.species_B >= 0) {
+                Real Y_B = state.xn[rhs_data.species_B-1] * aion_inv[rhs_data.species_B-1];
+                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_B);
+                forward_term *= std::pow(Y_B, rhs_data.exponent_B) /
+                    static_cast<Real>(identical_particle_factor);
+            }
+
+            if constexpr (rhs_data.species_C >= 0) {
+                Real Y_C = state.xn[rhs_data.species_C-1] * aion_inv[rhs_data.species_C-1];
+                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_C);
+                forward_term *= std::pow(Y_C, rhs_data.exponent_C) /
+                    static_cast<Real>(identical_particle_factor);
+            }
+
+            Real reverse_term = rr.reverse(rate);
+
+            if constexpr (rhs_data.species_D >= 0) {
+                Real Y_D = state.xn[rhs_data.species_D-1] * aion_inv[rhs_data.species_D-1];
+                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_D);
+                reverse_term *= std::pow(Y_D, rhs_data.exponent_D) /
+                    static_cast<Real>(identical_particle_factor);
+            }
+
+            if constexpr (rhs_data.species_E >= 0) {
+                Real Y_E = state.xn[rhs_data.species_E-1] * aion_inv[rhs_data.species_E-1];
+                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_E);
+                reverse_term *= std::pow(Y_E, rhs_data.exponent_E) /
+                    static_cast<Real>(identical_particle_factor);
+            }
+
+            if constexpr (rhs_data.species_F >= 0) {
+                Real Y_F = state.xn[rhs_data.species_F-1] * aion_inv[rhs_data.species_F-1];
+                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_F);
+                reverse_term *= std::pow(Y_F, rhs_data.exponent_F) /
+                    static_cast<Real>(identical_particle_factor);
+            }
+
+            // Now compute the total contribution to this species.
+
+            Real term = 0.0_rt;
+
+            if constexpr (rhs_data.species_A == species) {
+                term = rhs_data.number_A * (reverse_term - forward_term);
+            }
+            if constexpr (rhs_data.species_B == species) {
+                term = rhs_data.number_B * (reverse_term - forward_term);
+            }
+            if constexpr (rhs_data.species_C == species) {
+                term = rhs_data.number_C * (reverse_term - forward_term);
+            }
+            if constexpr (rhs_data.species_D == species) {
+                term = rhs_data.number_D * (forward_term - reverse_term);
+            }
+            if constexpr (rhs_data.species_E == species) {
+                term = rhs_data.number_E * (forward_term - reverse_term);
+            }
+            if constexpr (rhs_data.species_F == species) {
+                term = rhs_data.number_F * (forward_term - reverse_term);
+            }
+
+            spec_rhs(species) += term;
+        });
+    });
+
+    return spec_rhs;
 }
 
 // Calculate the energy generation rate, including neutrino losses.

--- a/interfaces/rhs_utilities.H
+++ b/interfaces/rhs_utilities.H
@@ -293,10 +293,12 @@ Array1D<Real, 1, NumSpec> species_rhs (const burn_t& state, rate_fr_t const& rr)
     // For every species, loop over all rates, and if that rate involves
     // the given species, add its contribution to the RHS.
 
-    RHS_impl::rhs_for<1, NumSpec+1>([&] (auto species)
+    RHS_impl::rhs_for<1, NumSpec+1>([&] (auto n1)
     {
-        RHS_impl::rhs_for<1, Rates::NumRates+1>([&] (auto rate)
+        constexpr int species = n1;
+        RHS_impl::rhs_for<1, Rates::NumRates+1>([&] (auto n2)
         {
+            constexpr int rate = n2;
             if constexpr (is_rate_used<species, rate>()) {
                 spec_rhs(species) += RHS::rhs_term<species, rate>(state, rr);
             }

--- a/interfaces/rhs_utilities.H
+++ b/interfaces/rhs_utilities.H
@@ -46,6 +46,17 @@ Array2D<Real, 1, NumSpec, 1, NumSpec> species_jac (const burn_t& state, rate_t c
 
 namespace RHS_impl {
 
+// Implementation of "constexpr for" based on
+// https://artificial-mind.net/blog/2020/10/31/constexpr-for
+template<auto I, auto N, class F>
+constexpr void rhs_for (F&& f)
+{
+    if constexpr (I < N) {
+        f(std::integral_constant<decltype(I), I>());
+        rhs_for<I+1, N>(f);
+    }
+}
+
 // Calculate an integer factorial.
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 constexpr int factorial (int n)
@@ -55,17 +66,6 @@ constexpr int factorial (int n)
     }
     else {
         return n * factorial(n - 1);
-    }
-}
-
-// Implementation of "constexpr for" based on
-// https://artificial-mind.net/blog/2020/10/31/constexpr-for
-template<auto I, auto N, class F>
-constexpr void rhs_for (F&& f)
-{
-    if constexpr (I < N) {
-        f(std::integral_constant<decltype(I), I>());
-        rhs_for<I+1, N>(f);
     }
 }
 
@@ -153,6 +153,121 @@ constexpr int density_exponent_reverse ()
     return exponent;
 }
 
+// Calculate the RHS term for a given species and rate.
+//
+// The general form of a reaction is
+// n_a A + n_b B + n_c C <-> n_d D + n_e E + n_f F
+// for species A, B, C, D, E, and F, where n_a particles of A,
+// n_b particles of B, and n_C particles of C are consumed in
+// the forward reaction and produced in the reverse reaction.
+//
+// For a given species, such as species A, the forward reaction
+// term is of the form
+// -n_A * Y(A)**a * Y(B)**b * Y(C)**c * forward_rate,
+// and the reverse reaction term is of the form
+//  n_A * Y(D)**d * Y(E)**e * Y(F)**f * reverse_rate.
+// Here a, b, and c are reaction-specific exponents which usually,
+// but not always, are equal to n_a, n_b, and n_c respectively.
+//
+// For example, in C12 + He4 <-> O16, species A is C12, species B
+// is He4, species D is O16 (the other species are unused). Then
+// n_a = n_b = n_d = 1, and a = b = d = 1. In the triple alpha forward
+// reaction we have A = He4, D = C12, n_a = 3, a = 3, and n_d = 1.
+//
+// We assume the reaction rates do not include the identical particle
+// factor, so we account for that here by dividing the rate by n!
+// Note that we use the exponent to determine this factorial term, not
+// the number consumed, because there are some reactions with special handling
+// like the Si28 + 7 * He4 <-> Ni56 reaction in iso7, where the number
+// of He4 consumed is not directly related to the actual reaction rate.
+// In every other case than that, the exponent should be equal to the
+// number consumed/produced, so there would be no difference.
+//
+// If a given reaction uses fewer than three species, we infer
+// this by calling its index -1 and then not accessing it
+// in the multiplication.
+template<int species, int rate>
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+constexpr Real rhs_term (const burn_t& state, rate_fr_t const& rr)
+{
+    constexpr rhs_t rhs_data = RHS::rhs_data(rate);
+
+    // First, compute the Y * rate component of both the forward and
+    // reverse reactions, which is the same regardless of which species
+    // we're producing or consuming.
+
+    Real forward_term = rr.forward(rate);
+
+    if constexpr (rhs_data.species_A >= 0) {
+        Real Y_A = state.xn[rhs_data.species_A-1] * aion_inv[rhs_data.species_A-1];
+        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_A);
+        forward_term *= std::pow(Y_A, rhs_data.exponent_A) /
+                        static_cast<Real>(identical_particle_factor);
+    }
+
+    if constexpr (rhs_data.species_B >= 0) {
+        Real Y_B = state.xn[rhs_data.species_B-1] * aion_inv[rhs_data.species_B-1];
+        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_B);
+        forward_term *= std::pow(Y_B, rhs_data.exponent_B) /
+                        static_cast<Real>(identical_particle_factor);
+    }
+
+    if constexpr (rhs_data.species_C >= 0) {
+        Real Y_C = state.xn[rhs_data.species_C-1] * aion_inv[rhs_data.species_C-1];
+        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_C);
+        forward_term *= std::pow(Y_C, rhs_data.exponent_C) /
+                        static_cast<Real>(identical_particle_factor);
+    }
+
+    Real reverse_term = rr.reverse(rate);
+
+    if constexpr (rhs_data.species_D >= 0) {
+        Real Y_D = state.xn[rhs_data.species_D-1] * aion_inv[rhs_data.species_D-1];
+        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_D);
+        reverse_term *= std::pow(Y_D, rhs_data.exponent_D) /
+                        static_cast<Real>(identical_particle_factor);
+    }
+
+    if constexpr (rhs_data.species_E >= 0) {
+        Real Y_E = state.xn[rhs_data.species_E-1] * aion_inv[rhs_data.species_E-1];
+        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_E);
+        reverse_term *= std::pow(Y_E, rhs_data.exponent_E) /
+                        static_cast<Real>(identical_particle_factor);
+    }
+
+    if constexpr (rhs_data.species_F >= 0) {
+        Real Y_F = state.xn[rhs_data.species_F-1] * aion_inv[rhs_data.species_F-1];
+        constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_F);
+        reverse_term *= std::pow(Y_F, rhs_data.exponent_F) /
+                        static_cast<Real>(identical_particle_factor);
+    }
+
+    // Now compute the total contribution to this species.
+
+    Real term = 0.0_rt;
+
+    if constexpr (rhs_data.species_A == species) {
+        term = rhs_data.number_A * (reverse_term - forward_term);
+    }
+    if constexpr (rhs_data.species_B == species) {
+        term = rhs_data.number_B * (reverse_term - forward_term);
+    }
+    if constexpr (rhs_data.species_C == species) {
+        term = rhs_data.number_C * (reverse_term - forward_term);
+    }
+    if constexpr (rhs_data.species_D == species) {
+        term = rhs_data.number_D * (forward_term - reverse_term);
+    }
+    if constexpr (rhs_data.species_E == species) {
+        term = rhs_data.number_E * (forward_term - reverse_term);
+    }
+    if constexpr (rhs_data.species_F == species) {
+        term = rhs_data.number_F * (forward_term - reverse_term);
+    }
+
+    return term;
+}
+
 // Calculate the array of RHS terms over all species.
 // Legacy interface using old-style rate array.
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -182,118 +297,9 @@ Array1D<Real, 1, NumSpec> species_rhs (const burn_t& state, rate_fr_t const& rr)
     {
         RHS_impl::rhs_for<1, Rates::NumRates+1>([&] (auto rate)
         {
-            if constexpr (!is_rate_used<species, rate>()) {
-                return;
+            if constexpr (is_rate_used<species, rate>()) {
+                spec_rhs(species) += RHS::rhs_term<species, rate>(state, rr);
             }
-
-            // The general form of a reaction is
-            // n_a A + n_b B + n_c C <-> n_d D + n_e E + n_f F
-            // for species A, B, C, D, E, and F, where n_a particles of A,
-            // n_b particles of B, and n_C particles of C are consumed in
-            // the forward reaction and produced in the reverse reaction.
-            //
-            // For a given species, such as species A, the forward reaction
-            // term is of the form
-            // -n_A * Y(A)**a * Y(B)**b * Y(C)**c * forward_rate,
-            // and the reverse reaction term is of the form
-            //  n_A * Y(D)**d * Y(E)**e * Y(F)**f * reverse_rate.
-            // Here a, b, and c are reaction-specific exponents which usually,
-            // but not always, are equal to n_a, n_b, and n_c respectively.
-            //
-            // For example, in C12 + He4 <-> O16, species A is C12, species B
-            // is He4, species D is O16 (the other species are unused). Then
-            // n_a = n_b = n_d = 1, and a = b = d = 1. In the triple alpha forward
-            // reaction we have A = He4, D = C12, n_a = 3, a = 3, and n_d = 1.
-            //
-            // We assume the reaction rates do not include the identical particle
-            // factor, so we account for that here by dividing the rate by n!
-            // Note that we use the exponent to determine this factorial term, not
-            // the number consumed, because there are some reactions with special handling
-            // like the Si28 + 7 * He4 <-> Ni56 reaction in iso7, where the number
-            // of He4 consumed is not directly related to the actual reaction rate.
-            // In every other case than that, the exponent should be equal to the
-            // number consumed/produced, so there would be no difference.
-            //
-            // If a given reaction uses fewer than three species, we infer
-            // this by calling its index -1 and then not accessing it
-            // in the multiplication.
-
-            constexpr rhs_t rhs_data = RHS::rhs_data(rate);
-
-            // First, compute the Y * rate component of both the forward and
-            // reverse reactions, which is the same regardless of which species
-            // we're producing or consuming.
-
-            Real forward_term = rr.forward(rate);
-
-            if constexpr (rhs_data.species_A >= 0) {
-                Real Y_A = state.xn[rhs_data.species_A-1] * aion_inv[rhs_data.species_A-1];
-                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_A);
-                forward_term *= std::pow(Y_A, rhs_data.exponent_A) /
-                    static_cast<Real>(identical_particle_factor);
-            }
-
-            if constexpr (rhs_data.species_B >= 0) {
-                Real Y_B = state.xn[rhs_data.species_B-1] * aion_inv[rhs_data.species_B-1];
-                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_B);
-                forward_term *= std::pow(Y_B, rhs_data.exponent_B) /
-                    static_cast<Real>(identical_particle_factor);
-            }
-
-            if constexpr (rhs_data.species_C >= 0) {
-                Real Y_C = state.xn[rhs_data.species_C-1] * aion_inv[rhs_data.species_C-1];
-                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_C);
-                forward_term *= std::pow(Y_C, rhs_data.exponent_C) /
-                    static_cast<Real>(identical_particle_factor);
-            }
-
-            Real reverse_term = rr.reverse(rate);
-
-            if constexpr (rhs_data.species_D >= 0) {
-                Real Y_D = state.xn[rhs_data.species_D-1] * aion_inv[rhs_data.species_D-1];
-                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_D);
-                reverse_term *= std::pow(Y_D, rhs_data.exponent_D) /
-                    static_cast<Real>(identical_particle_factor);
-            }
-
-            if constexpr (rhs_data.species_E >= 0) {
-                Real Y_E = state.xn[rhs_data.species_E-1] * aion_inv[rhs_data.species_E-1];
-                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_E);
-                reverse_term *= std::pow(Y_E, rhs_data.exponent_E) /
-                    static_cast<Real>(identical_particle_factor);
-            }
-
-            if constexpr (rhs_data.species_F >= 0) {
-                Real Y_F = state.xn[rhs_data.species_F-1] * aion_inv[rhs_data.species_F-1];
-                constexpr int identical_particle_factor = RHS_impl::factorial(rhs_data.exponent_F);
-                reverse_term *= std::pow(Y_F, rhs_data.exponent_F) /
-                    static_cast<Real>(identical_particle_factor);
-            }
-
-            // Now compute the total contribution to this species.
-
-            Real term = 0.0_rt;
-
-            if constexpr (rhs_data.species_A == species) {
-                term = rhs_data.number_A * (reverse_term - forward_term);
-            }
-            if constexpr (rhs_data.species_B == species) {
-                term = rhs_data.number_B * (reverse_term - forward_term);
-            }
-            if constexpr (rhs_data.species_C == species) {
-                term = rhs_data.number_C * (reverse_term - forward_term);
-            }
-            if constexpr (rhs_data.species_D == species) {
-                term = rhs_data.number_D * (forward_term - reverse_term);
-            }
-            if constexpr (rhs_data.species_E == species) {
-                term = rhs_data.number_E * (forward_term - reverse_term);
-            }
-            if constexpr (rhs_data.species_F == species) {
-                term = rhs_data.number_F * (forward_term - reverse_term);
-            }
-
-            spec_rhs(species) += term;
         });
     });
 

--- a/interfaces/rhs_utilities.H
+++ b/interfaces/rhs_utilities.H
@@ -48,6 +48,20 @@ namespace RHS_impl {
 
 // Implementation of "constexpr for" based on
 // https://artificial-mind.net/blog/2020/10/31/constexpr-for
+//
+// Approximates what one would get from a compile-time
+// unrolling of the loop
+// for (int i = 0; i < N; ++i) {
+//    f(i);
+// }
+//
+// The mechanism is recursive, we evaluate f(i) at the current
+// i and then call the for loop at i+1. f() is a lambda function
+// that provides the body of the loop and takes only an integer
+// i as its argument. It is assumed that at the loop call site
+// the lambda is declared [&] so that it can operate on whatever
+// data it needs.
+
 template<auto I, auto N, class F>
 constexpr void rhs_for (F&& f)
 {


### PR DESCRIPTION
The current method for constructing the RHS involves creating an array of all terms which participate in the reaction and then summing them together. This is suboptimal for two reasons: the construction of the intermediate array is no longer necessary (since we're not using esum anymore), and the code is quite hard to understand. But with C++17 we can effectively get compile-time/constexpr for loops using the method described [here](https://artificial-mind.net/blog/2020/10/31/constexpr-for). The main change is then that the body of the for loop is a lambda whose argument is the for loop index. As a result we can write an intuitive RHS construction which loops over species and then rates and adds a given term to the RHS if that species is involved in that rate.

The primary drawback is that gcc < 9 does not compile this code, so gcc >= 9 would become the de facto minimum compiler version for Castro and Maestro. If this became a problem, we could work around it by writing a version of `rhs_term()` that does not depend on any compile-time evaluation. It would be much slower at runtime relative to the current code, though -- some benchmarking suggests it would make test_react for iso7 take more than 2x the current time.