### PR TITLE
some more templating of apply_electrons

### DIFF
--- a/EOS/helmholtz/actual_eos.H
+++ b/EOS/helmholtz/actual_eos.H
@@ -348,8 +348,8 @@ void apply_electrons (T& state)
 
 
     // electron chemical potential etaele
+    [[maybe_unused]] amrex::Real etaele{};
     if constexpr (has_eta<T>::value) {
-        amrex::Real etaele = 0.0e0_rt;
         amrex::constexpr_for<0, 16>([&] (auto K) {
             constexpr int k = K;
             constexpr auto m = electron_table_indexing::map[k];
@@ -359,8 +359,8 @@ void apply_electrons (T& state)
     }
 
     // electron + positron number densities
+    [[maybe_unused]] amrex::Real xnefer{};
     if constexpr (has_xne_xnp<T>::value) {
-        amrex::Real xnefer = 0.0e0_rt;
         amrex::constexpr_for<0, 16>([&] (auto K) {
             constexpr int k = K;
             constexpr auto m = electron_table_indexing::map[k];
@@ -378,14 +378,16 @@ void apply_electrons (T& state)
     amrex::Real x       = din * din;
     amrex::Real pele    = x * df_d;
     amrex::Real dpepdt  = x * df_dt;
+    [[maybe_unused]] amrex::Real dpepda{};
+    [[maybe_unused]] amrex::Real dpepdz{};
     if constexpr (has_dpdA<T>::value || has_dpdZ<T>::value) {
         amrex::Real s       = dpepdd/state.y_e - 2.0e0_rt * din * df_d;
-    }
-    if constexpr (has_dpdA<T>::value) {
-        amrex::Real dpepda  = -ytot1 * (2.0e0_rt * pele + s * din);
-    }
-    if constexpr (has_dpdZ<T>::value) {
-        amrex::Real dpepdz  = state.rho*ytot1*(2.0e0_rt * din * df_d  +  s);
+        if constexpr (has_dpdA<T>::value) {
+            dpepda  = -ytot1 * (2.0e0_rt * pele + s * din);
+        }
+        if constexpr (has_dpdZ<T>::value) {
+            dpepdz  = state.rho*ytot1*(2.0e0_rt * din * df_d  +  s);
+        }
     }
 
     x            = state.y_e * state.y_e;
@@ -397,14 +399,16 @@ void apply_electrons (T& state)
     amrex::Real deepdt  = state.T * dsepdt;
     amrex::Real deepdd  = x * df_d + state.T * dsepdd;
 
+    [[maybe_unused]] amrex::Real deepda{};
     if constexpr (has_dedA<T>::value) {
-        amrex::Real dsepda  = ytot1 * (state.y_e * df_dt * din - sele);
-        amrex::Real deepda  = -state.y_e * ytot1 * (free +  df_d * din) + state.T * dsepda;
+        amrex::Real dsepda = ytot1 * (state.y_e * df_dt * din - sele);
+        deepda = -state.y_e * ytot1 * (free +  df_d * din) + state.T * dsepda;
     }
 
+    [[maybe_unused]] amrex::Real deepdz{};
     if constexpr (has_dedZ<T>::value) {
-        amrex::Real dsepdz  = -ytot1 * (state.y_e * df_dt * state.rho  + df_t);
-        amrex::Real deepdz  = ytot1* (free + state.y_e * df_d * state.rho) + state.T * dsepdz;
+        amrex::Real dsepdz = -ytot1 * (state.y_e * df_dt * state.rho  + df_t);
+        deepdz = ytot1* (free + state.y_e * df_d * state.rho) + state.T * dsepdz;
     }
 
     if constexpr (has_pressure<T>::value) {
@@ -564,14 +568,10 @@ void apply_radiation (T& state)
 
     amrex::Real dpraddd = 0.0e0_rt;
     amrex::Real dpraddt = 4.0e0_rt * prad * tempi;
-    [[maybe_unused]] amrex::Real dpradda = 0.0e0_rt;
-    [[maybe_unused]] amrex::Real dpraddz = 0.0e0_rt;
 
     amrex::Real erad    = 3.0e0_rt * prad*deni;
     amrex::Real deraddd = -erad * deni;
     amrex::Real deraddt = 3.0e0_rt * dpraddt * deni;
-    [[maybe_unused]] amrex::Real deradda = 0.0e0_rt;
-    [[maybe_unused]] amrex::Real deraddz = 0.0e0_rt;
 
     amrex::Real srad    = (prad * deni + erad) * tempi;
     amrex::Real dsraddd = (dpraddd * deni - prad * deni * deni + deraddd) * tempi;
@@ -586,10 +586,10 @@ void apply_radiation (T& state)
         state.dpdr = dpraddd;
         state.dpdT = dpraddt;
         if constexpr (has_dpdA<T>::value) {
-            state.dpdA = dpradda;
+            state.dpdA = 0.0_rt;
         }
         if constexpr (has_dpdZ<T>::value) {
-            state.dpdZ = dpraddz;
+            state.dpdZ = 0.0_rt;
         }
     }
 
@@ -598,10 +598,10 @@ void apply_radiation (T& state)
         state.dedr = deraddd;
         state.dedT = deraddt;
         if constexpr (has_dedA<T>::value) {
-            state.dedA = deradda;
+            state.dedA = 0.0_rt;
         }
         if constexpr (has_dedZ<T>::value) {
-            state.dedZ = deraddz;
+            state.dedZ = 0.0_rt;
         }
     }
 


### PR DESCRIPTION
don't compute the electron number density or degeneracy parameter unless needed. Also block off composition derivatives.