### PR TITLE
Remove Rosenbrock-Euler and Ros2 methods

### DIFF
--- a/Docs/source/ode_integrators.rst
+++ b/Docs/source/ode_integrators.rst
@@ -70,10 +70,6 @@ Presently, allowed integrators are:
 
   * ``3`` : ROS2S method, a 2nd order, stiff-accurate method :cite:`ros2s`.
 
-  * ``4`` : ROS2 method, a 2nd order, L-stable method :cite:`ros2`.
-
-  * ``5`` : Rosenbrock-Euler, a first-order method.
-
   Here the "P" suffix refers to methods developed to satisfy the stiff
   accuracy conditions of :cite:`Prothero1974` (ROS2S also satisfies
   these).

--- a/integration/Rosenbrock/_parameters
+++ b/integration/Rosenbrock/_parameters
@@ -18,3 +18,4 @@ h211b_k                      real         2.5
 h211b_fac_min                real         0.2
 h211b_fac_max                real         6.0
 h211b_reduction_fac          real         0.5
+

--- a/integration/Rosenbrock/_parameters
+++ b/integration/Rosenbrock/_parameters
@@ -8,9 +8,8 @@ X_reject_buffer              real         1.0
 #   0 = Rodas5P 8-stage method from DifferentialEquations.jl
 #   1 = Rodas4P 6-stage method from DifferentialEquations.jl
 #   2 = Rodas3P 5-stage method from DifferentialEquations.jl
-#   3 = existing 3-stage ROS2S tableau
+#   3 = Hamkar et al. (2012) 3-stage ROS2S tableau
 #   4 = Verwer et al. (1999) 2-stage ROS2 tableau
-#   5 = Rosenbrock-Euler 1-stage method
 rosenbrock_tableau           int          0
 
 # H211b timestep controller parameters

--- a/integration/Rosenbrock/_parameters
+++ b/integration/Rosenbrock/_parameters
@@ -8,8 +8,7 @@ X_reject_buffer              real         1.0
 #   0 = Rodas5P 8-stage method from DifferentialEquations.jl
 #   1 = Rodas4P 6-stage method from DifferentialEquations.jl
 #   2 = Rodas3P 5-stage method from DifferentialEquations.jl
-#   3 = Hamkar et al. (2012) 3-stage ROS2S tableau
-#   4 = Verwer et al. (1999) 2-stage ROS2 tableau
+#   3 = ROS2S   3-stage method from Hamkar et al. (2012)
 rosenbrock_tableau           int          0
 
 # H211b timestep controller parameters
@@ -18,4 +17,3 @@ h211b_k                      real         2.5
 h211b_fac_min                real         0.2
 h211b_fac_max                real         6.0
 h211b_reduction_fac          real         0.5
-

--- a/integration/Rosenbrock/rosenbrock_integrator.H
+++ b/integration/Rosenbrock/rosenbrock_integrator.H
@@ -600,9 +600,6 @@ int rosenbrock_integrator (BurnT& state, rosenbrock_t<integrator_neqs<BurnT>()>&
     if (integrator_rp::rosenbrock_tableau == 4) {
         return rosenbrock_integrator<BurnT, rosenbrock::ros2_tableau>(state, rstate);
     }
-    if (integrator_rp::rosenbrock_tableau == 5) {
-        return rosenbrock_integrator<BurnT, rosenbrock::rosenbrock_euler_tableau>(state, rstate);
-    }
 
     return rosenbrock_integrator<BurnT, rosenbrock::rodas5p_tableau>(state, rstate);
 }

--- a/integration/Rosenbrock/rosenbrock_integrator.H
+++ b/integration/Rosenbrock/rosenbrock_integrator.H
@@ -597,9 +597,6 @@ int rosenbrock_integrator (BurnT& state, rosenbrock_t<integrator_neqs<BurnT>()>&
     if (integrator_rp::rosenbrock_tableau == 3) {
         return rosenbrock_integrator<BurnT, rosenbrock::ros2s_tableau>(state, rstate);
     }
-    if (integrator_rp::rosenbrock_tableau == 4) {
-        return rosenbrock_integrator<BurnT, rosenbrock::ros2_tableau>(state, rstate);
-    }
 
     return rosenbrock_integrator<BurnT, rosenbrock::rodas5p_tableau>(state, rstate);
 }

--- a/integration/Rosenbrock/rosenbrock_tableau.H
+++ b/integration/Rosenbrock/rosenbrock_tableau.H
@@ -66,47 +66,6 @@ struct ros2s_tableau {
     }
 };
 
-struct ros2_tableau {
-    static constexpr int stages = 2;
-    static constexpr amrex::Real gamma = 1.7071067811865475_rt;
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real ct (const int i) {
-        (void) i;
-        return 1.0_rt;
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real a (const int i, const int j) {
-        if (i == 2 && j == 1) {
-            return 0.585786437626905_rt;
-        }
-        return 0.0_rt;
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real c (const int i, const int j) {
-        if (i == 2 && j == 1) {
-            return -1.1715728752538102_rt;
-        }
-        return 0.0_rt;
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real b (const int i) {
-        if (i == 1) {
-            return 0.8786796564403575_rt;
-        }
-        return 0.2928932188134525_rt;
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real e (const int i) {
-        (void) i;
-        return 0.2928932188134525_rt;
-    }
-};
-
 struct rodas3p_tableau {
     static constexpr int stages = 5;
     static constexpr amrex::Real gamma = 1.0_rt / 3.0_rt;

--- a/integration/Rosenbrock/rosenbrock_tableau.H
+++ b/integration/Rosenbrock/rosenbrock_tableau.H
@@ -530,43 +530,6 @@ struct rodas4p_tableau {
     }
 };
 
-struct rosenbrock_euler_tableau {
-    static constexpr int stages = 1;
-    static constexpr amrex::Real gamma = 1.0_rt;
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real ct (const int i) {
-        (void) i;
-        return 0.0_rt;
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real a (const int i, const int j) {
-        (void) i;
-        (void) j;
-        return 0.0_rt;
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real c (const int i, const int j) {
-        (void) i;
-        (void) j;
-        return 0.0_rt;
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real b (const int i) {
-        (void) i;
-        return 1.0_rt;
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static constexpr amrex::Real e (const int i) {
-        (void) i;
-        return 1.0_rt;
-    }
-};
-
 using coefficients = rodas5p_tableau;
 
 }


### PR DESCRIPTION
Removes the Rosenbrock-Euler and Ros2 methods. These are not performance-competitive for any networks.

The remaining Rosenbrock methods all have both stiff accuracy and stiffly accurate embedded error estimators (which Rosenbrock-Euler and Ros2 do not have).