### PR TITLE
fix primordial_chem actual_rhs signature to take const burn_t&

### DIFF
--- a/networks/primordial_chem/actual_rhs.H
+++ b/networks/primordial_chem/actual_rhs.H
@@ -1202,7 +1202,7 @@ Real rhs_eint(const burn_t& state,
 
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
+void actual_rhs (const burn_t& state, Array1D<Real, 1, neqs>& ydot)
 {
     Real z = redshift;
 


### PR DESCRIPTION
Changes function signature to use `const burn_t` instead of `burn_t` so it works with BackwardEuler.