### PR TITLE
update the build system to support standalone networks

### DIFF
--- a/Docs/source/build_system.rst
+++ b/Docs/source/build_system.rst
@@ -102,6 +102,8 @@ The following control whether certain physics modules are included in
 the build process.  Note: an EOS and network are always required.
 These can be set to ``TRUE`` to enable and ``FALSE`` to disable specific features.
 
+.. index:: USE_CONDUCTIVITY, USE_NEUTRINOS, USE_NSE_NET, USE_NSE_TABLE, USE_RATES, USE_REACT, USE_SCREENING
+
 * ``USE_CONDUCTIVITY`` : determines whether a conductivity routine
   should be included in the list of build packages.  If enabled, this
   also defines the ``CONDUCTIVITY`` preprocessor variable.  Default:
@@ -112,7 +114,7 @@ These can be set to ``TRUE`` to enable and ``FALSE`` to disable specific feature
   equation.  See :ref:`neutrino_loss`.  The default is set by each
   individual network.
 
-* ``USE_NET_NET`` : determines whether the self-consistent NSE
+* ``USE_NSE_NET`` : determines whether the self-consistent NSE
   infrastructure is included in the build.  See
   :ref:`self_consistent_nse`.  No default is set.
 
@@ -143,6 +145,7 @@ These can be set to ``TRUE`` to enable and ``FALSE`` to disable specific feature
 
 The following control the choice of implementation for the different physics modules:
 
+.. index:: CONDUCTIVITY_DIR, EOS_DIR, INTEGRATOR_DIR, NETWORK_DIR, GENERAL_NET_INPUTS, NETWORK_INPUTS, NETWORK_CUSTOM_DIR, OPACITY_DIR, SCREEN_METHOD
 
 * ``CONDUCTIVITY_DIR`` : the name of the conductivity implementation to use,
   relative to ``Microphysics/conductivity/``.
@@ -156,6 +159,13 @@ The following control the choice of implementation for the different physics mod
   If ``general_null`` is chosen, then the inputs file is determined by
   either ``GENERAL_NET_INPUTS`` or ``NETWORK_INPUTS`` (see :ref:`sec:networks:general_null`).
 
+  .. note::
+
+     Alternately, you can set ``NETWORK_CUSTOM_DIR`` to the full path of
+     the location of the network directory.  This is used for the case where
+     a network is created outside of ``Microphysics/`` (e.g. via pynucastro)
+     but we still want to build a simple driver to test it.
+
 * ``OPACITY_DIR`` : the name of the opacity implementation to use, relative
   to ``Microphysics/opacity/``.
 
@@ -165,6 +175,8 @@ The following control the choice of implementation for the different physics mod
 
 The following control the time-integration method used by the reaction
 network integration:
+
+.. index:: USE_SIMPLIFIED_SDC, USE_TRUE_SDC
 
 * ``USE_SIMPLIFIED_SDC`` : enable the simplified-SDC coupling of hydro and reactions.
   See :ref:`sec:simplified_sdc`.

--- a/Docs/source/rp_intro.rst
+++ b/Docs/source/rp_intro.rst
@@ -32,10 +32,19 @@ The individual parameter definitions take the form::
 where "data-type" can be: ``real``, ``bool``, ``int``, ``string``.
 
 The "priority" is simply an integer that is used to determine
-what happens when two different ``_paramerter`` files define the same
+what happens when two different ``_parameter`` files define the same
 parameter but with different defaults.  In this case, the version of
 the parameter with the highest priority takes precedence. This allows
 specific implementations to override the general parameter defaults.
+
+.. index:: CUSTOM_PARAMETERS
+
+.. note::
+
+   You can set ``CUSTOM_PARAMETERS`` to the a filename with additional
+   parameters.  This is used for standalone builds (when
+   ``NETWORK_CUSTOM_PATH`` is set).  This parameter file will be
+   added to the ones found via ``findparams.py``.
 
 Known Parameters
 ================

