### PR TITLE
[WIP] reduce species_failure_tolerance default from 1.e-2 to 1.e-4

### DIFF
--- a/integration/_parameters
+++ b/integration/_parameters
@@ -121,5 +121,5 @@ linalg_do_pivoting         bool        1
 # We will use this parameter to determine if a given species
 # abundance is unreasonably small or large (each X must satisfy
 # -failure_tolerance <= X <= 1.0 + failure_tolerance).
-species_failure_tolerance  real       1.e-2_rt
+species_failure_tolerance  real       1.e-4_rt
 


### PR DESCRIPTION
the value should be close to atol_spec to prevent large negative mass fractions from building up and becoming too big to handle.

this is a more sensible value.