### PR TITLE
make species_failure_tolerance a runtime parameter

### DIFF
--- a/integration/BackwardEuler/be_integrator.H
+++ b/integration/BackwardEuler/be_integrator.H
@@ -60,9 +60,9 @@ int single_step (BurnT& state, BeT& be, const amrex::Real dt)
         if (integrator_rp::do_corrector_validation) {
 #ifdef SDC
             const amrex::Real rho_current = state.rho_orig + be.t * state.ydot_a[SRHO];
-            const amrex::Real thresh = species_failure_tolerance * rho_current;
+            const amrex::Real thresh = integrator_rp::species_failure_tolerance * rho_current;
 #else
-            const amrex::Real thresh = species_failure_tolerance;
+            const amrex::Real thresh = integrator_rp::species_failure_tolerance;
 #endif
             bool fail{};
             for (int i = 1; i <= NumSpec; ++i) {

--- a/integration/VODE/vode_dvnlsd.H
+++ b/integration/VODE/vode_dvnlsd.H
@@ -151,9 +151,9 @@ amrex::Real dvnlsd (int& NFLAG, BurnT& state, DvodeT& vstate)
             if (integrator_rp::do_corrector_validation && !integrator_rp::use_number_densities) {
 #ifdef SDC
                 const amrex::Real rho_current = state.rho_orig + vstate.tn * state.ydot_a[SRHO];
-                const amrex::Real thresh = species_failure_tolerance * rho_current;
+                const amrex::Real thresh = integrator_rp::species_failure_tolerance * rho_current;
 #else
-                const amrex::Real thresh = species_failure_tolerance;
+                const amrex::Real thresh = integrator_rp::species_failure_tolerance;
 #endif
                 bool fail{};
                 for (int i = 1; i <= NumSpec; ++i) {

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -255,7 +255,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
             // Constrain abundances such that they are not negative (within a tolerance)
             // or greater than one (within a tolerance).
-            if (vstate.y(i) < -species_failure_tolerance) {
+            if (vstate.y(i) < -integrator_rp::species_failure_tolerance) {
                 valid_update = false;
                 break;
             }
@@ -263,7 +263,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
             // Don't enforce the condition below if
             // vstate.y contains number densities
             if (! integrator_rp::use_number_densities) {
-                if (vstate.y(i) > 1.0_rt + species_failure_tolerance) {
+                if (vstate.y(i) > 1.0_rt + integrator_rp::species_failure_tolerance) {
                     valid_update = false;
                     break;
                 }
@@ -293,12 +293,12 @@ int dvstep (BurnT& state, DvodeT& vstate)
                 break;
             }
 
-            if (vstate.y(SFS+i) < -species_failure_tolerance * rho_current) {
+            if (vstate.y(SFS+i) < -integrator_rp::species_failure_tolerance * rho_current) {
                 valid_update = false;
                 break;
             }
 
-            if (vstate.y(SFS+i) > (1.0_rt + species_failure_tolerance) * rho_current) {
+            if (vstate.y(SFS+i) > (1.0_rt + integrator_rp::species_failure_tolerance) * rho_current) {
                 valid_update = false;
                 break;
             }

--- a/integration/_parameters
+++ b/integration/_parameters
@@ -117,3 +117,9 @@ nse_include_enu_weak       bool        1
 
 # for the linear algebra, do we allow pivoting?
 linalg_do_pivoting         bool        1
+
+# We will use this parameter to determine if a given species
+# abundance is unreasonably small or large (each X must satisfy
+# -failure_tolerance <= X <= 1.0 + failure_tolerance).
+species_failure_tolerance  real       1.e-2_rt
+

--- a/integration/integrator_data.H
+++ b/integration/integrator_data.H
@@ -9,10 +9,6 @@
 
 constexpr int INT_NEQS = NumSpec + 1;
 
-// We will use this parameter to determine if a given species
-// abundance is unreasonably small or large (each X must satisfy
-// -failure_tolerance <= X <= 1.0 + failure_tolerance).
-constexpr amrex::Real species_failure_tolerance = 1.e-2_rt;
 
 // for outputting the burn state failure, use enough precision
 // to be reproducible (not guaranteed for std::fixed)

--- a/integration/integrator_setup_sdc.H
+++ b/integration/integrator_setup_sdc.H
@@ -186,11 +186,11 @@ void integrator_cleanup (IntegratorT& int_state, BurnT& state,
     }
 
     for (int n = 0; n < NumSpec; ++n) {
-        if (state.y[SFS+n] < -state.rho * species_failure_tolerance) {
+        if (state.y[SFS+n] < -state.rho * integrator_rp::species_failure_tolerance) {
             state.success = false;
         }
 
-        if (state.y[SFS+n] > state.rho * (1.0_rt + species_failure_tolerance)) {
+        if (state.y[SFS+n] > state.rho * (1.0_rt + integrator_rp::species_failure_tolerance)) {
             state.success = false;
         }
     }

--- a/integration/integrator_setup_strang.H
+++ b/integration/integrator_setup_strang.H
@@ -155,14 +155,14 @@ void integrator_cleanup (IntegratorT& int_state, BurnT& state,
     }
 
     for (int n = 1; n <= NumSpec; ++n) {
-        if (int_state.y(n) < -species_failure_tolerance) {
+        if (int_state.y(n) < -integrator_rp::species_failure_tolerance) {
             state.success = false;
         }
 
         // Don't enforce a max if we are evolving number densities
 
         if (! integrator_rp::use_number_densities) {
-            if (int_state.y(n) > 1.0_rt + species_failure_tolerance) {
+            if (int_state.y(n) > 1.0_rt + integrator_rp::species_failure_tolerance) {
                 state.success = false;
             }
         }


### PR DESCRIPTION
the current value of 0.01 is actually quite large.  If we get a mass fraction of -0.01, we've already gone bad and it is hard to recover.  Seeing species_failure_tolerance closer to atol_spec can really help with the step rejection logic.