### PR TITLE
fix potential out of bound error in nse_check

### DIFF
--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -290,6 +290,13 @@ void fill_reaction_timescale(amrex::Array1D<T, 1, Rates::NumRates>& reaction_tim
         }
     }
 
+    //
+    // 4) If the rate only involves Neutron, Proton or Helium-4
+    //
+    if (non_NHA_ind(1) == -1) {
+        return;
+    }
+
     // Calculate the forward and reverse rates of the current rate index
 
     amrex::Real b_f;


### PR DESCRIPTION
This happens when the rate only invovles neutron, proton or helium, then non_NHA_ind is -1, which is out of bound