### PR TITLE
Template EOS operator<< and use SFINAE to only operate on eos_t

### DIFF
--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -296,8 +296,12 @@ std::ostream& print_state (std::ostream& o, T const& eos_state)
     return o;
 }
 
+template <typename T, typename U = typename std::enable_if<std::is_same<T, eos_t>::value ||
+                                                           std::is_same<T, eos_re_t>::value ||
+                                                           std::is_same<T, eos_rep_t>::value
+                                                           >::type>
 inline
-std::ostream& operator<< (std::ostream& o, eos_base_t const& eos_state)
+std::ostream& operator<< (std::ostream& o, T const& eos_state)
 {
     return print_state(o, eos_state);
 }


### PR DESCRIPTION
This fixes #859.

Note that I think this can be done more elegantly by [matching all structs which inherit from eos_base_t](https://en.cppreference.com/w/cpp/types/is_base_of), so that could be a future improvement.