### PR TITLE
Fix vode_example network

### DIFF
--- a/.github/workflows/burn_cell.yml
+++ b/.github/workflows/burn_cell.yml
@@ -108,6 +108,22 @@ jobs:
           cd unit_test/burn_cell
           diff -I "^Initializing AMReX" -I "^AMReX" -I "^reading in reaclib rates" test.out ci-benchmarks/he-burn-19am_BE_unit_test.out
 
+      - name: Compile, burn_cell (BackwardEuler, vode_example)
+        run: |
+          cd unit_test/burn_cell
+          make realclean
+          make NETWORK_DIR=vode_example INTEGRATOR_DIR=BackwardEuler -j 4
+
+      - name: Run burn_cell (BackwardEuler, vode_example)
+        run: |
+          cd unit_test/burn_cell
+          ./main3d.gnu.ex inputs_vode_example amrex.fpe_trap_{invalid,zero,overflow}=1 > test.out
+
+      - name: Compare to stored output (BackwardEuler, vode_example)
+        run: |
+          cd unit_test/burn_cell
+          diff -I "^Initializing AMReX" -I "^AMReX" -I "^reading in reaclib rates" test.out ci-benchmarks/vode_example_BE_unit_test.out
+
       - name: Compile, burn_cell (QSS, aprox13)
         run: |
           cd unit_test/burn_cell

--- a/networks/vode_example/actual_rhs.H
+++ b/networks/vode_example/actual_rhs.H
@@ -14,7 +14,7 @@ void actual_rhs_init () {
 
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void actual_rhs (burn_t& state, amrex::Array1D<amrex::Real, 1, neqs>& ydot)
+void actual_rhs (const burn_t& state, amrex::Array1D<amrex::Real, 1, neqs>& ydot)
 {
     using namespace Species;
 
@@ -33,7 +33,7 @@ void actual_rhs (burn_t& state, amrex::Array1D<amrex::Real, 1, neqs>& ydot)
 
 template<class MatrixType>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void actual_jac (burn_t& state, MatrixType& jac)
+void actual_jac (const burn_t& state, MatrixType& jac)
 {
     using namespace Species;
 

--- a/unit_test/burn_cell/ci-benchmarks/vode_example_BE_unit_test.out
+++ b/unit_test/burn_cell/ci-benchmarks/vode_example_BE_unit_test.out
@@ -1,0 +1,33 @@
+Initializing AMReX (26.03-138-g66a74362aa17)...
+AMReX (26.03-138-g66a74362aa17) initialized
+starting the single zone burn...
+Maximum Time (s): 4e+10
+State Density (g/cm^3): 100000
+State Temperature (K): 100000000
+Mass Fraction (y1): 1
+Mass Fraction (y2): 0
+Mass Fraction (y3): 0
+RHS at t = 0
+    y1 -0.04
+    y2 0.04
+    y3 3e-53
+------------------------------------
+successful? 1
+ - Hnuc = 0
+ - added e = 0
+ - final T = 100000000
+------------------------------------
+e initial = 4.685675996e+16
+e final =   4.685675996e+16
+------------------------------------
+new mass fractions: 
+y1 5.209493144e-08
+y2 2.083797365e-13
+y3 0.9999999479
+------------------------------------
+species creation rates: 
+omegadot(y1): -2.49999987e-11
+omegadot(y2): 5.209493412e-24
+omegadot(y3): 2.49999987e-11
+number of steps taken: 312756
+AMReX (26.03-138-g66a74362aa17) finalized


### PR DESCRIPTION
Fixes `vode_example` so it compiles again. There was a const mismatch in the `actual_rhs` and `actual_jac` function signatures.