--- a/Make.Microphysics
+++ b/Make.Microphysics
@@ -119,7 +119,7 @@ ifdef MICROPHYSICS_HOME
 endif
 
 EXTERN_PARAMETERS := $(shell $(MICROPHYSICS_HOME)/util/build_scripts/findparams.py $(EXTERN_SEARCH))
-
+EXTERN_PARAMETERS += $(CUSTOM_PARAMETERS)
 
 $(MICROPHYSICS_AUTO_SOURCE_DIR)/extern_parameters.cpp: $(MICROPHYSICS_AUTO_SOURCE_DIR)/extern_parameters.H
 

--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -66,7 +66,11 @@ endif
 
 
 EOS_PATH := $(MICROPHYSICS_HOME)/EOS/$(strip $(EOS_DIR))
-NETWORK_PATH := $(MICROPHYSICS_HOME)/networks/$(strip $(NETWORK_DIR))
+ifneq ($(NETWORK_CUSTOM_PATH),)
+    NETWORK_PATH := $(NETWORK_CUSTOM_PATH)
+else
+    NETWORK_PATH := $(MICROPHYSICS_HOME)/networks/$(strip $(NETWORK_DIR))
+endif
 ifeq ($(USE_CONDUCTIVITY), TRUE)
    CONDUCTIVITY_PATH := $(MICROPHYSICS_HOME)/conductivity/$(strip $(CONDUCTIVITY_DIR))
 endif

--- a/networks/Make.package
+++ b/networks/Make.package
@@ -90,13 +90,18 @@ AUTO_BUILD_SOURCES += $(NETWORK_OUTPUT_PATH)/network_properties.H
 net_prop_debug: $(NETWORK_OUTPUT_PATH)/network_properties.H
 
 ifneq ($(NETWORK_DIR), general_null)
-  NAUX := $(shell PYTHONPATH=$(MICROPHYSICS_HOME)/networks/general_null $(MICROPHYSICS_HOME)/networks/get_naux.py --microphysics_path "$(MICROPHYSICS_HOME)" --defines "$(DEFINES)" --net "$(NETWORK_DIR)")
+  NAUX := $(shell PYTHONPATH=$(MICROPHYSICS_HOME)/networks/general_null $(MICROPHYSICS_HOME)/networks/get_naux.py \
+                 --microphysics_path "$(MICROPHYSICS_HOME)" \
+                 --defines "$(DEFINES)" \
+                 --net "$(NETWORK_DIR)" \
+                 --net-custom-path "$(NETWORK_CUSTOM_PATH)")
   DEFINES += "-DNAUX_NET=$(NAUX)"
 
 $(NETWORK_OUTPUT_PATH)/network_properties.H:
 	PYTHONPATH=$(MICROPHYSICS_HOME)/networks/general_null $(MICROPHYSICS_HOME)/networks/update_headers.py \
            --microphysics_path $(MICROPHYSICS_HOME) \
-           --net $(NETWORK_DIR) \
+           --net "$(NETWORK_DIR)" \
+           --net-custom-path "$(NETWORK_CUSTOM_PATH)" \
            --odir $(NETWORK_OUTPUT_PATH) \
            --defines "$(DEFINES)"
 

--- a/networks/general_null/network_param_file.py
+++ b/networks/general_null/network_param_file.py
@@ -76,7 +76,7 @@ def parse(species, extra_species, aux_vars, net_file, defines):
     try:
         f = open(net_file)
     except OSError:
-        sys.exit(f"write_network.py: ERROR: file {net_file} does not exist")
+        sys.exit(f"network_param_file.py: ERROR: file {net_file} does not exist")
 
     line = get_next_line(f)
 

