### PR TITLE
eliminate an exp at the low end of screening

### DIFF
--- a/screening/screen.H
+++ b/screening/screen.H
@@ -330,7 +330,10 @@ number_t actual_screen5 (const plasma_state_t<number_t>& state,
 
     // machine limit the output
     // further limit to avoid the pycnonuclear regime
-    h12 = admath::max(admath::min(h12, h12_max), 0.0_rt);
+    h12 = admath::min(h12, h12_max);
+    if (h12 <= 0.0) {
+        return 1.0;
+    }
     return admath::exp(h12);
 }
 


### PR DESCRIPTION
(found this while testing profiling for our hackathon on Thurs)