### PR TITLE
for burn failures, 16 digits output does not guarantee reproducibility

### DIFF
--- a/integration/integrator_data.H
+++ b/integration/integrator_data.H
@@ -1,6 +1,8 @@
 #ifndef INTEGRATOR_DATA_H
 #define INTEGRATOR_DATA_H
 
+#include <limits>
+
 #include <burn_type.H>
 
 // Define the size of the ODE system that VODE will integrate
@@ -11,6 +13,10 @@ constexpr int INT_NEQS = NumSpec + 1;
 // abundance is unreasonably small or large (each X must satisfy
 // -failure_tolerance <= X <= 1.0 + failure_tolerance).
 constexpr amrex::Real species_failure_tolerance = 1.e-2_rt;
+
+// for outputting the burn state failure, use enough precision
+// to be reproducible (not guaranteed for std::fixed)
+constexpr int OUTDIGITS = std::numeric_limits<amrex::Real>::max_digits10;
 
 #ifdef NSE
 constexpr int MIN_NSE_BAILOUT_STEPS = 10;

--- a/integration/integrator_setup_sdc.H
+++ b/integration/integrator_setup_sdc.H
@@ -219,47 +219,47 @@ void integrator_cleanup (IntegratorT& int_state, BurnT& state,
             }
             std::cout << "zone = (" << state.i << ", " << state.j << ", " << state.k << ")" << std::endl;
             std::cout << "time = " << state.time << std::endl;
-            std::cout << "dt = " << std::setprecision(16) << dt << std::endl;
-            std::cout << "dens start = " << std::setprecision(16) << state.rho_orig << std::endl;
-            std::cout << "temp start = " << std::setprecision(16) << state_save.T_in << std::endl;
-            std::cout << "rhoe start = " << std::setprecision(16) << state_save.rhoe_in << std::endl;
+            std::cout << "dt = " << std::setprecision(OUTDIGITS) << dt << std::endl;
+            std::cout << "dens start = " << std::setprecision(OUTDIGITS) << state.rho_orig << std::endl;
+            std::cout << "temp start = " << std::setprecision(OUTDIGITS) << state_save.T_in << std::endl;
+            std::cout << "rhoe start = " << std::setprecision(OUTDIGITS) << state_save.rhoe_in << std::endl;
             std::cout << "xn start = ";
             for (const auto X : state_save.xn_in) {
-                std::cout << std::setprecision(16) << X << " ";
+                std::cout << std::setprecision(OUTDIGITS) << X << " ";
             }
             std::cout << std::endl;
 #ifdef AUX_THERMO
             std::cout << "aux start = ";
             for (const auto aux : state_save.aux_in) {
-                std::cout << std::setprecision(16) << aux << " ";
+                std::cout << std::setprecision(OUTDIGITS) << aux << " ";
             }
             std::cout << std::endl;
 #endif
-            std::cout << "dens current = " << std::setprecision(16) << state.rho << std::endl;
-            std::cout << "temp current = " << std::setprecision(16) << state.T << std::endl;
+            std::cout << "dens current = " << std::setprecision(OUTDIGITS) << state.rho << std::endl;
+            std::cout << "temp current = " << std::setprecision(OUTDIGITS) << state.T << std::endl;
             std::cout << "xn current = ";
             for (int n = 0; n < NumSpec; ++n) {
-                std::cout << std::setprecision(16) << state.xn[n] << " ";
+                std::cout << std::setprecision(OUTDIGITS) << state.xn[n] << " ";
             }
             std::cout << std::endl;
 #ifdef AUX_THERMO
             std::cout << "aux current = ";
             for (int n = 0; n < NumAux; ++n) {
-                std::cout << std::setprecision(16) << state.aux[n] << " ";
+                std::cout << std::setprecision(OUTDIGITS) << state.aux[n] << " ";
             }
             std::cout << std::endl;
 #endif
-            std::cout << "A(rho) = " << std::setprecision(16) << state.ydot_a[SRHO] << std::endl;
-            std::cout << "A(rho e) = " << std::setprecision(16) << state.ydot_a[SEINT] << std::endl;
+            std::cout << "A(rho) = " << std::setprecision(OUTDIGITS) << state.ydot_a[SRHO] << std::endl;
+            std::cout << "A(rho e) = " << std::setprecision(OUTDIGITS) << state.ydot_a[SEINT] << std::endl;
             std::cout << "A(rho X_k) = ";
             for (int n = 0; n < NumSpec; n++) {
-                std::cout << std::setprecision(16) << state.ydot_a[SFS+n] << " ";
+                std::cout << std::setprecision(OUTDIGITS) << state.ydot_a[SFS+n] << " ";
             }
             std::cout << std::endl;
 #ifdef AUX_THERMO
             std::cout << "A(rho aux_k) = ";
             for (int n = 0; n < NumAux; n++) {
-                std::cout << std::setprecision(16) << state.ydot_a[SFX+n] << " ";
+                std::cout << std::setprecision(OUTDIGITS) << state.ydot_a[SFX+n] << " ";
             }
             std::cout << std::endl;
 #endif

--- a/integration/integrator_setup_strang.H
+++ b/integration/integrator_setup_strang.H
@@ -190,18 +190,18 @@ void integrator_cleanup (IntegratorT& int_state, BurnT& state,
         }
         std::cout << "zone = (" << state.i << ", " << state.j << ", " << state.k << ")" << std::endl;
         std::cout << "time = " << int_state.t << std::endl;
-        std::cout << "dt = " << std::setprecision(16) << dt << std::endl;
-        std::cout << "temp start = " << std::setprecision(16) << state_save.T_in << std::endl;
+        std::cout << "dt = " << std::setprecision(OUTDIGITS) << dt << std::endl;
+        std::cout << "temp start = " << std::setprecision(OUTDIGITS) << state_save.T_in << std::endl;
         std::cout << "xn start = ";
         for (const double X : state_save.xn_in) {
-            std::cout << std::scientific << std::setprecision(16) << X << " ";
+            std::cout << std::scientific << std::setprecision(OUTDIGITS) << X << " ";
         }
         std::cout << std::endl;
-        std::cout << "dens current = " << std::setprecision(16) << state.rho << std::endl;
-        std::cout << "temp current = " << std::setprecision(16) << state.T << std::endl;
+        std::cout << "dens current = " << std::setprecision(OUTDIGITS) << state.rho << std::endl;
+        std::cout << "temp current = " << std::setprecision(OUTDIGITS) << state.T << std::endl;
         std::cout << "xn current = ";
         for (const double X : state.xn) {
-            std::cout << std::scientific << std::setprecision(16) << X << " ";
+            std::cout << std::scientific << std::setprecision(OUTDIGITS) << X << " ";
         }
         std::cout << std::endl;
         std::cout << "energy generated = " << state.e << std::endl;


### PR DESCRIPTION
now we use std::numeric_limits<amrex::Real>::max_digits10 (which is 17 for double).
This should help with testing burn failures offline.