### PR TITLE
Remove implicit d/dP terms in aprox19 and aprox21 Jacobians

### DIFF
--- a/networks/aprox19/actual_rhs.H
+++ b/networks/aprox19/actual_rhs.H
@@ -1896,9 +1896,9 @@ void dfdy_isotopes_aprox19 (Array1D<Real, 1, NumSpec> const& y,
     b(1)  =  2.0e0_rt * y(Fe54) * y(P) * ratdum(ir5f54);
     b(2)  =  0.0;
     b(3)  =  0.0;
-    b(4)  = -y(Fe52) * y(He4) * ratdum(ir7f54);
+    b(4)  =  0.0;
     b(5)  =  0.0;
-    b(6)  =  y(Ni56) * ratdum(ir8f54);
+    b(6)  =  0.0;
     b(7)  =  0.0;
     b(8)  =  0.0;
     b(9)  =  2.0e0_rt * y(N)*y(N) * y(P) * ratdum(iralf2);
@@ -2261,9 +2261,9 @@ void dfdy_isotopes_aprox19 (Array1D<Real, 1, NumSpec> const& y,
     b(1) =  2.0e0_rt * y(Fe54) * y(P) * ratdum(ir5f54);
     b(2) =  0.0;
     b(3) =  0.0;
-    b(4) = -y(Fe52) * y(He4) * ratdum(ir7f54);
+    b(4) =  0.0;
     b(5) =  0.0;
-    b(6) =  y(Ni56) * ratdum(ir8f54);
+    b(6) =  0.0;
     b(7) =  0.0;
     dfdy(Fe52,P) = esum7(b);
 
@@ -2329,9 +2329,9 @@ void dfdy_isotopes_aprox19 (Array1D<Real, 1, NumSpec> const& y,
     b(1) =  2.0e0_rt * y(Fe54) * y(P) * ratdum(ir3f54);
     b(2) =  0.0;
     b(3) =  0.0;
-    b(4) =  y(Fe52) * y(He4)* ratdum(ir7f54);
+    b(4) =  0.0;
     b(5) =  0.0;
-    b(6) = -y(Ni56) * ratdum(ir8f54);
+    b(6) =  0.0;
     b(7) =  0.0;
     dfdy(Ni56,P) = esum7(b);
 

--- a/networks/aprox21/actual_rhs.H
+++ b/networks/aprox21/actual_rhs.H
@@ -2152,10 +2152,10 @@ void dfdy_isotopes_aprox21 (Array1D<Real, 1, NumSpec> const& y,
     b(1)  =  2.0e0_rt * y(Fe54) * y(P) * rr(1).rates(ir5f54);
     b(2)  =  y(Fe54) * y(P) * y(P) * rr(3).rates(ir5f54);
     b(3)  = -y(He4) * y(Fe52) * rr(3).rates(ir6f54);
-    b(4)  = -y(Fe52) * y(He4) * rr(1).rates(ir7f54);
-    b(5)  = -y(Fe52) * y(He4) * y(P) * rr(3).rates(ir7f54);
-    b(6)  =  y(Ni56) * rr(1).rates(ir8f54);
-    b(7)  =  y(Ni56) * y(P) * rr(3).rates(ir8f54);
+    b(4)  =  0.0_rt;
+    b(5)  =  0.0_rt;
+    b(6)  =  0.0_rt;
+    b(7)  =  0.0_rt;
     b(8)  = -y(He4) * rr(4).rates(iralf1);
     b(9)  =  2.0e0_rt * y(N)*y(N) * y(P) * rr(1).rates(iralf2);
     b(10) =  y(N)*y(N) * y(P)*y(P) * rr(4).rates(iralf2);
@@ -2548,10 +2548,10 @@ void dfdy_isotopes_aprox21 (Array1D<Real, 1, NumSpec> const& y,
     b(1) =  2.0e0_rt * y(Fe54) * y(P) * rr(1).rates(ir5f54);
     b(2) =  y(Fe54) * y(P) * y(P) * rr(3).rates(ir5f54);
     b(3) = -y(He4) * y(Fe52) * rr(3).rates(ir6f54);
-    b(4) = -y(Fe52) * y(He4) * rr(1).rates(ir7f54);
-    b(5) = -y(Fe52) * y(He4) * y(P) * rr(3).rates(ir7f54);
-    b(6) =  y(Ni56) * rr(1).rates(ir8f54);
-    b(7) =  y(Ni56) * y(P) * rr(3).rates(ir8f54);
+    b(4) =  0.0_rt;
+    b(5) =  0.0_rt;
+    b(6) =  0.0_rt;
+    b(7) =  0.0_rt;
     dfdy(Fe52, P) = esum7(b);
 
 
@@ -2668,10 +2668,10 @@ void dfdy_isotopes_aprox21 (Array1D<Real, 1, NumSpec> const& y,
     b(1) =  2.0e0_rt * y(Fe54) * y(P) * rr(1).rates(ir3f54);
     b(2) =  y(Fe54) * y(P) * y(P) * rr(3).rates(ir3f54);
     b(3) = -y(Ni56) * rr(3).rates(ir4f54);
-    b(4) =  y(Fe52) * y(He4)* rr(1).rates(ir7f54);
-    b(5) =  y(Fe52) * y(He4)* y(P) * rr(3).rates(ir7f54);
-    b(6) = -y(Ni56) * rr(1).rates(ir8f54);
-    b(7) = -y(Ni56) * y(P) * rr(3).rates(ir8f54);
+    b(4) =  0.0_rt;
+    b(5) =  0.0_rt;
+    b(6) =  0.0_rt;
+    b(7) =  0.0_rt;
     dfdy(Ni56, P) = esum7(b);
 
 


### PR DESCRIPTION
In both aprox19 and aprox21 there is the reaction sequence Fe52(a,p)Co55(p,g)Ni56. Co55 is an equilibrium isotope in this reaction chain, and its equilibrium abundance depends on both this reaction sequence as well as the reaction Fe54(p,g)Co55. Since there are two contributions to the effective y(Co55), the rate ends up being somewhat complicated, but the RHS term ends up simply looking like `y(Fe52) * y(He4) * y(P) * rate`. The Jacobian terms consequently have a d/dP entry. However, although the proton abundance plays a role in determining the rate, the reaction sequence doesn't actually consume or produce a net proton, so it is more appropriate to think of y(P) as being part of the rate rather than part of the RHS. If the y(P) is absorbed into the rate, then this term should not appear in the Jacobian due to the same reason #686 was done: in the upcoming network rewrite, it will not be straightforward (or desirable) to represent any d(rate)/dy term. So this PR proposes removing the term on the basis that it will eventually be removed anyway, and this will make the network rewrite PR easier to evaluate when comparing test_rhs and test_react.