### PR TITLE
do a better job at cleaning up linked files

### DIFF
--- a/Make.Microphysics
+++ b/Make.Microphysics
@@ -249,8 +249,6 @@ clean::
 clean::
 	$(RM) network.f90
 	$(RM) extern.f90
-	@if [ -L helm_table.dat ]; then rm -f helm_table.dat; fi
-	@if [ -L nse19.tbl ]; then rm -f nse19.tbl; fi
 
 
 # for debugging.  To see the value of a Makefile variable,

--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -129,3 +129,8 @@ endif
 EXTERN_CORE += $(MICROPHYSICS_HOME)/constants
 
 
+clean::
+	@if [ -L helm_table.dat ]; then rm -f helm_table.dat; fi
+	@if [ -L reaclib_rate_metadata.dat ]; then rm -f reaclib_rate_metadata.dat; fi
+	@if [ ! -f nse19.tbl ]; then rm -f nse19.tbl; fi
+	$(foreach t, $(NET_TABLES), $(shell if [ ! -L `basename $t` ]; then rm -f `basename $t` ; fi))

--- a/unit_test/test_jac/GNUmakefile
+++ b/unit_test/test_jac/GNUmakefile
@@ -50,6 +50,3 @@ Blocs   := .
 
 include $(MICROPHYSICS_HOME)/unit_test/Make.unit_test
 
-clean::
-	$(RM) *.dat
-

--- a/unit_test/test_react/GNUmakefile
+++ b/unit_test/test_react/GNUmakefile
@@ -48,6 +48,3 @@ Blocs   := .
 
 include $(MICROPHYSICS_HOME)/unit_test/Make.unit_test
 
-clean::
-	$(RM) *.dat
-

--- a/unit_test/test_rhs/GNUmakefile
+++ b/unit_test/test_rhs/GNUmakefile
@@ -44,7 +44,3 @@ Bpack   := ./Make.package
 Blocs   := .
 
 include $(MICROPHYSICS_HOME)/unit_test/Make.unit_test
-
-clean::
-	$(RM) *.dat
-

--- a/unit_test/test_sdc_vode_rhs/GNUmakefile
+++ b/unit_test/test_sdc_vode_rhs/GNUmakefile
@@ -45,6 +45,3 @@ Blocs   := .
 
 include $(MICROPHYSICS_HOME)/unit_test/Make.unit_test
 
-clean::
-	$(RM) *.dat
-


### PR DESCRIPTION
this now cleans up the pynucastro files and helm in the _extern stub
this way application codes pick up these rules automagically