### PR TITLE
add an assert on the NSE table index

### DIFF
--- a/nse_tabular/nse_table.H
+++ b/nse_tabular/nse_table.H
@@ -25,7 +25,9 @@ using namespace network_rp;
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int nse_idx(const int ir, const int it, const int ic) {
     // this uses a 1-based indexing
-    return (ir-1) * nse_table_size::ntemp * nse_table_size::nye + (it-1) * nse_table_size::nye + ic;
+    int idx = (ir-1) * nse_table_size::ntemp * nse_table_size::nye + (it-1) * nse_table_size::nye + ic;
+    AMREX_ASSERT(idx >= 1 && idx <= nse_table::npts);
+    return idx;
 }
 
 AMREX_INLINE

--- a/unit_test/nse_table_cell/README.md
+++ b/unit_test/nse_table_cell/README.md
@@ -1,4 +1,10 @@
 # nse_table_cell
 
-Given an input rho, T, Ye, evaluate the NSE table and print the outputs
+Given an input rho, T, Ye, evaluate the NSE table and print the outputs.
+This can be run as:
+
+```
+./main3d.gnu.ex unit_test.density=1.e9 unit_test.temperature=4.e9 unit_test.ye=0.5
+```
+
 


### PR DESCRIPTION
we should not be going out of bounds because we clamp the input state to the table limits, but this adds an additional check when run in debug mode.