### PR TITLE
Update CMake to allow choice of integrator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,15 @@ include(CMakePackageConfigHelpers)
 function(setup_target_for_microphysics_compilation network_name output_dir)
 
   set(networkparamfile "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/_parameters")
-  set(VODEparamfile "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/VODE/_parameters")
+  set(integrator_name "VODE")
+  if(ARGC GREATER 2)
+    set(integrator_name "${ARGV2}")
+  endif()
+  set(integrator_dir "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/${integrator_name}")
+  if(NOT EXISTS "${integrator_dir}/actual_integrator.H")
+    message(FATAL_ERROR "Given integrator_name ${integrator_name} does not provide ${integrator_dir}/actual_integrator.H")
+  endif()
+  set(integratorparamfile "${integrator_dir}/_parameters")
   set(integrationparamfile "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/_parameters")
   set(unittestparamfile "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/unit_test/_parameters")
 
@@ -39,7 +47,7 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
                              ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/constants PARENT_SCOPE)
 
     execute_process(COMMAND python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util/build_scripts/write_probin.py" --pa "${EOSparamfile} ${networkparamfile}
-                    ${VODEparamfile} ${integrationparamfile}" --use_namespace WORKING_DIRECTORY ${output_dir}/)
+                    ${integratorparamfile} ${integrationparamfile}" --use_namespace WORKING_DIRECTORY ${output_dir}/)
 
     set(gamma_law_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/eos_data.cpp
                           ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/network_initialization.cpp
@@ -60,7 +68,7 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
 
     #DO NOT change the order of the directories below!
     set (primordial_chem_dirs ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util/gcem/include
-                             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/VODE ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/utils
+                             ${integrator_dir} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/utils
                              ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces
                              ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/EOS ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/EOS/primordial_chem
                              ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/primordial_chem ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks
@@ -75,11 +83,11 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
 
     if(BUILD_UNIT_TEST_PC)
       execute_process(COMMAND python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util/build_scripts/write_probin.py" --pa "${paramfile} ${EOSparamfile}
-                      ${networkpcparamfile} ${networkparamfile} ${VODEparamfile} ${integrationparamfile} ${unittestparamfile}" --use_namespace WORKING_DIRECTORY ${output_dir}/)
+                      ${networkpcparamfile} ${networkparamfile} ${integratorparamfile} ${integrationparamfile} ${unittestparamfile}" --use_namespace WORKING_DIRECTORY ${output_dir}/)
     else()
       #do not need paramfile and unittestparamfile
       execute_process(COMMAND python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util/build_scripts/write_probin.py" --pa "${EOSparamfile} ${networkpcparamfile}
-                      ${networkparamfile} ${VODEparamfile} ${integrationparamfile} " --use_namespace WORKING_DIRECTORY ${output_dir}/)
+                      ${networkparamfile} ${integratorparamfile} ${integrationparamfile} " --use_namespace WORKING_DIRECTORY ${output_dir}/)
     endif()
 
     set(primordial_chem_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/eos_data.cpp
@@ -106,7 +114,7 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
 
     #DO NOT change the order of the directories below!
     set (metal_chem_dirs ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util/gcem/include
-                             ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/VODE ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/utils
+                             ${integrator_dir} ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration/utils
                              ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/integration ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces
                              ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/EOS ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/EOS/metal_chem
                              ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/metal_chem ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks
@@ -121,11 +129,11 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
 
     if(BUILD_UNIT_TEST_MC)
       execute_process(COMMAND python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util/build_scripts/write_probin.py" --pa "${paramfile} ${EOSparamfile}
-                      ${networkmcparamfile} ${networkparamfile} ${VODEparamfile} ${integrationparamfile} ${unittestparamfile}" --use_namespace WORKING_DIRECTORY ${output_dir}/)
+                      ${networkmcparamfile} ${networkparamfile} ${integratorparamfile} ${integrationparamfile} ${unittestparamfile}" --use_namespace WORKING_DIRECTORY ${output_dir}/)
     else()
       #do not need paramfile and unittestparamfile
       execute_process(COMMAND python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util/build_scripts/write_probin.py" --pa "${EOSparamfile} ${networkmcparamfile}
-                      ${networkparamfile} ${VODEparamfile} ${integrationparamfile} " --use_namespace WORKING_DIRECTORY ${output_dir}/)
+                      ${networkparamfile} ${integratorparamfile} ${integrationparamfile} " --use_namespace WORKING_DIRECTORY ${output_dir}/)
     endif()
 
     #unlike primordial chem, we also include actual_network_data.cpp here because it is in there that we read in the Semenov opacity table
@@ -215,4 +223,3 @@ elseif(BUILD_UNIT_TEST_MC)
 endif()
 
 #Sample command: cmake .. -DBUILD_UNIT_TEST_MC=True -DBUILD_AMReX=True -DAMReX_SPACEDIM=1
-


### PR DESCRIPTION
This updates the CMake build so applications can select the integrator they want to use for a particular build. Previously, VODE was hard-coded. Now, Rosenbrock can be used.