### PR TITLE
add Jacobian output to test_sdc_vode_rhs

### DIFF
--- a/unit_test/test_sdc_vode_rhs/vode_rhs_test.H
+++ b/unit_test/test_sdc_vode_rhs/vode_rhs_test.H
@@ -342,10 +342,13 @@ void do_vode_rhs()
     }
 #endif
 
-    // these need to be initialized 
+    // these need to be initialized
 
     burn_state.sdc_iter = 1;
     burn_state.num_sdc_iters = 1;
+    burn_state.i = 0;
+    burn_state.j = 0;
+    burn_state.k = 0;
 
     for (int n = 0; n < NumSpec; ++n) {
         burn_state.xn[n] = massfractions[n];
@@ -382,10 +385,23 @@ void do_vode_rhs()
     rhs(0.0_rt, burn_state, vode_state, ydot);
 
     std::cout << "ydot = " << std::endl;
-    for (int n = 1; n <= NumSpec+1; n++) {
+    for (int n = 1; n <= VODE_NEQS; n++) {
         std::cout << n << " " << ydot(n) << std::endl;
     }
- 
+
+    // call the Jacobian
+
+    RArray2D pd;
+    jac(burn_state, vode_state, pd);
+
+    for (int row = 1; row <= VODE_NEQS; ++row) {
+        for (int col = 1; col <= VODE_NEQS; ++col) {
+            std::cout << "(" << std::setw(2) << row << "," << std::setw(2) << col << ") = " << pd(row,col) << std::endl;
+        }
+    }
+
+    // do a full burn to make sure this zone can be integrated
+
     std::cout << "now do a burn" << std::endl;
 
     integrator(burn_state, tmax);


### PR DESCRIPTION
this comes directly from the VODE jac() wrapper, so applies for
jacobian = 1 or jacobian = 3