--- a/networks/general_null/write_network.py
+++ b/networks/general_null/write_network.py
@@ -62,7 +62,7 @@ def write_network(header_template,
         try:
             template = open(tmp)
         except OSError:
-            sys.exit(f"write_network.py: ERROR: file {tmp} does not exist")
+            sys.exit(f"write_network.py: ERROR: template file {tmp} does not exist")
         else:
             template_lines = template.readlines()
             template.close()

--- a/networks/get_naux.py
+++ b/networks/get_naux.py
@@ -39,9 +39,11 @@ def main():
     micro_path = args.microphysics_path
     net = args.net
 
-    if args.net_custom_path is None:
-        base_path = Path(micro_path) / "networks" / "net"
+    if len(args.net_custom_path.strip()) == 0:
+        # our network lives in Microphysics/networks
+        base_path = Path(micro_path) / "networks" / f"{net}"
     else:
+        # our network is standalone (outside of Microphysics/)
         base_path = Path(args.net_custom_path)
 
     net_file = base_path / "pynucastro.net"

--- a/networks/get_naux.py
+++ b/networks/get_naux.py
@@ -2,6 +2,7 @@
 
 import os
 import argparse
+from pathlib import Path
 
 from general_null import network_param_file
 
@@ -30,15 +31,22 @@ def main():
                         help="path to Microphysics/")
     parser.add_argument("--net", type=str, default="",
                         help="name of the network")
+    parser.add_argument("--net-custom-path", type=str, default="",
+                        help="full path to the network if it lives outside of Microphysics")
 
     args = parser.parse_args()
 
     micro_path = args.microphysics_path
     net = args.net
 
-    net_file = os.path.join(micro_path, "networks", net, f"{net}.net")
-    if not os.path.isfile(net_file):
-        net_file = os.path.join(micro_path, "networks", net, "pynucastro.net")
+    if args.net_custom_path is None:
+        base_path = Path(micro_path) / "networks" / "net"
+    else:
+        base_path = Path(args.net_custom_path)
+
+    net_file = base_path / "pynucastro.net"
+    if not net_file.exists() and len(net) > 0:
+        net_file = base_path / f"{net}.net"
 
     get_naux(net_file, args.defines)
 

--- a/networks/update_headers.py
+++ b/networks/update_headers.py
@@ -2,6 +2,7 @@
 
 import os
 import argparse
+from pathlib import Path
 
 from general_null import write_network
 
@@ -13,6 +14,8 @@ def main():
                         help="path to Microphysics/")
     parser.add_argument("--net", type=str, default="",
                         help="name of the network")
+    parser.add_argument("--net-custom-path", type=str, default="",
+                        help="full path to the network if it lives outside of Microphysics")
     parser.add_argument("--odir", type=str, default="",
                         help="output directory")
     parser.add_argument("--defines", type=str, default="",
@@ -23,9 +26,15 @@ def main():
     micro_path = args.microphysics_path
     net = args.net
 
-    net_file = os.path.join(micro_path, "networks", net, f"{net}.net")
-    if not os.path.isfile(net_file):
-        net_file = os.path.join(micro_path, "networks", net, "pynucastro.net")
+
+    if args.net_custom_path is None:
+        base_path = Path(micro_path) / "networks" / "net"
+    else:
+        base_path = Path(args.net_custom_path)
+
+    net_file = base_path / "pynucastro.net"
+    if not net_file.exists() and len(net) > 0:
+        net_file = base_path / f"{net}.net"
 
     cxx_template = os.path.join(micro_path, "networks",
                                 "general_null/network_header.template")
@@ -36,6 +45,7 @@ def main():
     except FileExistsError:
         pass
 
+    print(f"calling with {cxx_template}, {net_file}")
     write_network.write_network(cxx_template,
                                 net_file,
                                 cxx_name, args.defines)

--- a/networks/update_headers.py
+++ b/networks/update_headers.py
@@ -27,9 +27,11 @@ def main():
     net = args.net
 
 
-    if args.net_custom_path is None:
-        base_path = Path(micro_path) / "networks" / "net"
+    if len(args.net_custom_path.strip()) == 0:
+        # our network lives in Microphysics/networks
+        base_path = Path(micro_path) / "networks" / f"{net}"
     else:
+        # our network is standalone (outside of Microphysics/)
         base_path = Path(args.net_custom_path)
 
     net_file = base_path / "pynucastro.net"


### PR DESCRIPTION
this allows us to output a network outside of Microphysics/networks/ and initiate a build there.  This will be used to support pynucastro unit tests / comparsions to other pynucastro nets